### PR TITLE
feat: init lowcode graph builder

### DIFF
--- a/src/uipath_langchain/agent/__init__.py
+++ b/src/uipath_langchain/agent/__init__.py
@@ -1,0 +1,4 @@
+from .agent import create_lowcode_agent
+from .state import LowCodeAgentState
+
+__all__ = ["create_lowcode_agent", "LowCodeAgentState"]

--- a/src/uipath_langchain/agent/agent.py
+++ b/src/uipath_langchain/agent/agent.py
@@ -1,0 +1,35 @@
+from typing import Sequence
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import BaseTool
+from langgraph.constants import END, START
+from langgraph.graph import StateGraph
+from langgraph.prebuilt import ToolNode
+from pydantic import BaseModel
+
+from uipath_langchain.agent.state import LowCodeAgentState
+
+
+def create_lowcode_agent(
+    model: BaseChatModel,
+    tools: Sequence[BaseTool] | ToolNode,
+    messages: Sequence[SystemMessage | HumanMessage],
+    *,
+    response_format: type[BaseModel] | None = None,
+) -> StateGraph[LowCodeAgentState]:
+    """Create a LangGraph agent with the LowCode agent pattern.
+
+    Args:
+        model: The language model to use for the agent
+        tools: Sequence of tools available to the agent
+        messages: Initial messages to populate the graph state
+        response_format: Optional structured output schema for agent
+
+    Returns:
+        StateGraph configured with model and tools executing the LowCode agent
+    """
+    builder = StateGraph(LowCodeAgentState)
+    builder.add_edge(START, END)
+
+    return builder

--- a/src/uipath_langchain/agent/state.py
+++ b/src/uipath_langchain/agent/state.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+from langgraph.graph import MessagesState
+
+
+class LowCodeAgentState(MessagesState):
+    """LowCodeAgentState extending MessagesState"""
+
+
+class GraphNode(str, Enum):
+    """Graph node identifiers for the LowCode agent graph."""
+
+    STATE_INIT = "state_init"
+    AGENT = "agent"
+    TOOLS = "tools"
+    TERMINATE = "terminate"


### PR DESCRIPTION
## What changed?

- add `create_lowcode_agent` method signature with default implementation

The assumption would be to use it interchangeably with `create_react_agent` / newly `create_agent` from langchain >=1.0