### PR TITLE
fix: react agent output args

### DIFF
--- a/src/uipath_langchain/agent/react/agent.py
+++ b/src/uipath_langchain/agent/react/agent.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, Sequence, Type
+from typing import Callable, Sequence
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -31,7 +31,6 @@ def create_agent(
     messages: Sequence[SystemMessage | HumanMessage]
     | Callable[[AgentGraphState], Sequence[SystemMessage | HumanMessage]],
     *,
-    state_schema: Type[AgentGraphState] = AgentGraphState,
     response_format: type[BaseModel] | None = None,
     config: AgentGraphConfig | None = None,
 ) -> StateGraph[AgentGraphState]:
@@ -53,7 +52,7 @@ def create_agent(
     tool_nodes = create_tool_node(agent_tools)
     terminate_node = create_terminate_node(response_format)
 
-    builder: StateGraph[AgentGraphState] = StateGraph(state_schema)
+    builder: StateGraph[AgentGraphState] = StateGraph(AgentGraphState)
     builder.add_node(AgentGraphNode.INIT, init_node)
     builder.add_node(AgentGraphNode.AGENT, agent_node)
 

--- a/src/uipath_langchain/agent/react/terminate_node.py
+++ b/src/uipath_langchain/agent/react/terminate_node.py
@@ -17,7 +17,7 @@ from .types import AgentGraphState
 def create_terminate_node(
     response_schema: type[BaseModel] | None = None,
 ):
-    """Validates and returns end_execution args, or raises AgentTerminationException for raise_error."""
+    """Validates and extracts end_execution args to state output field."""
 
     def terminate_node(state: AgentGraphState):
         last_message = state["messages"][-1]
@@ -33,7 +33,7 @@ def create_terminate_node(
                 args = tool_call["args"]
                 output_schema = response_schema or END_EXECUTION_TOOL.args_schema
                 validated = output_schema.model_validate(args)
-                return validated.model_dump()
+                return {"output": validated.model_dump()}
 
             if tool_name == RAISE_ERROR_TOOL.name:
                 error_message = tool_call["args"].get(

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Any
 
 from langgraph.graph import MessagesState
 from pydantic import BaseModel, Field
+from typing_extensions import NotRequired
 
 
 class AgentGraphState(MessagesState):
     """Agent Graph state for standard loop execution."""
 
-    pass
+    output: NotRequired[dict[str, Any]]
 
 
 class AgentGraphNode(StrEnum):


### PR DESCRIPTION
What changed?
---

- Add `output_channels` declaration to StateGraph to properly expose agent output
- Update terminate node to wrap validation results in "output" field
- Add optional "output" field to AgentGraphState to store final results