### PR TITLE
feat: add create react agent

### DIFF
--- a/src/uipath_langchain/agent/react/__init__.py
+++ b/src/uipath_langchain/agent/react/__init__.py
@@ -1,0 +1,12 @@
+"""UiPath ReAct Agent implementation"""
+
+from .agent import create_agent
+from .state import AgentGraphNode, AgentGraphState
+from .utils import resolve_output_model
+
+__all__ = [
+    "create_agent",
+    "AgentGraphState",
+    "AgentGraphNode",
+    "resolve_output_model",
+]

--- a/src/uipath_langchain/agent/react/agent.py
+++ b/src/uipath_langchain/agent/react/agent.py
@@ -1,0 +1,76 @@
+import os
+from typing import Sequence, Type
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import BaseTool
+from langgraph.constants import END, START
+from langgraph.graph import StateGraph
+from pydantic import BaseModel
+
+from ..tools import create_tool_node
+from .init_node import (
+    create_init_node,
+)
+from .llm_node import (
+    create_llm_node,
+)
+from .router import (
+    route_agent,
+)
+from .state import AgentGraphNode, AgentGraphState
+from .terminate_node import (
+    create_terminate_node,
+)
+from .tools import create_flow_control_tools
+
+
+def create_agent(
+    model: BaseChatModel,
+    tools: Sequence[BaseTool],
+    messages: Sequence[SystemMessage | HumanMessage],
+    *,
+    state_schema: Type[AgentGraphState] = AgentGraphState,
+    response_format: type[BaseModel] | None = None,
+    recursion_limit: int = 50,
+) -> StateGraph[AgentGraphState]:
+    """Build agent graph with INIT -> AGENT <-> TOOLS loop, terminated by control flow tools.
+
+    Control flow tools (end_execution, raise_error) are auto-injected alongside regular tools.
+    """
+    os.environ["LANGCHAIN_RECURSION_LIMIT"] = str(recursion_limit)
+
+    agent_tools = list(tools)
+    flow_control_tools: list[BaseTool] = create_flow_control_tools(response_format)
+    llm_tools: list[BaseTool] = [*agent_tools, *flow_control_tools]
+
+    init_node = create_init_node(messages)
+    agent_node = create_llm_node(model, llm_tools)
+    tool_nodes = create_tool_node(agent_tools)
+    terminate_node = create_terminate_node(response_format)
+
+    builder: StateGraph[AgentGraphState] = StateGraph(state_schema)
+    builder.add_node(AgentGraphNode.INIT, init_node)
+    builder.add_node(AgentGraphNode.AGENT, agent_node)
+
+    for tool_name, tool_node in tool_nodes.items():
+        builder.add_node(tool_name, tool_node)
+
+    builder.add_node(AgentGraphNode.TERMINATE, terminate_node)
+
+    builder.add_edge(START, AgentGraphNode.INIT)
+    builder.add_edge(AgentGraphNode.INIT, AgentGraphNode.AGENT)
+
+    tool_node_names = list(tool_nodes.keys())
+    builder.add_conditional_edges(
+        AgentGraphNode.AGENT,
+        route_agent,
+        [AgentGraphNode.AGENT, *tool_node_names, AgentGraphNode.TERMINATE],
+    )
+
+    for tool_name in tool_node_names:
+        builder.add_edge(tool_name, AgentGraphNode.AGENT)
+
+    builder.add_edge(AgentGraphNode.TERMINATE, END)
+
+    return builder

--- a/src/uipath_langchain/agent/react/constants.py
+++ b/src/uipath_langchain/agent/react/constants.py
@@ -1,0 +1,2 @@
+# Agent routing configuration
+MAX_SUCCESSIVE_COMPLETIONS = 1

--- a/src/uipath_langchain/agent/react/exceptions.py
+++ b/src/uipath_langchain/agent/react/exceptions.py
@@ -1,0 +1,11 @@
+"""Exceptions for the basic agent loop."""
+
+from uipath._cli._runtime._contracts import UiPathRuntimeError
+
+
+class AgentNodeRoutingException(Exception):
+    pass
+
+
+class AgentTerminationException(UiPathRuntimeError):
+    pass

