### PR TITLE
feat(status_interrupt): determine status based on err info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.0.136"
+version = "0.0.137"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"


### PR DESCRIPTION
**Description**
This pull request adds enhanced status handling to the `LangChainExporter` in the OpenTelemetry adapter, allowing for more granular tracking of operation outcomes. The main changes introduce a status field that distinguishes between success, error, and interrupted operations based on error messages.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.0.137.dev1002030643",

  # Any version from PR
  "uipath-langchain>=0.0.137.dev1002030000,<0.0.137.dev1002040000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }
```