### PR TITLE
fix: remove unnecessary uipath instantiate

### DIFF
--- a/src/uipath_langchain/_cli/_runtime/_input.py
+++ b/src/uipath_langchain/_cli/_runtime/_input.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any, Optional, cast
 
 from langgraph.types import Command
-from uipath import UiPath
 from uipath._cli._runtime._contracts import (
     UiPathApiTrigger,
     UiPathErrorCategory,
@@ -32,7 +31,6 @@ class LangGraphInputProcessor:
             context: The runtime context for the graph execution.
         """
         self.context = context
-        self.uipath = UiPath()
 
     async def process(self) -> Any:
         """


### PR DESCRIPTION
## Description

This PR removes an unnecessary UiPath instantiation from the runtime input processor. The change eliminates both the import statement and the instance variable that was being created but apparently not used.

- Removes unused UiPath import from the module
- Eliminates unnecessary UiPath instance creation in the constructor