### PR TITLE
chore: bump version

### DIFF
--- a/samples/company-research-agent/pyproject.toml
+++ b/samples/company-research-agent/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "langchain-community>=0.3.9",
     "langchain-anthropic>=0.3.8",
     "tavily-python>=0.5.0",
-    "uipath-langchain==0.0.87"
+    "uipath-langchain==0.0.88"
 ]
 
 [project.optional-dependencies]

--- a/samples/company-research-agent/uv.lock
+++ b/samples/company-research-agent/uv.lock
@@ -355,7 +355,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.1" },
     { name = "tavily-python", specifier = ">=0.5.0" },
-    { name = "uipath-langchain", specifier = "==0.0.87" },
+    { name = "uipath-langchain", specifier = "==0.0.88" },
 ]
 provides-extras = ["dev"]
 
@@ -1815,7 +1815,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1828,14 +1828,14 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1852,9 +1852,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "uipath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/f0/f9ac644bcb818efd2b1e35e50eeb8d20980177aabf1d359dda4e5a6c77a5/uipath_langchain-0.0.87.tar.gz", hash = "sha256:07f61284e0c734fddb7dfbdc020e16d439a319adb306a453fa8d55aebcc78cab", size = 1309008 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/0e/e05ecfc5a5b6b7f277dca18e61724c1a923ae4c9af39f71f2c8dce52343d/uipath_langchain-0.0.88.tar.gz", hash = "sha256:f06cc80c9499ae4309275119a9abf5d74c881aaef6731c6efb5b525a1291ef33", size = 1188502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/1a/4e34819ac42413b8a4650dcb05c698da7114909584c0205d66b4fe4a4424/uipath_langchain-0.0.87-py3-none-any.whl", hash = "sha256:92dd352c985ed580a9a93bcede2232205c9700bcec7ec62b1835ae372d184084", size = 50642 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/68ec6fcb4698af7f27c30a2107c349fb6115b84373dba38413346e8c5a57/uipath_langchain-0.0.88-py3-none-any.whl", hash = "sha256:78c92bebbd4a3651adcf914d3563a551222bef86f54cb3eb270d93a39ede7d28", size = 50641 },
 ]
 
 [[package]]

--- a/samples/hitl-inbox-server/pyproject.toml
+++ b/samples/hitl-inbox-server/pyproject.toml
@@ -11,6 +11,6 @@ dependencies = [
     "jinja2>=3.1.6",
     "httpx>=0.28.1",
     "python-multipart>=0.0.20",
-    "uipath==2.0.1"
+    "uipath==2.0.4"
 ]
 requires-python = ">=3.10"

--- a/samples/hitl-inbox-server/uv.lock
+++ b/samples/hitl-inbox-server/uv.lock
@@ -235,7 +235,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "sqlalchemy", specifier = ">=2.0.38" },
-    { name = "uipath", specifier = "==2.0.1" },
+    { name = "uipath", specifier = "==2.0.4" },
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 
@@ -686,7 +686,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -699,9 +699,9 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]

--- a/samples/multi-agent-planner-researcher-coder-distributed/pyproject.toml
+++ b/samples/multi-agent-planner-researcher-coder-distributed/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "langchain-anthropic>=0.3.8",
     "langchain-experimental>=0.3.4",
     "tavily-python>=0.5.0",
-    "uipath-langchain==0.0.87"
+    "uipath-langchain==0.0.88"
 ]
 
 [project.optional-dependencies]

--- a/samples/multi-agent-planner-researcher-coder-distributed/src/multi-agent-distributed/planner.py
+++ b/samples/multi-agent-planner-researcher-coder-distributed/src/multi-agent-distributed/planner.py
@@ -8,7 +8,7 @@ from langgraph.graph import START, MessagesState, StateGraph
 from langgraph.types import Command, interrupt
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
-from uipath._models import InvokeProcess
+from uipath.models import InvokeProcess
 
 worker_agents = {"researcher": "researcher-agent", "coder": "coder-agent"}
 agent_names = list(worker_agents.values())

