### PR TITLE
fix: update uipath-langchain version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.0.157"
+version = "0.0.158"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath_langchain/_cli/cli_new.py
+++ b/src/uipath_langchain/_cli/cli_new.py
@@ -31,10 +31,10 @@ version = "0.0.1"
 description = "{project_name}"
 authors = [{{ name = "John Doe", email = "john.doe@myemail.com" }}]
 dependencies = [
-    "uipath-langchain>=0.0.106",
+    "uipath-langchain>=0.0.158",
     "langchain-anthropic>=0.3.8",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 """
 
     with open(project_toml_path, "w") as f:


### PR DESCRIPTION
This PR updates the library version for the template `pyproject.toml` file created when running `uipath new`.