### PR TITLE
feat(StructuredToolWithOutputType): support dynamic output types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.1.21"
+version = "0.1.22"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/context_tool.py
+++ b/src/uipath_langchain/agent/tools/context_tool.py
@@ -10,6 +10,7 @@ from uipath.eval.mocks import mockable
 
 from uipath_langchain.retrievers import ContextGroundingRetriever
 
+from .structured_tool_with_output_type import StructuredToolWithOutputType
 from .utils import sanitize_tool_name
 
 
@@ -43,9 +44,10 @@ def create_context_tool(resource: AgentContextResourceConfig) -> StructuredTool:
     async def context_tool_fn(query: str) -> dict[str, Any]:
         return {"documents": await retriever.ainvoke(query)}
 
-    return StructuredTool(
+    return StructuredToolWithOutputType(
         name=tool_name,
         description=resource.description,
         args_schema=input_model,
         coroutine=context_tool_fn,
+        output_type=output_model,
     )

--- a/src/uipath_langchain/agent/tools/integration_tool.py
+++ b/src/uipath_langchain/agent/tools/integration_tool.py
@@ -12,6 +12,7 @@ from uipath.platform import UiPath
 from uipath.platform.connections import ActivityMetadata, ActivityParameterLocationInfo
 
 from .static_args import handle_static_args
+from .structured_tool_with_output_type import StructuredToolWithOutputType
 from .utils import sanitize_tool_name
 
 
@@ -169,11 +170,12 @@ def create_integration_tool(
 
         return result
 
-    tool = StructuredTool(
+    tool = StructuredToolWithOutputType(
         name=tool_name,
         description=resource.description,
         args_schema=resource.input_schema,
         coroutine=integration_tool_fn,
+        output_type=output_model,
     )
 
     return tool

--- a/src/uipath_langchain/agent/tools/process_tool.py
+++ b/src/uipath_langchain/agent/tools/process_tool.py
@@ -9,6 +9,7 @@ from uipath.agent.models.agent import AgentProcessToolResourceConfig
 from uipath.eval.mocks import mockable
 from uipath.platform.common import InvokeProcess
 
+from .structured_tool_with_output_type import StructuredToolWithOutputType
 from .utils import sanitize_tool_name
 
 
@@ -37,11 +38,12 @@ def create_process_tool(resource: AgentProcessToolResourceConfig) -> StructuredT
             )
         )
 
-    tool = StructuredTool(
+    tool = StructuredToolWithOutputType(
         name=tool_name,
         description=resource.description,
         args_schema=input_model,
         coroutine=process_tool_fn,
+        output_type=output_model,
     )
 
     return tool

--- a/src/uipath_langchain/agent/tools/structured_tool_with_output_type.py
+++ b/src/uipath_langchain/agent/tools/structured_tool_with_output_type.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from langchain_core.tools import StructuredTool
+from pydantic import Field
+from typing_extensions import override
+
+
+class StructuredToolWithOutputType(StructuredTool):
+    output_type: Any = Field(Any, description="Output type.")
+
+    @override
+    @property
+    def OutputType(self) -> type[Any]:
+        return self.output_type

--- a/uv.lock
+++ b/uv.lock
@@ -3312,7 +3312,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.1.21"
+version = "0.1.22"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
`StructuredTool`s are `Runnable`s, but `OutputType` is always `Any` unless overridden. This commit adds the override since we have strongly typed output types.

Additionally, removing asterisks from IS output schemas (bugfix).