### PR TITLE
fix: escalation tool missing runtime parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/tool_factory.py
+++ b/src/uipath_langchain/agent/tools/tool_factory.py
@@ -1,7 +1,7 @@
 """Factory functions for creating tools from agent resources."""
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.tools import BaseTool, StructuredTool
+from langchain_core.tools import BaseTool
 from uipath.agent.models.agent import (
     AgentContextResourceConfig,
     AgentEscalationResourceConfig,
@@ -34,7 +34,7 @@ async def create_tools_from_resources(
 
 async def _build_tool_for_resource(
     resource: BaseAgentResourceConfig, llm: BaseChatModel
-) -> StructuredTool | None:
+) -> BaseTool | None:
     if isinstance(resource, AgentProcessToolResourceConfig):
         return create_process_tool(resource)
 

--- a/src/uipath_langchain/agent/tools/tool_node.py
+++ b/src/uipath_langchain/agent/tools/tool_node.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Callable, Literal
 
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.tool import ToolCall, ToolMessage
+from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.types import Command
@@ -48,7 +49,7 @@ class UiPathToolNode(RunnableCallable):
         self.wrapper = wrapper
         self.awrapper = awrapper
 
-    def _func(self, state: Any) -> OutputType:
+    def _func(self, state: Any, config: RunnableConfig | None = None) -> OutputType:
         call = self._extract_tool_call(state)
         if call is None:
             return None
@@ -57,10 +58,11 @@ class UiPathToolNode(RunnableCallable):
             result = self.wrapper(self.tool, call, filtered_state)
         else:
             result = self.tool.invoke(call["args"])
-
         return self._process_result(call, result)
 
-    async def _afunc(self, state: Any) -> OutputType:
+    async def _afunc(
+        self, state: Any, config: RunnableConfig | None = None
+    ) -> OutputType:
         call = self._extract_tool_call(state)
         if call is None:
             return None
@@ -69,7 +71,6 @@ class UiPathToolNode(RunnableCallable):
             result = await self.awrapper(self.tool, call, filtered_state)
         else:
             result = await self.tool.ainvoke(call["args"])
-
         return self._process_result(call, result)
 
     def _extract_tool_call(self, state: Any) -> ToolCall | None:

--- a/uv.lock
+++ b/uv.lock
@@ -3282,7 +3282,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Fixes escalation tool that was broken due to missing `tool_call_id` when returning `Command`.

### Problem
- Escalation tool required `runtime: ToolRuntime` parameter to get `tool_call_id`
- Nothing was injecting `ToolRuntime` into the tool
- Result: `TypeError: escalation_tool_fn() missing 1 required positional argument: 'runtime'`

### Solution
Use wrapper pattern consistent with other tools:

1. **Tool returns dict** (like `process_tool`, `context_tool`, etc.)
   - `escalation_tool_fn` returns `{"action": ..., "output": ..., "escalation_action": ...}`
   - Graph-agnostic, no knowledge of Commands or Messages

2. **Wrapper handles graph integration**
   - `escalation_wrapper` receives `(tool, call, state)` where `call["id"]` is the `tool_call_id`
   - Converts result to `Command` when termination needed
   - Uses `ToolWrapperMixin` to attach wrapper to tool

3. **Simplified tool_node.py**
   - Removed `ToolRuntime` injection logic that was never fully implemented
   - Clean separation: tools return data, wrappers handle graph concerns

### Why escalation is different from other tools
- Other tools (process, context, integration) always continue - just return data
- Escalation can END the graph based on user action - needs to return `Command`
- Wrapper pattern elegantly handles this: tool returns data, wrapper decides Command vs dict

## Changes
- `escalation_tool.py`: Returns dict, wrapper converts to Command
- `tool_node.py`: Removed unused ToolRuntime injection code
- `tool_factory.py`: Fixed return type
- `test_tool_node.py`: Cleaned up imports
- `pyproject.toml`: Version bump to 0.2.5

## Test plan
- [x] `pytest tests/agent/tools/test_tool_node.py` - all pass
- [x] `ruff check .` - no errors
- [x] `mypy` - no new errors