--- a/src/uipath_langchain/agent/react/init_node.py
+++ b/src/uipath_langchain/agent/react/init_node.py
@@ -1,0 +1,16 @@
+"""State initialization node for the ReAct Agent graph."""
+
+from typing import Sequence
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from .state import AgentGraphState
+
+
+def create_init_node(
+    messages: Sequence[SystemMessage | HumanMessage],
+):
+    def graph_state_init(_: AgentGraphState):
+        return {"messages": list(messages)}
+
+    return graph_state_init

--- a/src/uipath_langchain/agent/react/llm_node.py
+++ b/src/uipath_langchain/agent/react/llm_node.py
@@ -1,0 +1,44 @@
+"""LLM node implementation for LangGraph."""
+
+from typing import Sequence
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, AnyMessage
+from langchain_core.tools import BaseTool
+
+from .constants import MAX_SUCCESSIVE_COMPLETIONS
+from .state import AgentGraphState
+from .utils import count_successive_completions
+
+
+def create_llm_node(
+    model: BaseChatModel,
+    tools: Sequence[BaseTool] | None = None,
+):
+    """Invoke LLM with tools and dynamically control tool_choice based on successive completions.
+
+    When successive completions reach the limit, tool_choice is set to "required" to force
+    the LLM to use a tool and prevent infinite reasoning loops.
+    """
+    bindable_tools = list(tools) if tools else []
+    base_llm = model.bind_tools(bindable_tools) if bindable_tools else model
+
+    async def llm_node(state: AgentGraphState):
+        messages: list[AnyMessage] = state["messages"]
+
+        successive_completions = count_successive_completions(messages)
+
+        if successive_completions >= MAX_SUCCESSIVE_COMPLETIONS and bindable_tools:
+            llm = base_llm.bind(tool_choice="required")
+        else:
+            llm = base_llm
+
+        response = await llm.ainvoke(messages)
+        if not isinstance(response, AIMessage):
+            raise TypeError(
+                f"LLM returned {type(response).__name__} instead of AIMessage"
+            )
+
+        return {"messages": [response]}
+
+    return llm_node

