### PR TITLE
fix: extend runtime with callbacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.1.36"
+version = "0.1.37"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/runtime/runtime.py
+++ b/src/uipath_langchain/runtime/runtime.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, AsyncGenerator
 from uuid import uuid4
 
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.runnables.config import RunnableConfig
 from langgraph.errors import EmptyInputError, GraphRecursionError, InvalidUpdateError
 from langgraph.graph.state import CompiledStateGraph
@@ -41,6 +42,7 @@ class UiPathLangGraphRuntime:
         graph: CompiledStateGraph[Any, Any, Any, Any],
         runtime_id: str | None = None,
         entrypoint: str | None = None,
+        callbacks: list[BaseCallbackHandler] | None = None,
     ):
         """
         Initialize the runtime.
@@ -53,6 +55,7 @@ class UiPathLangGraphRuntime:
         self.graph: CompiledStateGraph[Any, Any, Any, Any] = graph
         self.runtime_id: str = runtime_id or "default"
         self.entrypoint: str | None = entrypoint
+        self.callbacks: list[BaseCallbackHandler] = callbacks or []
         self.chat = UiPathChatMessagesMapper()
         self._middleware_node_names: set[str] = self._detect_middleware_nodes()
 
@@ -196,7 +199,7 @@ class UiPathLangGraphRuntime:
         """Build graph execution configuration."""
         graph_config: RunnableConfig = {
             "configurable": {"thread_id": self.runtime_id},
-            "callbacks": [],
+            "callbacks": self.callbacks,
         }
 
         # Add optional config from environment

--- a/uv.lock
+++ b/uv.lock
@@ -3260,7 +3260,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.1.36"
+version = "0.1.37"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Description

This PR extends the `UiPathLangGraphRuntime` class to support custom callback handlers, enabling developers to hook into graph execution events. The version is bumped from 0.1.36 to 0.1.37.

- Added `callbacks` parameter to the runtime constructor to accept custom LangChain callback handlers
- Updated graph configuration to use the provided callbacks instead of an empty list

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.1.37.dev1003671608",

  # Any version from PR
  "uipath-langchain>=0.1.37.dev1003670000,<0.1.37.dev1003680000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }
```