--- a/samples/multi-agent-planner-researcher-coder-distributed/uv.lock
+++ b/samples/multi-agent-planner-researcher-coder-distributed/uv.lock
@@ -863,7 +863,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.1" },
     { name = "tavily-python", specifier = ">=0.5.0" },
-    { name = "uipath-langchain", specifier = "==0.0.87" },
+    { name = "uipath-langchain", specifier = "==0.0.88" },
 ]
 provides-extras = ["dev"]
 
@@ -1818,7 +1818,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1831,14 +1831,14 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1855,9 +1855,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "uipath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/f0/f9ac644bcb818efd2b1e35e50eeb8d20980177aabf1d359dda4e5a6c77a5/uipath_langchain-0.0.87.tar.gz", hash = "sha256:07f61284e0c734fddb7dfbdc020e16d439a319adb306a453fa8d55aebcc78cab", size = 1309008 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/0e/e05ecfc5a5b6b7f277dca18e61724c1a923ae4c9af39f71f2c8dce52343d/uipath_langchain-0.0.88.tar.gz", hash = "sha256:f06cc80c9499ae4309275119a9abf5d74c881aaef6731c6efb5b525a1291ef33", size = 1188502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/1a/4e34819ac42413b8a4650dcb05c698da7114909584c0205d66b4fe4a4424/uipath_langchain-0.0.87-py3-none-any.whl", hash = "sha256:92dd352c985ed580a9a93bcede2232205c9700bcec7ec62b1835ae372d184084", size = 50642 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/68ec6fcb4698af7f27c30a2107c349fb6115b84373dba38413346e8c5a57/uipath_langchain-0.0.88-py3-none-any.whl", hash = "sha256:78c92bebbd4a3651adcf914d3563a551222bef86f54cb3eb270d93a39ede7d28", size = 50641 },
 ]
 
 [[package]]

--- a/samples/multi-agent-supervisor-researcher-coder/pyproject.toml
+++ b/samples/multi-agent-supervisor-researcher-coder/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "langchain-anthropic>=0.3.8",
     "langchain-experimental>=0.3.4",
     "tavily-python>=0.5.0",
-    "uipath-langchain==0.0.87"
+    "uipath-langchain==0.0.88"
 ]
 
 [project.optional-dependencies]

--- a/samples/multi-agent-supervisor-researcher-coder/uv.lock
+++ b/samples/multi-agent-supervisor-researcher-coder/uv.lock
@@ -863,7 +863,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.1" },
     { name = "tavily-python", specifier = ">=0.5.0" },
-    { name = "uipath-langchain", specifier = "==0.0.87" },
+    { name = "uipath-langchain", specifier = "==0.0.88" },
 ]
 provides-extras = ["dev"]
 
@@ -1818,7 +1818,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1831,14 +1831,14 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1855,9 +1855,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "uipath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/f0/f9ac644bcb818efd2b1e35e50eeb8d20980177aabf1d359dda4e5a6c77a5/uipath_langchain-0.0.87.tar.gz", hash = "sha256:07f61284e0c734fddb7dfbdc020e16d439a319adb306a453fa8d55aebcc78cab", size = 1309008 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/0e/e05ecfc5a5b6b7f277dca18e61724c1a923ae4c9af39f71f2c8dce52343d/uipath_langchain-0.0.88.tar.gz", hash = "sha256:f06cc80c9499ae4309275119a9abf5d74c881aaef6731c6efb5b525a1291ef33", size = 1188502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/1a/4e34819ac42413b8a4650dcb05c698da7114909584c0205d66b4fe4a4424/uipath_langchain-0.0.87-py3-none-any.whl", hash = "sha256:92dd352c985ed580a9a93bcede2232205c9700bcec7ec62b1835ae372d184084", size = 50642 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/68ec6fcb4698af7f27c30a2107c349fb6115b84373dba38413346e8c5a57/uipath_langchain-0.0.88-py3-none-any.whl", hash = "sha256:78c92bebbd4a3651adcf914d3563a551222bef86f54cb3eb270d93a39ede7d28", size = 50641 },
 ]
 
 [[package]]