--- a/src/uipath_langchain/agent/react/router.py
+++ b/src/uipath_langchain/agent/react/router.py
@@ -1,0 +1,97 @@
+"""Routing functions for conditional edges in the agent graph."""
+
+from typing import Literal
+
+from langchain_core.messages import AIMessage, AnyMessage, ToolCall
+from uipath.agent.react import END_EXECUTION_TOOL, RAISE_ERROR_TOOL
+
+from .constants import MAX_SUCCESSIVE_COMPLETIONS
+from .exceptions import AgentNodeRoutingException
+from .state import AgentGraphNode, AgentGraphState
+from .utils import count_successive_completions
+
+FLOW_CONTROL_TOOLS = [END_EXECUTION_TOOL.name, RAISE_ERROR_TOOL.name]
+
+
+def __filter_control_flow_tool_calls(
+    tool_calls: list[ToolCall],
+) -> list[ToolCall]:
+    """Remove control flow tools when multiple tool calls exist."""
+    if len(tool_calls) <= 1:
+        return tool_calls
+
+    return [tc for tc in tool_calls if tc.get("name") not in FLOW_CONTROL_TOOLS]
+
+
+def __has_control_flow_tool(tool_calls: list[ToolCall]) -> bool:
+    """Check if any tool call is of a control flow tool."""
+    return any(tc.get("name") in FLOW_CONTROL_TOOLS for tc in tool_calls)
+
+
+def __validate_last_message_is_AI(messages: list[AnyMessage]) -> AIMessage:
+    """Validate and return last message from state.
+
+    Raises:
+        AgentNodeRoutingException: If messages are empty or last message is not AIMessage
+    """
+    if not messages:
+        raise AgentNodeRoutingException(
+            "No messages in state - cannot route after agent"
+        )
+
+    last_message = messages[-1]
+    if not isinstance(last_message, AIMessage):
+        raise AgentNodeRoutingException(
+            f"Last message is not AIMessage (type: {type(last_message).__name__}) - cannot route after agent"
+        )
+
+    return last_message
+
+
+def route_agent(
+    state: AgentGraphState,
+) -> list[str] | Literal[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE]:
+    """Route after agent: handles all routing logic including control flow detection.
+
+    Routing logic:
+    1. If multiple tool calls exist, filter out control flow tools (EndExecution, RaiseError)
+    2. If control flow tool(s) remain, route to TERMINATE
+    3. If regular tool calls remain, route to specific tool nodes (return list of tool names)
+    4. If no tool calls, handle successive completions
+
+    Returns:
+        - list[str]: Tool node names for parallel execution
+        - AgentGraphNode.AGENT: For successive completions
+        - AgentGraphNode.TERMINATE: For control flow termination
+
+    Raises:
+        AgentNodeRoutingException: When encountering unexpected state (empty messages, non-AIMessage, or excessive completions)
+    """
+    messages = state.get("messages", [])
+    last_message = __validate_last_message_is_AI(messages)
+
+    tool_calls = list(last_message.tool_calls) if last_message.tool_calls else []
+    tool_calls = __filter_control_flow_tool_calls(tool_calls)
+
+    if tool_calls and __has_control_flow_tool(tool_calls):
+        return AgentGraphNode.TERMINATE
+
+    if tool_calls:
+        return [tc["name"] for tc in tool_calls]
+
+    successive_completions = count_successive_completions(messages)
+
+    if successive_completions > MAX_SUCCESSIVE_COMPLETIONS:
+        raise AgentNodeRoutingException(
+            f"Agent exceeded successive completions limit without producing tool calls "
+            f"(completions: {successive_completions}, max: {MAX_SUCCESSIVE_COMPLETIONS}). "
+            f"This should not happen as tool_choice='required' is enforced at the limit."
+        )
+
+    if last_message.content:
+        return AgentGraphNode.AGENT
+
+    raise AgentNodeRoutingException(
+        f"Agent produced empty response without tool calls "
+        f"(completions: {successive_completions}, has_content: False)"
+    )

--- a/src/uipath_langchain/agent/react/state.py
+++ b/src/uipath_langchain/agent/react/state.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from langgraph.graph import MessagesState
+
+
+class AgentGraphState(MessagesState):
+    """Agent Graph state for standard loop execution."""
+
+    pass
+
+
+class AgentGraphNode(StrEnum):
+    INIT = "init"
+    AGENT = "agent"
+    TOOLS = "tools"
+    TERMINATE = "terminate"

--- a/src/uipath_langchain/agent/react/terminate_node.py
+++ b/src/uipath_langchain/agent/react/terminate_node.py
@@ -1,0 +1,50 @@
+"""Termination node for the Agent graph."""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage
+from pydantic import BaseModel
+from uipath.agent.react import END_EXECUTION_TOOL, RAISE_ERROR_TOOL
+
+from .exceptions import (
+    AgentNodeRoutingException,
+    AgentTerminationException,
+)
+from .state import AgentGraphState
+
+
+def create_terminate_node(
+    response_schema: type[BaseModel] | None = None,
+):
+    """Validates and returns end_execution args, or raises AgentTerminationException for raise_error."""
+
+    def terminate_node(state: AgentGraphState):
+        last_message = state["messages"][-1]
+        if not isinstance(last_message, AIMessage):
+            raise AgentNodeRoutingException(
+                f"Expected last message to be AIMessage, got {type(last_message).__name__}"
+            )
+
+        for tool_call in last_message.tool_calls:
+            tool_name = tool_call["name"]
+
+            if tool_name == END_EXECUTION_TOOL.name:
+                args = tool_call["args"]
+                output_schema = response_schema or END_EXECUTION_TOOL.args_schema
+                validated = output_schema.model_validate(args)
+                return validated.model_dump()
+
+            if tool_name == RAISE_ERROR_TOOL.name:
+                error_message = tool_call["args"].get(
+                    "message", "The LLM did not set the error message"
+                )
+                detail = tool_call["args"].get("details", "")
+                raise AgentTerminationException(
+                    code="400", title=error_message, detail=detail
+                )
+
+        raise AgentNodeRoutingException(
+            "No control flow tool call found in terminate node. Unexpected state."
+        )
+
+    return terminate_node

