### PR TITLE
feat: Add deterministic guardrails filtering action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.1.38"
+version = "0.1.39"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/guardrails/actions/filter_action.py
+++ b/src/uipath_langchain/agent/guardrails/actions/filter_action.py
@@ -1,6 +1,9 @@
 import re
 from typing import Any
 
+from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.types import Command
+from uipath.core.guardrails.guardrails import FieldReference, FieldSource
 from uipath.platform.guardrails import BaseGuardrail, GuardrailScope
 from uipath.runtime.errors import UiPathErrorCategory, UiPathErrorCode
 
@@ -14,10 +17,17 @@ from .base_action import GuardrailAction, GuardrailActionNode
 class FilterAction(GuardrailAction):
     """Action that filters inputs/outputs on guardrail failure.
 
-    For now, filtering is only supported for non-AGENT and non-LLM scopes.
-    If invoked for ``GuardrailScope.AGENT`` or ``GuardrailScope.LLM``, this action
-    raises an exception to indicate the operation is not supported yet.
+    For Tool scope, this action removes specified fields from tool call arguments.
+    For AGENT and LLM scopes, this action raises an exception as it's not supported yet.
     """
+
+    def __init__(self, fields: list[FieldReference] | None = None):
+        """Initialize FilterAction with fields to filter.
+
+        Args:
+            fields: List of FieldReference objects specifying which fields to filter.
+        """
+        self.fields = fields or []
 
     def action_node(
         self,
@@ -41,15 +51,240 @@ class FilterAction(GuardrailAction):
         raw_node_name = f"{scope.name}_{execution_stage.name}_{guardrail.name}_filter"
         node_name = re.sub(r"\W+", "_", raw_node_name.lower()).strip("_")
 
-        async def _node(_state: AgentGuardrailsGraphState) -> dict[str, Any]:
-            if scope in (GuardrailScope.AGENT, GuardrailScope.LLM):
-                raise AgentTerminationException(
-                    code=UiPathErrorCode.EXECUTION_ERROR,
-                    title="Guardrail filter action not supported",
-                    detail=f"FilterAction is not supported for scope [{scope.name}] at this time.",
-                    category=UiPathErrorCategory.USER,
+        async def _node(
+            _state: AgentGuardrailsGraphState,
+        ) -> dict[str, Any] | Command[Any]:
+            if scope == GuardrailScope.TOOL:
+                return _filter_tool_fields(
+                    _state,
+                    self.fields,
+                    execution_stage,
+                    guarded_component_name,
+                    guardrail.name,
                 )
-            # No-op for other scopes for now.
-            return {}
+
+            raise AgentTerminationException(
+                code=UiPathErrorCode.EXECUTION_ERROR,
+                title="Guardrail filter action not supported",
+                detail=f"FilterAction is not supported for scope [{scope.name}] at this time.",
+                category=UiPathErrorCategory.USER,
+            )
 
         return node_name, _node
+
+
+def _filter_tool_fields(
+    state: AgentGuardrailsGraphState,
+    fields_to_filter: list[FieldReference],
+    execution_stage: ExecutionStage,
+    tool_name: str,
+    guardrail_name: str,
+) -> dict[str, Any] | Command[Any]:
+    """Filter specified fields from tool call arguments or tool output.
+
+    The filter action filters fields based on the execution stage:
+    - PRE_EXECUTION: Only input fields are filtered
+    - POST_EXECUTION: Only output fields are filtered
+
+    Args:
+        state: The current agent graph state.
+        fields_to_filter: List of FieldReference objects specifying which fields to filter.
+        execution_stage: The execution stage (PRE_EXECUTION or POST_EXECUTION).
+        tool_name: Name of the tool to filter.
+        guardrail_name: Name of the guardrail for logging purposes.
+
+    Returns:
+        Command to update messages with filtered tool call args or output.
+
+    Raises:
+        AgentTerminationException: If filtering fails.
+    """
+    try:
+        if not fields_to_filter:
+            return {}
+
+        if execution_stage == ExecutionStage.PRE_EXECUTION:
+            return _filter_tool_input_fields(state, fields_to_filter, tool_name)
+        else:
+            return _filter_tool_output_fields(state, fields_to_filter)
+
+    except Exception as e:
+        raise AgentTerminationException(
+            code=UiPathErrorCode.EXECUTION_ERROR,
+            title="Filter action failed",
+            detail=f"Failed to filter tool fields: {str(e)}",
+            category=UiPathErrorCategory.USER,
+        ) from e
+
+
+def _filter_tool_input_fields(
+    state: AgentGuardrailsGraphState,
+    fields_to_filter: list[FieldReference],
+    tool_name: str,
+) -> dict[str, Any] | Command[Any]:
+    """Filter specified input fields from tool call arguments (PRE_EXECUTION only).
+
+    This function is called at PRE_EXECUTION to filter input fields from tool call arguments
+    before the tool is executed.
+
+    Args:
+        state: The current agent graph state.
+        fields_to_filter: List of FieldReference objects specifying which fields to filter.
+        tool_name: Name of the tool to filter.
+
+    Returns:
+        Command to update messages with filtered tool call args, or empty dict if no input fields to filter.
+    """
+    # Check if there are any input fields to filter
+    has_input_fields = any(
+        field_ref.source == FieldSource.INPUT for field_ref in fields_to_filter
+    )
+
+    if not has_input_fields:
+        return {}
+
+    msgs = state.messages.copy()
+    if not msgs:
+        return {}
+
+    # Find the AIMessage with tool calls
+    # At PRE_EXECUTION, this is always the last message
+    ai_message = None
+    for i in range(len(msgs) - 1, -1, -1):
+        msg = msgs[i]
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            ai_message = msg
+            break
+
+    if ai_message is None:
+        return {}
+
+    # Find and filter the tool call with matching name
+    # Type assertion: we know ai_message is AIMessage from the check above
+    assert isinstance(ai_message, AIMessage)
+    tool_calls = list(ai_message.tool_calls)
+    modified = False
+
+    for tool_call in tool_calls:
+        call_name = (
+            tool_call.get("name")
+            if isinstance(tool_call, dict)
+            else getattr(tool_call, "name", None)
+        )
+
+        if call_name == tool_name:
+            # Get the current args
+            args = (
+                tool_call.get("args")
+                if isinstance(tool_call, dict)
+                else getattr(tool_call, "args", None)
+            )
+
+            if args and isinstance(args, dict):
+                # Filter out the specified input fields
+                filtered_args = args.copy()
+                for field_ref in fields_to_filter:
+                    # Only filter input fields
+                    if (
+                        field_ref.source == FieldSource.INPUT
+                        and field_ref.path in filtered_args
+                    ):
+                        del filtered_args[field_ref.path]
+                        modified = True
+
+                # Update the tool call with filtered args
+                if isinstance(tool_call, dict):
+                    tool_call["args"] = filtered_args
+                else:
+                    tool_call.args = filtered_args
+
+            break
+
+    if modified:
+        ai_message.tool_calls = tool_calls
+        return Command(update={"messages": msgs})
+
+    return {}
+
+
+def _filter_tool_output_fields(
+    state: AgentGuardrailsGraphState,
+    fields_to_filter: list[FieldReference],
+) -> dict[str, Any] | Command[Any]:
+    """Filter specified output fields from tool output (POST_EXECUTION only).
+
+    This function is called at POST_EXECUTION to filter output fields from tool results
+    after the tool has been executed.
+
+    Args:
+        state: The current agent graph state.
+        fields_to_filter: List of FieldReference objects specifying which fields to filter.
+
+    Returns:
+        Command to update messages with filtered tool output, or empty dict if no output fields to filter.
+    """
+    # Check if there are any output fields to filter
+    has_output_fields = any(
+        field_ref.source == FieldSource.OUTPUT for field_ref in fields_to_filter
+    )
+
+    if not has_output_fields:
+        return {}
+
+    msgs = state.messages.copy()
+    if not msgs:
+        return {}
+
+    last_message = msgs[-1]
+    if not isinstance(last_message, ToolMessage):
+        return {}
+
+    # Parse the tool output content
+    import json
+
+    content = last_message.content
+    if not content:
+        return {}
+
+    # Try to parse the content as JSON or dict
+    try:
+        if isinstance(content, dict):
+            output_data = content
+        elif isinstance(content, str):
+            try:
+                output_data = json.loads(content)
+            except json.JSONDecodeError:
+                # Try to parse as Python literal (dict representation)
+                import ast
+
+                try:
+                    output_data = ast.literal_eval(content)
+                    if not isinstance(output_data, dict):
+                        return {}
+                except (ValueError, SyntaxError):
+                    return {}
+        else:
+            # Content is not JSON-parseable, can't filter specific fields
+            return {}
+    except Exception:
+        return {}
+
+    if not isinstance(output_data, dict):
+        return {}
+
+    # Filter out the specified fields
+    filtered_output = output_data.copy()
+    modified = False
+
+    for field_ref in fields_to_filter:
+        # Only filter output fields
+        if field_ref.source == FieldSource.OUTPUT and field_ref.path in filtered_output:
+            del filtered_output[field_ref.path]
+            modified = True
+
+    if modified:
+        # Update the tool message content with filtered output
+        last_message.content = json.dumps(filtered_output)
+        return Command(update={"messages": msgs})
+
+    return {}

--- a/tests/agent/guardrails/actions/test_filter_action.py
+++ b/tests/agent/guardrails/actions/test_filter_action.py
@@ -1,11 +1,20 @@
-"""Tests for FilterAction guardrail failure behavior."""
+"""Tests for FilterAction in isolation.
+
+These tests validate the filter action behavior independently of guardrail rules.
+The filter action is responsible for removing specified fields from tool inputs/outputs
+when invoked, regardless of which rule triggered the guardrail.
+"""
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.types import Command
+from uipath.core.guardrails.guardrails import FieldReference, FieldSource
 from uipath.platform.guardrails import GuardrailScope
 from uipath.runtime.errors import UiPathErrorCode
 
@@ -22,7 +31,17 @@ if TYPE_CHECKING:
     from pytest_mock.plugin import MockerFixture  # noqa: F401
 
 
+def create_field_reference(path: str, source: str) -> FieldReference:
+    """Create a FieldReference object."""
+    return FieldReference(
+        path=path,
+        source=FieldSource.INPUT if source == "input" else FieldSource.OUTPUT,
+    )
+
+
 class TestFilterAction:
+    """Test FilterAction for various scenarios."""
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("scope", "stage", "expected_node_name"),
@@ -82,21 +101,399 @@ class TestFilterAction:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "stage",
-        [ExecutionStage.PRE_EXECUTION, ExecutionStage.POST_EXECUTION],
+        "stage,expected_node_name",
+        [
+            (
+                ExecutionStage.PRE_EXECUTION,
+                "tool_pre_execution_test_guardrail_v1_filter",
+            ),
+            (
+                ExecutionStage.POST_EXECUTION,
+                "tool_post_execution_test_guardrail_v1_filter",
+            ),
+        ],
     )
-    async def test_tool_scope_returns_empty_dict(self, stage: ExecutionStage) -> None:
-        """TOOL scope currently performs no-op and returns empty dict."""
-        action = FilterAction()
+    async def test_tool_scope_node_name(
+        self, stage: ExecutionStage, expected_node_name: str
+    ) -> None:
+        """TOOL scope: node name is sanitized correctly."""
+        action = FilterAction(fields=[create_field_reference("test", "input")])
         guardrail = MagicMock()
-        guardrail.name = "My Guardrail v1"
+        guardrail.name = "Test Guardrail v1"
 
-        _, node = action.action_node(
+        node_name, _ = action.action_node(
             guardrail=guardrail,
             scope=GuardrailScope.TOOL,
             execution_stage=stage,
             guarded_component_name="test_tool",
         )
 
-        result = await node(AgentGuardrailsGraphState(messages=[]))
+        assert node_name == expected_node_name
+
+    @pytest.mark.asyncio
+    async def test_filter_input_at_pre_execution(self) -> None:
+        """Filter single input field at PRE_EXECUTION."""
+        fields = [create_field_reference("sentence", "input")]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.PRE_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        # Create state with tool call
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "Agent___Sentence_Analyzer",
+                    "args": {"sentence": "Test sentence"},
+                    "id": "call_1",
+                }
+            ],
+        )
+        state = AgentGuardrailsGraphState(messages=[ai_message])
+
+        result = await node(state)
+
+        # Verify input field was filtered
+        assert isinstance(result, Command)
+        assert result.update is not None
+        updated_message = result.update["messages"][0]
+        assert updated_message.tool_calls[0]["args"] == {}
+
+    @pytest.mark.asyncio
+    async def test_filter_output_at_post_execution(self) -> None:
+        """Filter single output field at POST_EXECUTION."""
+        fields = [create_field_reference("content", "output")]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.POST_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        # Create state with tool message
+        tool_message = ToolMessage(
+            content='{"content": "Test content", "other": "data"}',
+            tool_call_id="call_1",
+            name="Agent___Sentence_Analyzer",
+        )
+        state = AgentGuardrailsGraphState(messages=[tool_message])
+
+        result = await node(state)
+
+        # Verify output field was filtered
+        assert isinstance(result, Command)
+        assert result.update is not None
+        updated_message = result.update["messages"][0]
+        parsed_content = json.loads(updated_message.content)
+        assert "content" not in parsed_content
+        assert parsed_content["other"] == "data"
+
+    @pytest.mark.asyncio
+    async def test_filter_both_input_and_output_at_pre(self) -> None:
+        """Filter both input and output fields at PRE_EXECUTION (only input filtered)."""
+        fields = [
+            create_field_reference("sentence", "input"),
+            create_field_reference("content", "output"),
+        ]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.PRE_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "Agent___Sentence_Analyzer",
+                    "args": {"sentence": "Test sentence"},
+                    "id": "call_1",
+                }
+            ],
+        )
+        state = AgentGuardrailsGraphState(messages=[ai_message])
+
+        result = await node(state)
+
+        # At PRE_EXECUTION, only input fields should be filtered
+        assert isinstance(result, Command)
+        assert result.update is not None
+        updated_message = result.update["messages"][0]
+        assert updated_message.tool_calls[0]["args"] == {}
+
+    @pytest.mark.asyncio
+    async def test_filter_both_input_and_output_at_post(self) -> None:
+        """Filter multiple input and output fields at POST_EXECUTION (only output filtered).
+
+        This test validates:
+        - Multiple input fields specified (but not filtered at POST)
+        - Multiple output fields filtered at POST_EXECUTION
+        - Unspecified fields remain intact
+        """
+        fields = [
+            create_field_reference("sentence", "input"),
+            create_field_reference("param", "input"),
+            create_field_reference("content", "output"),
+            create_field_reference("metadata", "output"),
+        ]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.POST_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        # Create state with both AIMessage (with tool call) and ToolMessage
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "Agent___Sentence_Analyzer",
+                    "args": {
+                        "sentence": "Test sentence",
+                        "param": "value",
+                        "keep_input": "this",
+                    },
+                    "id": "call_1",
+                }
+            ],
+        )
+        tool_message = ToolMessage(
+            content='{"content": "Test content", "metadata": "info", "keep_output": "this"}',
+            tool_call_id="call_1",
+            name="Agent___Sentence_Analyzer",
+        )
+        state = AgentGuardrailsGraphState(messages=[ai_message, tool_message])
+
+        result = await node(state)
+
+        # At POST_EXECUTION, only output fields should be filtered (not input)
+        assert isinstance(result, Command)
+        assert result.update is not None
+
+        # Check input was NOT filtered (all input args remain)
+        updated_ai_message = result.update["messages"][0]
+        assert updated_ai_message.tool_calls[0]["args"] == {
+            "sentence": "Test sentence",
+            "param": "value",
+            "keep_input": "this",
+        }
+
+        # Check multiple output fields were filtered, but unspecified field remains
+        updated_tool_message = result.update["messages"][1]
+        parsed_content = json.loads(updated_tool_message.content)
+        assert "content" not in parsed_content
+        assert "metadata" not in parsed_content
+        assert parsed_content["keep_output"] == "this"
+
+    # Edge cases and error handling
+    @pytest.mark.asyncio
+    async def test_filter_with_no_fields_returns_empty(self) -> None:
+        """Filter action with no fields returns empty dict."""
+        action = FilterAction(fields=[])
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.PRE_EXECUTION,
+            guarded_component_name="test_tool",
+        )
+
+        state = AgentGuardrailsGraphState(messages=[])
+        result = await node(state)
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_filter_input_with_no_matching_tool_call(self) -> None:
+        """Filter input when no matching tool call exists returns empty dict."""
+        fields = [create_field_reference("sentence", "input")]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.PRE_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        # Tool call with different name
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "Different_Tool",
+                    "args": {"sentence": "Test"},
+                    "id": "call_1",
+                }
+            ],
+        )
+        state = AgentGuardrailsGraphState(messages=[ai_message])
+
+        result = await node(state)
+
+        # No matching tool, should return empty
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_filter_output_with_no_matching_tool_message(self) -> None:
+        """Filter output processes last ToolMessage regardless of name."""
+        fields = [create_field_reference("content", "output")]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.POST_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        # Tool message with different name - still gets processed
+        tool_message = ToolMessage(
+            content='{"content": "Test", "other": "data"}',
+            tool_call_id="call_1",
+            name="Different_Tool",
+        )
+        state = AgentGuardrailsGraphState(messages=[tool_message])
+
+        result = await node(state)
+
+        # Output filtering processes last ToolMessage regardless of name
+        assert isinstance(result, Command)
+        assert result.update is not None
+        updated_message = result.update["messages"][0]
+        parsed_content = json.loads(updated_message.content)
+        assert "content" not in parsed_content
+        assert parsed_content["other"] == "data"
+
+    @pytest.mark.asyncio
+    async def test_filter_output_with_non_json_content(self) -> None:
+        """Filter output with non-JSON content returns empty dict."""
+        fields = [create_field_reference("content", "output")]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.POST_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        tool_message = ToolMessage(
+            content="Not JSON content",
+            tool_call_id="call_1",
+            name="Agent___Sentence_Analyzer",
+        )
+        state = AgentGuardrailsGraphState(messages=[tool_message])
+
+        result = await node(state)
+
+        # Non-JSON content, should return empty
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_filter_input_field_not_in_args(self) -> None:
+        """Filter input when field doesn't exist in args returns empty dict."""
+        fields = [create_field_reference("nonexistent_field", "input")]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.PRE_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "Agent___Sentence_Analyzer",
+                    "args": {"sentence": "Test"},
+                    "id": "call_1",
+                }
+            ],
+        )
+        state = AgentGuardrailsGraphState(messages=[ai_message])
+
+        result = await node(state)
+
+        # Field doesn't exist, should return empty (no modification)
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_filter_output_field_not_in_content(self) -> None:
+        """Filter output when field doesn't exist in content returns empty dict."""
+        fields = [create_field_reference("nonexistent_field", "output")]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.POST_EXECUTION,
+            guarded_component_name="Agent___Sentence_Analyzer",
+        )
+
+        tool_message = ToolMessage(
+            content='{"content": "Test"}',
+            tool_call_id="call_1",
+            name="Agent___Sentence_Analyzer",
+        )
+        state = AgentGuardrailsGraphState(messages=[tool_message])
+
+        result = await node(state)
+
+        # Field doesn't exist, should return empty (no modification)
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_filter_with_empty_messages_returns_empty(self) -> None:
+        """Filter action with empty messages returns empty dict."""
+        fields = [create_field_reference("sentence", "input")]
+        action = FilterAction(fields=fields)
+        guardrail = MagicMock()
+        guardrail.name = "Test Guardrail"
+
+        _, node = action.action_node(
+            guardrail=guardrail,
+            scope=GuardrailScope.TOOL,
+            execution_stage=ExecutionStage.PRE_EXECUTION,
+            guarded_component_name="test_tool",
+        )
+
+        state = AgentGuardrailsGraphState(messages=[])
+        result = await node(state)
+
         assert result == {}

