### PR TITLE
feat: stream chat messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.0.125"
+version = "0.0.126"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 dependencies = [
-    "uipath>=2.1.33, <2.2.0",
+    "uipath>=2.1.38, <2.2.0",
     "langgraph>=0.5.0, <0.7.0",
     "langchain-core>=0.3.34",
     "langgraph-checkpoint-sqlite>=2.0.3",

--- a/src/uipath_langchain/_cli/_runtime/_conversation.py
+++ b/src/uipath_langchain/_cli/_runtime/_conversation.py
@@ -1,0 +1,256 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    HumanMessage,
+    ToolMessage,
+)
+from uipath.agent.conversation import (
+    UiPathConversationContentPartChunkEvent,
+    UiPathConversationContentPartEndEvent,
+    UiPathConversationContentPartEvent,
+    UiPathConversationContentPartStartEvent,
+    UiPathConversationEvent,
+    UiPathConversationExchangeEvent,
+    UiPathConversationMessageEndEvent,
+    UiPathConversationMessageEvent,
+    UiPathConversationMessageStartEvent,
+    UiPathConversationToolCallEndEvent,
+    UiPathConversationToolCallEvent,
+    UiPathConversationToolCallStartEvent,
+    UiPathInlineValue,
+)
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _wrap_in_conversation_event(
+    msg_event: UiPathConversationMessageEvent,
+    exchange_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+) -> UiPathConversationEvent:
+    """Helper to wrap a message event into a conversation-level event."""
+    return UiPathConversationEvent(
+        conversation_id=conversation_id or _new_id(),
+        exchange=UiPathConversationExchangeEvent(
+            exchange_id=exchange_id or _new_id(),
+            message=msg_event,
+        ),
+    )
+
+
+def _extract_text(content) -> str:
+    """Normalize LangGraph message.content to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return str(content or "")
+
+
+def map_message(
+    message: BaseMessage,
+    exchange_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+) -> Optional[UiPathConversationEvent]:
+    """Convert LangGraph BaseMessage (chunk or full) into a UiPathConversationEvent."""
+    message_id = getattr(message, "id", None) or _new_id()
+    timestamp = datetime.now().isoformat()
+
+    # --- Streaming AIMessageChunk ---
+    if isinstance(message, AIMessageChunk):
+        msg_event = UiPathConversationMessageEvent(
+            message_id=message.id or _new_id(),
+        )
+
+        if message.content == []:
+            msg_event.start = UiPathConversationMessageStartEvent(
+                role="assistant", timestamp=timestamp
+            )
+            msg_event.content_part = UiPathConversationContentPartEvent(
+                content_part_id=f"chunk-{message.id}-{0}",
+                start=UiPathConversationContentPartStartEvent(mime_type="text/plain"),
+            )
+
+        elif isinstance(message.content, list) and message.content:
+            for chunk in message.content:
+                if not isinstance(chunk, dict):
+                    continue
+                idx = chunk.get("index", 0)
+                ctype = chunk.get("type")
+                id = chunk.get("id", f"chunk-{message.id}-{idx}")
+
+                # Start of a tool call
+                if ctype == "tool_use":
+                    msg_event.tool_call = UiPathConversationToolCallEvent(
+                        tool_call_id=id,
+                        start=UiPathConversationToolCallStartEvent(
+                            tool_name=chunk.get("name") or "",
+                            arguments=UiPathInlineValue(inline=""),
+                            timestamp=timestamp,
+                        ),
+                    )
+
+                # JSON args streaming (content part for tool args)
+                elif ctype == "input_json_delta":
+                    text = chunk.get("partial_json", "")
+                    # first delta: emit content part start + first chunk
+                    if text == "":
+                        msg_event.content_part = UiPathConversationContentPartEvent(
+                            content_part_id=id,
+                            start=UiPathConversationContentPartStartEvent(
+                                mime_type="application/json"
+                            ),
+                        )
+                    else:
+                        msg_event.content_part = UiPathConversationContentPartEvent(
+                            content_part_id=id,
+                            chunk=UiPathConversationContentPartChunkEvent(
+                                data=text,
+                                content_part_sequence=idx,
+                            ),
+                        )
+
+                # Plain text from assistant
+                elif ctype == "text":
+                    text = chunk.get("text", "")
+                    msg_event.content_part = UiPathConversationContentPartEvent(
+                        content_part_id=id,
+                        chunk=UiPathConversationContentPartChunkEvent(
+                            data=text,
+                            content_part_sequence=idx,
+                        ),
+                    )
+
+        stop_reason = message.response_metadata.get("stop_reason")
+        if not message.content and stop_reason in ("tool_use", "end_turn"):
+            msg_event.end = UiPathConversationMessageEndEvent(timestamp=timestamp)
+
+        if (
+            msg_event.start
+            or msg_event.content_part
+            or msg_event.tool_call
+            or msg_event.end
+        ):
+            return _wrap_in_conversation_event(msg_event, exchange_id, conversation_id)
+
+        return None
+
+    text_content = _extract_text(message.content)
+
+    # --- HumanMessage ---
+    if isinstance(message, HumanMessage):
+        return _wrap_in_conversation_event(
+            UiPathConversationMessageEvent(
+                message_id=message_id,
+                start=UiPathConversationMessageStartEvent(
+                    role="user", timestamp=timestamp
+                ),
+                content_part=UiPathConversationContentPartEvent(
+                    content_part_id=f"cp-{message_id}",
+                    start=UiPathConversationContentPartStartEvent(
+                        mime_type="text/plain"
+                    ),
+                    chunk=UiPathConversationContentPartChunkEvent(data=text_content),
+                    end=UiPathConversationContentPartEndEvent(),
+                ),
+                end=UiPathConversationMessageEndEvent(),
+            ),
+            exchange_id,
+            conversation_id,
+        )
+
+    # --- AIMessage ---
+    if isinstance(message, AIMessage):
+        # Extract first tool call if present
+        tool_calls = getattr(message, "tool_calls", []) or []
+        first_tc = tool_calls[0] if tool_calls else None
+
+        return _wrap_in_conversation_event(
+            UiPathConversationMessageEvent(
+                message_id=message_id,
+                start=UiPathConversationMessageStartEvent(
+                    role="assistant", timestamp=timestamp
+                ),
+                content_part=(
+                    UiPathConversationContentPartEvent(
+                        content_part_id=f"cp-{message_id}",
+                        start=UiPathConversationContentPartStartEvent(
+                            mime_type="text/plain"
+                        ),
+                        chunk=UiPathConversationContentPartChunkEvent(
+                            data=text_content
+                        ),
+                        end=UiPathConversationContentPartEndEvent(),
+                    )
+                    if text_content
+                    else None
+                ),
+                tool_call=(
+                    UiPathConversationToolCallEvent(
+                        tool_call_id=first_tc.get("id") or _new_id(),
+                        start=UiPathConversationToolCallStartEvent(
+                            tool_name=first_tc.get("name"),
+                            arguments=UiPathInlineValue(
+                                inline=str(first_tc.get("args", ""))
+                            ),
+                            timestamp=timestamp,
+                        ),
+                    )
+                    if first_tc
+                    else None
+                ),
+                end=UiPathConversationMessageEndEvent(),
+            ),
+            exchange_id,
+            conversation_id,
+        )
+
+    # --- ToolMessage ---
+    if isinstance(message, ToolMessage):
+        return _wrap_in_conversation_event(
+            UiPathConversationMessageEvent(
+                message_id=message_id,
+                tool_call=UiPathConversationToolCallEvent(
+                    tool_call_id=message.tool_call_id,
+                    start=UiPathConversationToolCallStartEvent(
+                        tool_name=message.name or "",
+                        arguments=UiPathInlineValue(inline=""),
+                        timestamp=timestamp,
+                    ),
+                    end=UiPathConversationToolCallEndEvent(
+                        timestamp=timestamp,
+                        result=UiPathInlineValue(inline=message.content),
+                    ),
+                ),
+            ),
+            exchange_id,
+            conversation_id,
+        )
+
+    # --- Fallback ---
+    return _wrap_in_conversation_event(
+        UiPathConversationMessageEvent(
+            message_id=message_id,
+            start=UiPathConversationMessageStartEvent(
+                role="assistant", timestamp=timestamp
+            ),
+            content_part=UiPathConversationContentPartEvent(
+                content_part_id=f"cp-{message_id}",
+                chunk=UiPathConversationContentPartChunkEvent(data=text_content),
+            ),
+            end=UiPathConversationMessageEndEvent(),
+        ),
+        exchange_id,
+        conversation_id,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2230,6 +2230,12 @@ crypto = [
 ]
 
 [[package]]
+name = "pyperclip"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/2f0a3efc4d6a32f3b63cdff36cd398d9701d26cda58e3ab97ac79fb5e60d/pyperclip-1.9.0.tar.gz", hash = "sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310", size = 20961, upload-time = "2024-06-18T20:38:48.401Z" }
+
+[[package]]
 name = "pytest"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2740,7 +2746,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.33"
+version = "2.1.38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },
@@ -2750,6 +2756,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pathlib" },
     { name = "pydantic" },
+    { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "tenacity" },
@@ -2757,14 +2764,14 @@ dependencies = [
     { name = "tomli" },
     { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/5b/6cdab558c7d34652c01a6f083e53c406f99bcedffd82a9097414db6d36e8/uipath-2.1.33.tar.gz", hash = "sha256:17f6a6062056ccf502d72770692c1ca96e5be6190e5648bb1ee0df93806caa6f", size = 1976249, upload-time = "2025-09-04T15:03:22.551Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/de/54ab0f9dc3081dff136271d19259162dbbfb0917a2ffcce16cc55062d715/uipath-2.1.38.tar.gz", hash = "sha256:d9d32e87dcafba89c642ba53c4bdb24100e7ca5efbdb7c4bfec3a8aee62fcd61", size = 1984272, upload-time = "2025-09-09T05:27:29.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/3b/ef1f1d1a23bba6aaa800fb74415dab56cdcb317b99d9c97392bd2043bbbd/uipath-2.1.33-py3-none-any.whl", hash = "sha256:6f9f8b35724517981bb14aa0b408e691eeefdf3b06cb7f8786562884639accff", size = 200206, upload-time = "2025-09-04T15:03:20.755Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/56/ee8e70825279938f7105edaa3ddc91c559c5c4e1f4b5df3cc86d7f31484c/uipath-2.1.38-py3-none-any.whl", hash = "sha256:cd78cb4b0cdab2ee8372dc573e3892684db08074586c2580c163f6a98dca05bb", size = 212810, upload-time = "2025-09-09T05:27:27.691Z" },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.125"
+version = "0.0.126"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -2808,7 +2815,7 @@ requires-dist = [
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.50" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.1.33,<2.2.0" },
+    { name = "uipath", specifier = ">=2.1.38,<2.2.0" },
     { name = "uipath-langchain", marker = "extra == 'langchain'", specifier = ">=0.0.2" },
 ]
 provides-extras = ["langchain"]


### PR DESCRIPTION
## Description

This PR implements chat message streaming functionality by intercepting LangGraph stream output and converting it to UiPath conversation events. It adds support for real-time chat message handling when a chat handler is present.

- Adds streaming support for chat messages through LangGraph's astream with "messages" mode
- Creates a message mapping system to convert LangChain messages to UiPath conversation events
- Updates dependency version to support new conversation event models

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.0.126.dev1001660502",

  # Any version from PR
  "uipath-langchain>=0.0.126.dev1001660000,<0.0.126.dev1001670000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }
```