--- a/samples/retrieval-chain/pyproject.toml
+++ b/samples/retrieval-chain/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 description = "Sample retrieval chain using UiPath Context Grounding API"
 authors = [{ name = "Andrei Rusu", email = "andrei.rusu@uipath.com" }]
 dependencies = [
-    "uipath-langchain>=0.0.87",
+    "uipath-langchain==0.0.88",
 ]
 requires-python = ">=3.10"

--- a/samples/retrieval-chain/uv.lock
+++ b/samples/retrieval-chain/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12.4'",
@@ -1486,7 +1487,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "uipath-langchain", specifier = ">=0.0.87" }]
+requires-dist = [{ name = "uipath-langchain", specifier = "==0.0.88" }]
 
 [[package]]
 name = "sniffio"
@@ -1686,7 +1687,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1699,14 +1700,14 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1723,9 +1724,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "uipath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/f0/f9ac644bcb818efd2b1e35e50eeb8d20980177aabf1d359dda4e5a6c77a5/uipath_langchain-0.0.87.tar.gz", hash = "sha256:07f61284e0c734fddb7dfbdc020e16d439a319adb306a453fa8d55aebcc78cab", size = 1309008 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/0e/e05ecfc5a5b6b7f277dca18e61724c1a923ae4c9af39f71f2c8dce52343d/uipath_langchain-0.0.88.tar.gz", hash = "sha256:f06cc80c9499ae4309275119a9abf5d74c881aaef6731c6efb5b525a1291ef33", size = 1188502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/1a/4e34819ac42413b8a4650dcb05c698da7114909584c0205d66b4fe4a4424/uipath_langchain-0.0.87-py3-none-any.whl", hash = "sha256:92dd352c985ed580a9a93bcede2232205c9700bcec7ec62b1835ae372d184084", size = 50642 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/68ec6fcb4698af7f27c30a2107c349fb6115b84373dba38413346e8c5a57/uipath_langchain-0.0.88-py3-none-any.whl", hash = "sha256:78c92bebbd4a3651adcf914d3563a551222bef86f54cb3eb270d93a39ede7d28", size = 50641 },
 ]
 
 [[package]]

--- a/samples/simple-local-mcp/pyproject.toml
+++ b/samples/simple-local-mcp/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "langchain-anthropic>=0.3.9",
     "langgraph-checkpoint-sqlite>=2.0.3",
     "python-dotenv>=1.0.1",
-    "uipath-langchain==0.0.87",
+    "uipath-langchain==0.0.88",
     "pydantic>=2.10.6",
     "aiohttp>=3.11.12",
     "typing-extensions>=4.12.2",

--- a/samples/simple-local-mcp/uv.lock
+++ b/samples/simple-local-mcp/uv.lock
@@ -1738,7 +1738,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "uipath-langchain", specifier = "==0.0.87" },
+    { name = "uipath-langchain", specifier = "==0.0.88" },
 ]
 
 [[package]]
@@ -1987,7 +1987,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2000,14 +2000,14 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2024,9 +2024,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "uipath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/f0/f9ac644bcb818efd2b1e35e50eeb8d20980177aabf1d359dda4e5a6c77a5/uipath_langchain-0.0.87.tar.gz", hash = "sha256:07f61284e0c734fddb7dfbdc020e16d439a319adb306a453fa8d55aebcc78cab", size = 1309008 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/0e/e05ecfc5a5b6b7f277dca18e61724c1a923ae4c9af39f71f2c8dce52343d/uipath_langchain-0.0.88.tar.gz", hash = "sha256:f06cc80c9499ae4309275119a9abf5d74c881aaef6731c6efb5b525a1291ef33", size = 1188502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/1a/4e34819ac42413b8a4650dcb05c698da7114909584c0205d66b4fe4a4424/uipath_langchain-0.0.87-py3-none-any.whl", hash = "sha256:92dd352c985ed580a9a93bcede2232205c9700bcec7ec62b1835ae372d184084", size = 50642 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/68ec6fcb4698af7f27c30a2107c349fb6115b84373dba38413346e8c5a57/uipath_langchain-0.0.88-py3-none-any.whl", hash = "sha256:78c92bebbd4a3651adcf914d3563a551222bef86f54cb3eb270d93a39ede7d28", size = 50641 },
 ]
 
 [[package]]