--- a/tests/agent/guardrails/test_guardrails_utils.py
+++ b/tests/agent/guardrails/test_guardrails_utils.py
@@ -1,0 +1,113 @@
+"""Tests for guardrails utils module."""
+
+from __future__ import annotations
+
+from uipath.core.guardrails import GuardrailSelector
+from uipath.platform.guardrails import GuardrailScope
+
+from uipath_langchain.agent.guardrails.utils import _sanitize_selector_tool_names
+
+
+class TestSanitizeSelectorToolNames:
+    """Tests for _sanitize_selector_tool_names function."""
+
+    def test_sanitizes_tool_names_for_tool_scope_guardrails(self) -> None:
+        """Tool names in match_names are sanitized when selector has TOOL scope."""
+        # Create a selector with TOOL scope and tool names that need sanitization
+        selector = GuardrailSelector(
+            scopes=[GuardrailScope.TOOL],
+            match_names=["My Tool!", "Another Tool@123", "Tool With Spaces"],
+        )
+
+        result = _sanitize_selector_tool_names(selector)
+
+        # Tool names should be sanitized (special chars removed, spaces replaced with _)
+        assert result.match_names == ["My_Tool", "Another_Tool123", "Tool_With_Spaces"]
+
+    def test_handles_tool_names_with_valid_characters(self) -> None:
+        """Tool names with only valid characters (alphanumeric, underscore, hyphen) remain unchanged."""
+        selector = GuardrailSelector(
+            scopes=[GuardrailScope.TOOL],
+            match_names=["valid_tool", "another-tool", "Tool123"],
+        )
+
+        result = _sanitize_selector_tool_names(selector)
+
+        assert result.match_names == ["valid_tool", "another-tool", "Tool123"]
+
+    def test_truncates_long_tool_names(self) -> None:
+        """Tool names longer than 64 characters are truncated."""
+        long_name = "a" * 100  # 100 characters
+        selector = GuardrailSelector(
+            scopes=[GuardrailScope.TOOL],
+            match_names=[long_name],
+        )
+
+        result = _sanitize_selector_tool_names(selector)
+
+        assert len(result.match_names[0]) == 64
+        assert result.match_names[0] == "a" * 64
+
+    def test_does_not_sanitize_when_tool_scope_not_present(self) -> None:
+        """Tool names are not sanitized when TOOL scope is not in the scopes list."""
+        selector = GuardrailSelector(
+            scopes=[GuardrailScope.LLM, GuardrailScope.AGENT],
+            match_names=["My Tool!", "Another Tool@123"],
+        )
+
+        result = _sanitize_selector_tool_names(selector)
+
+        assert result.match_names == ["My Tool!", "Another Tool@123"]
+
+    def test_handles_mixed_scopes_with_tool_scope_present(self) -> None:
+        """Tool names are sanitized when TOOL scope is present among other scopes."""
+        selector = GuardrailSelector(
+            scopes=[GuardrailScope.LLM, GuardrailScope.TOOL, GuardrailScope.AGENT],
+            match_names=["My Tool!", "Another Tool@123"],
+        )
+
+        result = _sanitize_selector_tool_names(selector)
+
+        assert result.match_names == ["My_Tool", "Another_Tool123"]
+
+    def test_handles_whitespace_in_tool_names(self) -> None:
+        """Whitespace in tool names is replaced with underscores."""
+        selector = GuardrailSelector(
+            scopes=[GuardrailScope.TOOL],
+            match_names=[
+                "tool with spaces",
+                "tool\twith\ttabs",
+                "tool\nwith\nnewlines",
+            ],
+        )
+
+        result = _sanitize_selector_tool_names(selector)
+
+        assert result.match_names == [
+            "tool_with_spaces",
+            "tool_with_tabs",
+            "tool_with_newlines",
+        ]
+
+    def test_preserves_hyphens_and_underscores(self) -> None:
+        """Hyphens and underscores are preserved in tool names."""
+        selector = GuardrailSelector(
+            scopes=[GuardrailScope.TOOL],
+            match_names=["my-tool_name", "another_tool-name"],
+        )
+
+        result = _sanitize_selector_tool_names(selector)
+
+        assert result.match_names == ["my-tool_name", "another_tool-name"]
+
+    def test_sanitizes_with_proper_guardrail_selector(self) -> None:
+        """Function works correctly with proper GuardrailSelector type."""
+        selector = GuardrailSelector(
+            scopes=[GuardrailScope.TOOL],
+            match_names=["My Tool!", "Another Tool@123"],
+        )
+
+        result = _sanitize_selector_tool_names(selector)
+
+        assert result.match_names == ["My_Tool", "Another_Tool123"]
+        assert result is selector  # Same object is returned

