### PR TITLE
chore: ensure `uv.lock` is up-to-date

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: Lint
 
-on:
-  workflow_call
+on: workflow_call
 
 jobs:
   # Job that runs when custom version testing is enabled - just completes successfully
@@ -40,7 +39,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Check static types
         run: uv run mypy --config-file pyproject.toml .
@@ -50,4 +49,3 @@ jobs:
 
       - name: Check formatting
         run: uv run ruff format --check .
-

--- a/uv.lock
+++ b/uv.lock
@@ -2825,7 +2825,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.0.158"
+version = "0.0.159"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Add `--locked` flag during `lint` action to ensure the lock file has been updated.