--- a/samples/simple-remote-mcp/pyproject.toml
+++ b/samples/simple-remote-mcp/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "simple-remote-mcp"
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 dependencies = [
-    "uipath-langchain==0.0.87",
+    "uipath-langchain==0.0.88",
     "langchain>=0.1.0",
     "langchain-anthropic>=0.0.1",
     "langgraph>=0.3.21",

--- a/samples/simple-remote-mcp/uv.lock
+++ b/samples/simple-remote-mcp/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12.4'",
@@ -1565,7 +1566,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.3.21" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
-    { name = "uipath-langchain", specifier = "==0.0.87" },
+    { name = "uipath-langchain", specifier = "==0.0.88" },
 ]
 
 [[package]]
@@ -1791,7 +1792,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1804,14 +1805,14 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1828,9 +1829,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "uipath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/f0/f9ac644bcb818efd2b1e35e50eeb8d20980177aabf1d359dda4e5a6c77a5/uipath_langchain-0.0.87.tar.gz", hash = "sha256:07f61284e0c734fddb7dfbdc020e16d439a319adb306a453fa8d55aebcc78cab", size = 1309008 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/0e/e05ecfc5a5b6b7f277dca18e61724c1a923ae4c9af39f71f2c8dce52343d/uipath_langchain-0.0.88.tar.gz", hash = "sha256:f06cc80c9499ae4309275119a9abf5d74c881aaef6731c6efb5b525a1291ef33", size = 1188502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/1a/4e34819ac42413b8a4650dcb05c698da7114909584c0205d66b4fe4a4424/uipath_langchain-0.0.87-py3-none-any.whl", hash = "sha256:92dd352c985ed580a9a93bcede2232205c9700bcec7ec62b1835ae372d184084", size = 50642 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/68ec6fcb4698af7f27c30a2107c349fb6115b84373dba38413346e8c5a57/uipath_langchain-0.0.88-py3-none-any.whl", hash = "sha256:78c92bebbd4a3651adcf914d3563a551222bef86f54cb3eb270d93a39ede7d28", size = 50641 },
 ]
 
 [[package]]

--- a/samples/ticket-classification/pyproject.toml
+++ b/samples/ticket-classification/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "langchain-openai>=0.3.9",
     "langgraph-checkpoint-sqlite>=2.0.3",
     "python-dotenv>=1.0.1",
-    "uipath-langchain==0.0.87",
+    "uipath-langchain==0.0.88",
     "pydantic>=2.10.6",
     "aiohttp>=3.11.12",
     "typing-extensions>=4.12.2",

--- a/samples/ticket-classification/uv.lock
+++ b/samples/ticket-classification/uv.lock
@@ -1679,7 +1679,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "uipath-langchain", specifier = "==0.0.87" },
+    { name = "uipath-langchain", specifier = "==0.0.88" },
 ]
 
 [[package]]
@@ -1826,7 +1826,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1839,14 +1839,14 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1863,9 +1863,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "uipath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/f0/f9ac644bcb818efd2b1e35e50eeb8d20980177aabf1d359dda4e5a6c77a5/uipath_langchain-0.0.87.tar.gz", hash = "sha256:07f61284e0c734fddb7dfbdc020e16d439a319adb306a453fa8d55aebcc78cab", size = 1309008 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/0e/e05ecfc5a5b6b7f277dca18e61724c1a923ae4c9af39f71f2c8dce52343d/uipath_langchain-0.0.88.tar.gz", hash = "sha256:f06cc80c9499ae4309275119a9abf5d74c881aaef6731c6efb5b525a1291ef33", size = 1188502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/1a/4e34819ac42413b8a4650dcb05c698da7114909584c0205d66b4fe4a4424/uipath_langchain-0.0.87-py3-none-any.whl", hash = "sha256:92dd352c985ed580a9a93bcede2232205c9700bcec7ec62b1835ae372d184084", size = 50642 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/68ec6fcb4698af7f27c30a2107c349fb6115b84373dba38413346e8c5a57/uipath_langchain-0.0.88-py3-none-any.whl", hash = "sha256:78c92bebbd4a3651adcf914d3563a551222bef86f54cb3eb270d93a39ede7d28", size = 50641 },
 ]
 
 [[package]]

