### PR TITLE
feat: add execution_callbacks context var for per-execution callback injection

### DIFF
--- a/src/uipath_langchain/runtime/__init__.py
+++ b/src/uipath_langchain/runtime/__init__.py
@@ -5,7 +5,7 @@ from uipath.runtime import (
 )
 
 from uipath_langchain.runtime.factory import UiPathLangGraphRuntimeFactory
-from uipath_langchain.runtime.runtime import UiPathLangGraphRuntime
+from uipath_langchain.runtime.runtime import UiPathLangGraphRuntime, execution_callbacks
 from uipath_langchain.runtime.schema import (
     get_entrypoints_schema,
     get_graph_schema,
@@ -33,4 +33,5 @@ __all__ = [
     "get_graph_schema",
     "UiPathLangGraphRuntimeFactory",
     "UiPathLangGraphRuntime",
+    "execution_callbacks",
 ]


### PR DESCRIPTION
- Add execution_callbacks ContextVar to allow wrappers to inject callbacks at execution time
- Modify _get_graph_config to copy self.callbacks (prevent mutation) and extend with context callbacks
- Export execution_callbacks from runtime module

This enables clean callback injection without monkey-patching, solving the duplicate callback issue when runtime instances are reused across multiple executions (chat/debug mode).