### PR TITLE
feat(load_dotenv): remove load_dotenv()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.0.130"
+version = "0.0.131"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 dependencies = [
-    "uipath>=2.1.49, <2.2.0",
+    "uipath>=2.1.54, <2.2.0",
     "langgraph>=0.5.0, <0.7.0",
     "langchain-core>=0.3.34",
     "langgraph-checkpoint-sqlite>=2.0.3",

--- a/samples/retrieval-chain/main.py
+++ b/samples/retrieval-chain/main.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pprint import pprint
 from typing import Any
 
-from dotenv import find_dotenv, load_dotenv
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
@@ -68,7 +67,6 @@ def create_retrieval_chain(vectorstore: VectorStore, model: BaseChatModel, k: in
 
 
 async def main(input_data: MainInput):
-    load_dotenv(find_dotenv())
 
     """Run a simple example of ContextGroundingVectorStore."""
     vectorstore = ContextGroundingVectorStore(

--- a/samples/simple-remote-mcp/main.py
+++ b/samples/simple-remote-mcp/main.py
@@ -1,4 +1,3 @@
-import dotenv
 import os
 from contextlib import asynccontextmanager
 from langgraph.prebuilt import create_react_agent
@@ -7,7 +6,6 @@ from langchain_mcp_adapters.tools import load_mcp_tools
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
-dotenv.load_dotenv()
 
 @asynccontextmanager
 async def make_graph():

--- a/src/uipath_langchain/_cli/_utils/_graph.py
+++ b/src/uipath_langchain/_cli/_utils/_graph.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, cast
 
-from dotenv import load_dotenv
 from langgraph.graph import StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
@@ -160,18 +159,6 @@ class LangGraphConfig:
                 raise ValueError(
                     f"Missing required fields in langgraph.json: {missing_fields}"
                 )
-
-            if env_file := config.get("env"):
-                env_path = os.path.abspath(os.path.normpath(env_file))
-                if os.path.exists(env_path):
-                    if not load_dotenv(env_path):
-                        # log warning only if dotenv is not empty
-                        if os.path.getsize(env_path) > 0:
-                            logger.warning(
-                                f"Could not load environment variables from {env_path}"
-                            )
-                    else:
-                        logger.debug(f"Loaded environment variables from {env_path}")
 
             self._config = config
             self._load_graphs()


### PR DESCRIPTION
This pull request removes the use of the python-dotenv library and all calls to load_dotenv() from both sample scripts and the CLI utility code.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.0.131.dev1001780560",

  # Any version from PR
  "uipath-langchain>=0.0.131.dev1001780000,<0.0.131.dev1001790000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }
```