--- a/samples/travel-planner-local-mcp/pyproject.toml
+++ b/samples/travel-planner-local-mcp/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "langchain-openai>=0.3.9",
     "langgraph-checkpoint-sqlite>=2.0.3",
     "python-dotenv>=1.0.1",
-    "uipath-langchain==0.0.87",
+    "uipath-langchain==0.0.88",
     "pydantic>=2.10.6",
     "aiohttp>=3.11.12",
     "typing-extensions>=4.12.2",

--- a/samples/travel-planner-local-mcp/uv.lock
+++ b/samples/travel-planner-local-mcp/uv.lock
@@ -1904,7 +1904,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "uipath-langchain", specifier = "==0.0.87" },
+    { name = "uipath-langchain", specifier = "==0.0.88" },
 ]
 
 [[package]]
@@ -1955,7 +1955,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.1"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1968,14 +1968,14 @@ dependencies = [
     { name = "tomli" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/3d0e8c9c133492af75cc47d64b76e9ef9b108b4d709ea98e039aec0ff289/uipath-2.0.1.tar.gz", hash = "sha256:869637a976cca6058c4ee0b2ed79a85d4a9eb19a3306bee5e24a6dd49979c550", size = 206254 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0d/4ae746ca61ec42ca6ab449692bacfbb34e013a97224e6f175715b448ab9b/uipath-2.0.4.tar.gz", hash = "sha256:9ac7abbc2e1f53207e11cb1235e99efc6cf7c265595e0f1ac981512a443e70bc", size = 207150 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a6/c45c040b5a2ab86da0e4312b20208a5df68100d04be7f2e69c17f18ccc04/uipath-2.0.1-py3-none-any.whl", hash = "sha256:992a34bef5aef8c9a98fa188d1cff165e8271b9de93e25d3ed0b18d0f16c65c4", size = 84375 },
+    { url = "https://files.pythonhosted.org/packages/0f/d9/e4c2d3ba7d87e59937ca5980f4bc2b7d06c68578df33a9a0d4eb99764d44/uipath-2.0.4-py3-none-any.whl", hash = "sha256:698680eb2f8fd885dbc9e13856028cdd10cfac525698375022ff484629f3f778", size = 85424 },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1992,9 +1992,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "uipath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/f0/f9ac644bcb818efd2b1e35e50eeb8d20980177aabf1d359dda4e5a6c77a5/uipath_langchain-0.0.87.tar.gz", hash = "sha256:07f61284e0c734fddb7dfbdc020e16d439a319adb306a453fa8d55aebcc78cab", size = 1309008 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/0e/e05ecfc5a5b6b7f277dca18e61724c1a923ae4c9af39f71f2c8dce52343d/uipath_langchain-0.0.88.tar.gz", hash = "sha256:f06cc80c9499ae4309275119a9abf5d74c881aaef6731c6efb5b525a1291ef33", size = 1188502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/1a/4e34819ac42413b8a4650dcb05c698da7114909584c0205d66b4fe4a4424/uipath_langchain-0.0.87-py3-none-any.whl", hash = "sha256:92dd352c985ed580a9a93bcede2232205c9700bcec7ec62b1835ae372d184084", size = 50642 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/68ec6fcb4698af7f27c30a2107c349fb6115b84373dba38413346e8c5a57/uipath_langchain-0.0.88-py3-none-any.whl", hash = "sha256:78c92bebbd4a3651adcf914d3563a551222bef86f54cb3eb270d93a39ede7d28", size = 50641 },
 ]
 
 [[package]]


### PR DESCRIPTION
- bumped `uipath-langchain` version to `0.0.88`
- bumped `uipath` version to `2.0.4`