### PR TITLE
fix: updated uipath new example to use our model endpoints

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -121,7 +121,6 @@ Generate your first UiPath LangChain agent:
 ✓  Created 'main.py' file.
 ✓  Created 'langgraph.json' file.
 ✓  Created 'pyproject.toml' file.
-🔧  Please ensure to define either ANTHROPIC_API_KEY or OPENAI_API_KEY in your .env file.
 💡  Initialize project: uipath init
 💡  Run agent: uipath run agent '{"topic": "UiPath"}'
 ```

--- a/src/uipath_langchain/_cli/_templates/main.py.template
+++ b/src/uipath_langchain/_cli/_templates/main.py.template
@@ -1,27 +1,26 @@
-from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_openai import ChatOpenAI
 from langgraph.graph import START, StateGraph, END
+from uipath_langchain.chat import UiPathChat
 from pydantic import BaseModel
-import os
+
+llm = UiPathChat(model="gpt-4o-mini-2024-07-18")
+
 
 class GraphState(BaseModel):
     topic: str
 
+
 class GraphOutput(BaseModel):
     report: str
 
-async def generate_report(state: GraphState) -> GraphOutput:
-    if os.getenv("ANTHROPIC_API_KEY"):
-        llm_model = ChatAnthropic(model="claude-3-5-sonnet-latest")
-    elif os.getenv("OPENAI_API_KEY"):
-        llm_model = ChatOpenAI(model="gpt-4o-mini", temperature=0)
-    else:
-        raise Exception("Missing API Key. Please define either ANTHROPIC_API_KEY or OPENAI_API_KEY.")
 
+async def generate_report(state: GraphState) -> GraphOutput:
     system_prompt = "You are a report generator. Please provide a brief report based on the given topic."
-    output = await llm_model.ainvoke([SystemMessage(system_prompt), HumanMessage(state.topic)])
+    output = await llm.ainvoke(
+        [SystemMessage(system_prompt), HumanMessage(state.topic)]
+    )
     return GraphOutput(report=output.content)
+
 
 builder = StateGraph(GraphState, output=GraphOutput)
 

--- a/src/uipath_langchain/_cli/cli_new.py
+++ b/src/uipath_langchain/_cli/cli_new.py
@@ -54,9 +54,6 @@ def langgraph_new_middleware(name: str) -> MiddlewareResult:
             console.success("Created 'langgraph.json' file.")
             generate_pyproject(directory, name)
             console.success("Created 'pyproject.toml' file.")
-            console.config(
-                f""" Please ensure to define either {click.style("ANTHROPIC_API_KEY", fg="bright_yellow")} or {click.style("OPENAI_API_KEY", fg="bright_yellow")} in your .env file. """
-            )
             init_command = """uipath init"""
             run_command = """uipath run agent '{"topic": "UiPath"}'"""
             console.hint(


### PR DESCRIPTION
This pull request simplifies the agent template and onboarding instructions by removing support for Anthropic and OpenAI API keys, and standardizing on the `UiPathChat` model. The changes streamline the user experience and codebase, making it easier for new users to get started without configuring external API keys.

**Template and onboarding simplification:**

* Updated `main.py` template to use only the `UiPathChat` model, removing dependencies on Anthropic and OpenAI models and related API key checks. (`src/uipath_langchain/_cli/_templates/main.py.template`)
* Removed onboarding instructions and CLI messages that previously required users to set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` in their `.env` file. (`docs/quick_start.md`, `src/uipath_langchain/_cli/cli_new.py`) [[1]](diffhunk://#diff-61f4196322cfa9f52c5f548f13b7f781243b2cae898862a8688462d914ba7173L124) [[2]](diffhunk://#diff-dd1422bffd5e66793005a3966d6c789623414d36c0f9251e9f560dd34be726b2L57-L59)