### PR TITLE
fix: class config deprecation warning

### DIFF
--- a/src/uipath_langchain/_utils/_request_mixin.py
+++ b/src/uipath_langchain/_utils/_request_mixin.py
@@ -9,7 +9,7 @@ import httpx
 import openai
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models.chat_models import _cleanup_llm_representation
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 from tenacity import (
     AsyncRetrying,
     Retrying,
@@ -37,8 +37,7 @@ def get_from_uipath_url():
 
 
 class UiPathRequestMixin(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     default_headers: Optional[Mapping[str, str]] = {
         "X-UiPath-Streaming-Enabled": "false",


### PR DESCRIPTION
```
.venv\Lib\site-packages\pydantic\_internal\_config.py:323
  C:\Users\cristian.pufu\Documents\GitHub\uipath-langchain-python\.venv\Lib\site-packages\pydantic\_internal\_config.py:323: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```
Old style:
```python
class MyModel(BaseModel):
    class Config:
        arbitrary_types_allowed = True
```
New style:
```python
from pydantic import BaseModel, ConfigDict

class MyModel(BaseModel):
    model_config = ConfigDict(arbitrary_types_allowed=True)
```