### PR TITLE
fix: pin aiosqlite 0.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.1.26"
+version = "0.1.27"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -8,6 +8,7 @@ dependencies = [
     "uipath>=2.2.30, <2.3.0",
     "langgraph>=1.0.0, <2.0.0",
     "langchain-core>=1.0.0, <2.0.0",
+    "aiosqlite==0.21.0",
     "langgraph-checkpoint-sqlite>=3.0.0, <4.0.0",
     "langchain-openai>=1.0.0, <2.0.0",
     "langchain>=1.0.0, <2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2863,9 +2863,10 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "httpx" },
     { name = "jsonpath-ng" },
     { name = "jsonschema-pydantic-converter" },
@@ -2905,6 +2906,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = "==0.21.0" },
     { name = "boto3-stubs", marker = "extra == 'bedrock'", specifier = ">=1.41.4" },
     { name = "google-generativeai", marker = "extra == 'vertex'", specifier = ">=0.8.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Description

`aiosqlite` released a new version [0.22.0](https://github.com/omnilib/aiosqlite/releases/tag/v0.22.0) which comes with [breaking-changes](https://github.com/omnilib/aiosqlite/commit/1cd60adcab12347577150a6fa6c7d92b7b86d989#diff-3716bdfa73f4bf05a8cbf62e271bc61298991ae6a7a6cab1d293a23342b86a4cL47-R48)

The class `Connection` no longer inherits from `Thread`, so `AsyncSqliteSaver` [will fail with](https://github.com/langchain-ai/langgraph/blob/main/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py#L284C1-L285C32): 
```
AttributeError: 'Connection' object has no attribute 'is_alive'
```

LangGraph issue reference: https://github.com/langchain-ai/langgraph/issues/6583
aiosqlite issue reference:  https://github.com/omnilib/aiosqlite/issues/368

Temporary fix until the issue gets resolved in `langgraph-checkpoint-sqlite`: https://github.com/langchain-ai/langgraph/pull/6584