### PR TITLE
fix: decouple runtime from graph config

### DIFF
--- a/src/uipath_langchain/_cli/_runtime/_context.py
+++ b/src/uipath_langchain/_cli/_runtime/_context.py
@@ -1,17 +1,12 @@
 from typing import Any, Optional, Union
 
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-from langgraph.graph import StateGraph
 from uipath._cli._runtime._contracts import UiPathRuntimeContext
-
-from .._utils._graph import LangGraphConfig
 
 
 class LangGraphRuntimeContext(UiPathRuntimeContext):
     """Context information passed throughout the runtime execution."""
 
-    langgraph_config: Optional[LangGraphConfig] = None
-    state_graph: Optional[StateGraph[Any, Any]] = None
     output: Optional[Any] = None
     state: Optional[Any] = (
         None  # TypedDict issue, the actual type is: Optional[langgraph.types.StateSnapshot]

--- a/src/uipath_langchain/_cli/_runtime/_graph_resolver.py
+++ b/src/uipath_langchain/_cli/_runtime/_graph_resolver.py
@@ -1,0 +1,143 @@
+import asyncio
+from typing import Any, Awaitable, Callable, Optional
+
+from langgraph.graph.state import CompiledStateGraph, StateGraph
+from uipath._cli._runtime._contracts import (
+    UiPathErrorCategory,
+)
+
+from .._utils._graph import GraphConfig, LangGraphConfig
+from ._exception import LangGraphRuntimeError
+
+
+class LangGraphJsonResolver:
+    def __init__(self, entrypoint: Optional[str] = None) -> None:
+        self.entrypoint = entrypoint
+        self.graph_config: Optional[GraphConfig] = None
+        self._lock = asyncio.Lock()
+        self._graph_cache: Optional[StateGraph[Any, Any, Any]] = None
+        self._resolving: bool = False
+
+    async def __call__(self) -> StateGraph[Any, Any, Any]:
+        # Fast path: if already resolved, return immediately without locking
+        if self._graph_cache is not None:
+            return self._graph_cache
+
+        # Slow path: acquire lock and resolve
+        async with self._lock:
+            # Double-check after acquiring lock (another coroutine may have resolved it)
+            if self._graph_cache is not None:
+                return self._graph_cache
+
+            self._graph_cache = await self._resolve(self.entrypoint)
+            return self._graph_cache
+
+    async def _resolve(self, entrypoint: Optional[str]) -> StateGraph[Any, Any, Any]:
+        config = LangGraphConfig()
+        if not config.exists:
+            raise LangGraphRuntimeError(
+                "CONFIG_MISSING",
+                "Invalid configuration",
+                "Failed to load configuration",
+                UiPathErrorCategory.DEPLOYMENT,
+            )
+
+        try:
+            config.load_config()
+        except Exception as e:
+            raise LangGraphRuntimeError(
+                "CONFIG_INVALID",
+                "Invalid configuration",
+                f"Failed to load configuration: {str(e)}",
+                UiPathErrorCategory.DEPLOYMENT,
+            ) from e
+
+        # Determine entrypoint if not provided
+        graphs = config.graphs
+        if not entrypoint and len(graphs) == 1:
+            entrypoint = graphs[0].name
+        elif not entrypoint:
+            graph_names = ", ".join(g.name for g in graphs)
+            raise LangGraphRuntimeError(
+                "ENTRYPOINT_MISSING",
+                "Entrypoint required",
+                f"Multiple graphs available. Please specify one of: {graph_names}.",
+                UiPathErrorCategory.DEPLOYMENT,
+            )
+
+        # Get the specified graph
+        self.graph_config = config.get_graph(entrypoint)
+        if not self.graph_config:
+            raise LangGraphRuntimeError(
+                "GRAPH_NOT_FOUND",
+                "Graph not found",
+                f"Graph '{entrypoint}' not found.",
+                UiPathErrorCategory.DEPLOYMENT,
+            )
+        try:
+            loaded_graph = await self.graph_config.load_graph()
+            return (
+                loaded_graph.builder
+                if isinstance(loaded_graph, CompiledStateGraph)
+                else loaded_graph
+            )
+        except ImportError as e:
+            raise LangGraphRuntimeError(
+                "GRAPH_IMPORT_ERROR",
+                "Graph import failed",
+                f"Failed to import graph '{entrypoint}': {str(e)}",
+                UiPathErrorCategory.USER,
+            ) from e
+        except TypeError as e:
+            raise LangGraphRuntimeError(
+                "GRAPH_TYPE_ERROR",
+                "Invalid graph type",
+                f"Graph '{entrypoint}' is not a valid StateGraph or CompiledStateGraph: {str(e)}",
+                UiPathErrorCategory.USER,
+            ) from e
+        except ValueError as e:
+            raise LangGraphRuntimeError(
+                "GRAPH_VALUE_ERROR",
+                "Invalid graph value",
+                f"Invalid value in graph '{entrypoint}': {str(e)}",
+                UiPathErrorCategory.USER,
+            ) from e
+        except Exception as e:
+            raise LangGraphRuntimeError(
+                "GRAPH_LOAD_ERROR",
+                "Failed to load graph",
+                f"Unexpected error loading graph '{entrypoint}': {str(e)}",
+                UiPathErrorCategory.USER,
+            ) from e
+
+    async def cleanup(self):
+        """Clean up resources"""
+        async with self._lock:
+            if self.graph_config:
+                await self.graph_config.cleanup()
+                self.graph_config = None
+            self._graph_cache = None
+
+
+AsyncResolver = Callable[[], Awaitable[StateGraph[Any, Any, Any]]]
+
+
+class LangGraphJsonResolverContext:
+    """
+    Async context manager wrapping LangGraphJsonResolver.
+    Returns a callable that can be passed directly as AsyncResolver to LangGraphRuntime.
+    Thread-safe and reuses the same resolved graph across concurrent executions.
+    """
+
+    def __init__(self, entrypoint: Optional[str] = None) -> None:
+        self._resolver = LangGraphJsonResolver(entrypoint)
+
+    async def __aenter__(self) -> AsyncResolver:
+        # Return a callable that safely reuses the cached graph
+        async def resolver_callable() -> StateGraph[Any, Any, Any]:
+            return await self._resolver()
+
+        return resolver_callable
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self._resolver.cleanup()

--- a/src/uipath_langchain/_cli/cli_dev.py
+++ b/src/uipath_langchain/_cli/cli_dev.py
@@ -12,7 +12,7 @@ from uipath._cli.middlewares import MiddlewareResult
 
 from .._tracing import _instrument_traceable_attributes
 from ._runtime._context import LangGraphRuntimeContext
-from ._runtime._runtime import LangGraphRuntime
+from ._runtime._runtime import LangGraphScriptRuntime
 
 console = ConsoleLogger()
 
@@ -22,8 +22,14 @@ def langgraph_dev_middleware(interface: Optional[str]) -> MiddlewareResult:
 
     try:
         if interface == "terminal":
+
+            def generate_runtime(
+                ctx: LangGraphRuntimeContext,
+            ) -> LangGraphScriptRuntime:
+                return LangGraphScriptRuntime(ctx, ctx.entrypoint)
+
             runtime_factory = UiPathRuntimeFactory(
-                LangGraphRuntime, LangGraphRuntimeContext
+                LangGraphScriptRuntime, LangGraphRuntimeContext, generate_runtime
             )
 
             _instrument_traceable_attributes()


### PR DESCRIPTION
## Description

This PR decouples the runtime from graph configuration by introducing a new `LangGraphScriptRuntime` class and a `LangGraphJsonResolver` to handle graph loading. The changes separate concerns by removing graph configuration logic from the runtime and moving it to a dedicated resolver pattern.

- Introduces `LangGraphScriptRuntime` as a specialized runtime for script-based execution
- Creates `LangGraphJsonResolver` to handle graph loading and configuration validation
- Removes graph configuration dependencies from the base runtime and context classes

This change also introduces `LangGraphJsonResolverContext`, an async context manager that wraps the existing `LangGraphJsonResolver` and returns a callable compatible with `LangGraphRuntime`. It ensures that the underlying graph is loaded only once, improving performance and efficiency when executing multiple runtimes with the same entrypoint.

```python
async with LangGraphJsonResolverContext(entrypoint="my_agent") as resolver:
    # Pass the callable directly to the runtime
    runtime = LangGraphRuntime(context, resolver)
    result = await runtime.execute()
```

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.0.138.dev1001900658",

  # Any version from PR
  "uipath-langchain>=0.0.138.dev1001900000,<0.0.138.dev1001910000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }
```