--- a/src/uipath_langchain/agent/react/tools/__init__.py
+++ b/src/uipath_langchain/agent/react/tools/__init__.py
@@ -1,0 +1,7 @@
+from .tools import (
+    create_flow_control_tools,
+)
+
+__all__ = [
+    "create_flow_control_tools",
+]

--- a/src/uipath_langchain/agent/react/tools/tools.py
+++ b/src/uipath_langchain/agent/react/tools/tools.py
@@ -1,0 +1,50 @@
+"""Control flow tools for agent execution."""
+
+from typing import Any
+
+from langchain_core.tools import BaseTool, StructuredTool
+from pydantic import BaseModel
+from uipath.agent.react import (
+    END_EXECUTION_TOOL,
+    RAISE_ERROR_TOOL,
+)
+
+
+def create_end_execution_tool(
+    agent_output_schema: type[BaseModel] | None = None,
+) -> StructuredTool:
+    """Never executed - routing intercepts and extracts args for successful termination."""
+    input_schema = agent_output_schema or END_EXECUTION_TOOL.args_schema
+
+    async def end_execution_fn(**kwargs: Any) -> dict[str, Any]:
+        return kwargs
+
+    return StructuredTool(
+        name=END_EXECUTION_TOOL.name,
+        description=END_EXECUTION_TOOL.description,
+        args_schema=input_schema,
+        coroutine=end_execution_fn,
+    )
+
+
+def create_raise_error_tool() -> StructuredTool:
+    """Never executed - routing intercepts and raises AgentTerminationException."""
+
+    async def raise_error_fn(**kwargs: Any) -> dict[str, Any]:
+        return kwargs
+
+    return StructuredTool(
+        name=RAISE_ERROR_TOOL.name,
+        description=RAISE_ERROR_TOOL.description,
+        args_schema=RAISE_ERROR_TOOL.args_schema,
+        coroutine=raise_error_fn,
+    )
+
+
+def create_flow_control_tools(
+    agent_output_schema: type[BaseModel] | None = None,
+) -> list[BaseTool]:
+    return [
+        create_end_execution_tool(agent_output_schema),
+        create_raise_error_tool(),
+    ]

--- a/src/uipath_langchain/agent/react/utils.py
+++ b/src/uipath_langchain/agent/react/utils.py
@@ -1,0 +1,39 @@
+"""ReAct Agent loop utilities."""
+
+from typing import Any, Sequence
+
+from jsonschema_pydantic import jsonschema_to_pydantic  # type: ignore[import-untyped]
+from langchain_core.messages import AIMessage, BaseMessage
+from pydantic import BaseModel
+from uipath.agent.react import END_EXECUTION_TOOL
+
+
+def resolve_output_model(
+    output_schema: dict[str, Any] | None,
+) -> type[BaseModel]:
+    """Fallback to default end_execution tool schema when no agent output schema is provided."""
+    if output_schema:
+        return jsonschema_to_pydantic(output_schema)
+
+    return END_EXECUTION_TOOL.args_schema
+
+
+def count_successive_completions(messages: Sequence[BaseMessage]) -> int:
+    """Count consecutive AIMessages without tool calls at end of message history."""
+    if not messages:
+        return 0
+
+    count = 0
+    for message in reversed(messages):
+        if not isinstance(message, AIMessage):
+            break
+
+        if message.tool_calls:
+            break
+
+        if not message.content:
+            break
+
+        count += 1
+
+    return count