--- a/uv.lock
+++ b/uv.lock
@@ -3260,7 +3260,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.1.38"
+version = "0.1.39"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
# Filter Action Implementation - PR Summary

## Overview
Implements filter action for deterministic tool guardrails, allowing selective removal of input/output fields based on guardrail rules.

## Key Features

### ✅ Execution Stage Awareness
- **PRE_EXECUTION**: Filters input fields only
- **POST_EXECUTION**: Filters output fields only
- Guardrails trigger based on rules, actions apply based on stage

### ✅ Python Dict String Handling
- Added `ast.literal_eval()` fallback for tool outputs stored as dict string representations
- Handles JSON strings, native dicts, and Python literal strings

### ✅ Type Safety & Code Quality
- Fixed mypy type errors with proper `BaseGuardrail` annotations
- Resolved test file naming conflicts (`test_utils.py` → `test_guardrails_utils.py`)
- Replaced mock objects with proper `GuardrailSelector` types

## Implementation Details

### Modified Files
- `filter_action.py` - Core filtering logic with stage-aware field filtering
- `utils.py` - Enhanced data extraction with dict literal parsing
- `guardrails_factory.py` - Type safety improvements
- `guardrails_subgraph.py` - Bug fix for POST_EXECUTION node routing

### Test Coverage
- **17 comprehensive tests** (consolidated from 20, -15% reduction)
- **165 total guardrails tests** passing
- All edge cases covered: empty fields, missing data, non-JSON content, multiple fields

## Validation

Tested against 7 agent configurations covering:
- Always rules (PRE/POST)
- Conditional rules (word matching)
- Field selectors (specific/all)
- Same-field filtering
- Multiple field filtering
