### PR TITLE
fix(otel): fix spamy logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.0.134"
+version = "0.0.135"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath_langchain/_tracing/_oteladapter.py
+++ b/src/uipath_langchain/_tracing/_oteladapter.py
@@ -166,7 +166,7 @@ class LangChainExporter(LlmOpsHttpExporter):
         if "Attributes" not in span_data:
             return span_data
 
-        logger.info(f"Processing span: {span_data}")
+        logger.debug(f"Processing span: {span_data}")
 
         attributes_val = span_data["Attributes"]
         if isinstance(attributes_val, str):


### PR DESCRIPTION
# Description
`logger.info(f"Processing span: {span_data}")` was too verbose, it should be at debug level.