--- a/src/uipath_langchain/agent/tools/__init__.py
+++ b/src/uipath_langchain/agent/tools/__init__.py
@@ -1,0 +1,8 @@
+"""Tool creation and management for LowCode agents."""
+
+from .tool_factory import (
+    create_tools_from_resources,
+)
+from .tool_node import create_tool_node
+
+__all__ = ["create_tools_from_resources", "create_tool_node"]

--- a/src/uipath_langchain/agent/tools/context_tool.py
+++ b/src/uipath_langchain/agent/tools/context_tool.py
@@ -1,0 +1,42 @@
+"""Context tool creation for semantic index retrieval."""
+
+from __future__ import annotations
+
+import json
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+from uipath.agent.models.agent import AgentContextResourceConfig
+
+from uipath_langchain.retrievers import ContextGroundingRetriever
+
+from .utils import sanitize_tool_name
+
+
+def create_context_tool(resource: AgentContextResourceConfig) -> StructuredTool:
+    tool_name = sanitize_tool_name(resource.name)
+    retriever = ContextGroundingRetriever(
+        index_name=resource.index_name,
+        folder_path=resource.folder_path,
+        number_of_results=resource.settings.result_count,
+    )
+
+    async def context_tool_fn(query: str) -> str:
+        docs = await retriever.ainvoke(query)
+
+        if not docs:
+            return ""
+
+        return json.dumps([doc.model_dump() for doc in docs], indent=2)
+
+    class ContextInputSchemaModel(BaseModel):
+        query: str = Field(
+            ..., description="The query to search for in the knowledge base"
+        )
+
+    return StructuredTool(
+        name=tool_name,
+        description=resource.description,
+        args_schema=ContextInputSchemaModel,
+        coroutine=context_tool_fn,
+    )

--- a/src/uipath_langchain/agent/tools/process_tool.py
+++ b/src/uipath_langchain/agent/tools/process_tool.py
@@ -1,0 +1,51 @@
+"""Process tool creation for UiPath process execution."""
+
+from __future__ import annotations
+
+from typing import Any, Type
+
+from jsonschema_pydantic import jsonschema_to_pydantic  # type: ignore[import-untyped]
+from langchain_core.tools import StructuredTool
+from langgraph.types import interrupt
+from pydantic import BaseModel
+from uipath.agent.models.agent import AgentProcessToolResourceConfig
+from uipath.models import InvokeProcess
+
+from .utils import sanitize_tool_name
+
+
+def create_process_tool(resource: AgentProcessToolResourceConfig) -> StructuredTool:
+    """Uses interrupt() to suspend graph execution until process completes (handled by runtime)."""
+    tool_name: str = sanitize_tool_name(resource.name)
+    process_name = resource.properties.process_name
+    folder_path = resource.properties.folder_path
+
+    input_model: Type[BaseModel] = jsonschema_to_pydantic(resource.input_schema)
+    output_model: Type[BaseModel] = jsonschema_to_pydantic(resource.output_schema)
+
+    async def process_tool_fn(**kwargs: Any):
+        try:
+            result = interrupt(
+                InvokeProcess(
+                    name=process_name,
+                    input_arguments=kwargs,
+                    process_folder_path=folder_path,
+                    process_folder_key=None,
+                )
+            )
+        except Exception:
+            raise
+
+        return result
+
+    class ProcessTool(StructuredTool):
+        """Process tool with OutputType for schema compatibility."""
+
+        OutputType: Type[BaseModel] = output_model
+
+    return ProcessTool(
+        name=tool_name,
+        description=resource.description,
+        args_schema=input_model,
+        coroutine=process_tool_fn,
+    )

--- a/src/uipath_langchain/agent/tools/tool_factory.py
+++ b/src/uipath_langchain/agent/tools/tool_factory.py
@@ -1,0 +1,39 @@
+"""Factory functions for creating tools from agent resources."""
+
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool, StructuredTool
+from uipath.agent.models.agent import (
+    AgentContextResourceConfig,
+    AgentProcessToolResourceConfig,
+    BaseAgentResourceConfig,
+    LowCodeAgentDefinition,
+)
+
+from .context_tool import create_context_tool
+from .process_tool import create_process_tool
+
+
+async def create_tools_from_resources(
+    agent: LowCodeAgentDefinition,
+) -> list[BaseTool]:
+    tools: list[BaseTool] = []
+
+    for resource in agent.resources:
+        tool = await _build_tool_for_resource(resource)
+        if tool is not None:
+            tools.append(tool)
+
+    return tools
+
+
+async def _build_tool_for_resource(
+    resource: BaseAgentResourceConfig,
+) -> StructuredTool | None:
+    if isinstance(resource, AgentProcessToolResourceConfig):
+        return create_process_tool(resource)
+
+    elif isinstance(resource, AgentContextResourceConfig):
+        return create_context_tool(resource)
+
+    return None

--- a/src/uipath_langchain/agent/tools/tool_node.py
+++ b/src/uipath_langchain/agent/tools/tool_node.py
@@ -1,0 +1,22 @@
+"""Tool node factory wiring directly to LangGraph's ToolNode."""
+
+from collections.abc import Sequence
+
+from langchain_core.tools import BaseTool
+from langgraph.prebuilt import ToolNode
+
+
+def create_tool_node(tools: Sequence[BaseTool]) -> dict[str, ToolNode]:
+    """Create individual ToolNode for each tool.
+
+    Args:
+        tools: Sequence of tools to create nodes for.
+
+    Returns:
+        Dict mapping tool.name -> ToolNode([tool]).
+        Each tool gets its own dedicated node for middleware composition.
+
+    Note:
+        handle_tool_errors=False delegates error handling to LangGraph's error boundary.
+    """
+    return {tool.name: ToolNode([tool], handle_tool_errors=False) for tool in tools}

--- a/src/uipath_langchain/agent/tools/utils.py
+++ b/src/uipath_langchain/agent/tools/utils.py
@@ -1,0 +1,11 @@
+"""Tool-related utility functions."""
+
+import re
+
+
+def sanitize_tool_name(name: str) -> str:
+    """Sanitize tool name for LLM compatibility (alphanumeric, underscore, hyphen only, max 64 chars)."""
+    trim_whitespaces = "_".join(name.split())
+    sanitized_tool_name = re.sub(r"[^a-zA-Z0-9_-]", "", trim_whitespaces)
+    sanitized_tool_name = sanitized_tool_name[:64]
+    return sanitized_tool_name

--- a/tests/agent/react/__init__.py
+++ b/tests/agent/react/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ReAct agent."""

--- a/tests/agent/react/test_utils.py
+++ b/tests/agent/react/test_utils.py
@@ -1,0 +1,135 @@
+"""Tests for ReAct agent utilities."""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from uipath_langchain.agent.react.utils import count_successive_completions
+
+
+class TestCountSuccessiveCompletions:
+    """Test successive completions calculation from message history."""
+
+    def test_empty_messages(self):
+        """Should return 0 for empty message list."""
+        assert count_successive_completions([]) == 0
+
+    def test_no_ai_messages(self):
+        """Should return 0 when no AI messages exist."""
+        messages = [HumanMessage(content="test")]
+        assert count_successive_completions(messages) == 0
+
+    def test_last_message_not_ai(self):
+        """Should return 0 when last message is not AI."""
+        messages = [
+            AIMessage(content="response"),
+            HumanMessage(content="follow-up"),
+        ]
+        assert count_successive_completions(messages) == 0
+
+    def test_ai_message_with_tool_calls(self):
+        """Should return 0 when last AI message has tool calls."""
+        messages = [
+            HumanMessage(content="query"),
+            AIMessage(
+                content="using tool",
+                tool_calls=[{"name": "test", "args": {}, "id": "call_1"}],
+            ),
+        ]
+        assert count_successive_completions(messages) == 0
+
+    def test_ai_message_without_content(self):
+        """Should return 0 when last AI message has no content."""
+        messages = [
+            HumanMessage(content="query"),
+            AIMessage(content=""),
+        ]
+        assert count_successive_completions(messages) == 0
+
+    def test_single_text_completion(self):
+        """Should count single text-only AI message."""
+        messages = [
+            HumanMessage(content="query"),
+            AIMessage(content="thinking"),
+        ]
+        assert count_successive_completions(messages) == 1
+
+    def test_two_successive_completions(self):
+        """Should count multiple consecutive text-only AI messages."""
+        messages = [
+            HumanMessage(content="query"),
+            AIMessage(content="thinking 1"),
+            AIMessage(content="thinking 2"),
+        ]
+        assert count_successive_completions(messages) == 2
+
+    def test_three_successive_completions(self):
+        """Should count all consecutive text-only AI messages at end."""
+        messages = [
+            HumanMessage(content="query"),
+            AIMessage(content="thinking 1"),
+            AIMessage(content="thinking 2"),
+            AIMessage(content="thinking 3"),
+        ]
+        assert count_successive_completions(messages) == 3
+
+    def test_tool_call_resets_count(self):
+        """Should only count completions after last tool call."""
+        messages = [
+            HumanMessage(content="query"),
+            AIMessage(content="thinking 1"),
+            AIMessage(
+                content="using tool",
+                tool_calls=[{"name": "test", "args": {}, "id": "call_1"}],
+            ),
+            ToolMessage(content="result", tool_call_id="call_1"),
+            AIMessage(content="thinking 2"),
+            AIMessage(content="thinking 3"),
+        ]
+        assert count_successive_completions(messages) == 2
+
+    def test_mixed_message_types(self):
+        """Should handle complex message patterns correctly."""
+        messages = [
+            HumanMessage(content="initial query"),
+            AIMessage(content="first thought"),
+            AIMessage(
+                content="calling tool",
+                tool_calls=[{"name": "tool1", "args": {}, "id": "call_1"}],
+            ),
+            ToolMessage(content="tool result", tool_call_id="call_1"),
+            AIMessage(content="analyzing result"),
+            HumanMessage(content="user follow-up"),
+            AIMessage(content="responding to follow-up"),
+        ]
+        assert count_successive_completions(messages) == 1
+
+    def test_multiple_tool_calls_in_message(self):
+        """Should reset count even with multiple tool calls."""
+        messages = [
+            HumanMessage(content="query"),
+            AIMessage(content="thinking"),
+            AIMessage(
+                content="using tools",
+                tool_calls=[
+                    {"name": "tool1", "args": {}, "id": "call_1"},
+                    {"name": "tool2", "args": {}, "id": "call_2"},
+                ],
+            ),
+        ]
+        assert count_successive_completions(messages) == 0
+
+    def test_ai_message_with_empty_tool_calls_list(self):
+        """Should handle AI message with empty tool_calls list."""
+        messages = [
+            HumanMessage(content="query"),
+            AIMessage(content="thinking", tool_calls=[]),
+        ]
+        assert count_successive_completions(messages) == 1
+
+    def test_only_ai_messages_all_text(self):
+        """Should count all AI messages when all are text-only."""
+        messages = [
+            AIMessage(content="thought 1"),
+            AIMessage(content="thought 2"),
+            AIMessage(content="thought 3"),
+        ]
+        assert count_successive_completions(messages) == 3


### PR DESCRIPTION
## What changed?
- Implement a variation of ReAct loop architecture for agent execution with INIT → AGENT ↔ TOOLS flow
- Add agent graph builder with state management and conditional routing
- Create process and context tools with interrupt-based execution
- Implement control flow tools for agent termination (`end_execution`, `raise_error`)
