### PR TITLE
feat: support sequential parallel tool calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -4,9 +4,12 @@ from typing import Annotated, Any, Optional
 from langchain_core.messages import AnyMessage
 from langgraph.graph.message import add_messages
 from pydantic import BaseModel, Field
+from uipath.agent.react import END_EXECUTION_TOOL, RAISE_ERROR_TOOL
 from uipath.platform.attachments import Attachment
 
 from uipath_langchain.agent.react.utils import add_job_attachments
+
+FLOW_CONTROL_TOOLS = [END_EXECUTION_TOOL.name, RAISE_ERROR_TOOL.name]
 
 
 class AgentTerminationSource(StrEnum):
@@ -27,6 +30,7 @@ class AgentGraphState(BaseModel):
     messages: Annotated[list[AnyMessage], add_messages] = []
     job_attachments: Annotated[dict[str, Attachment], add_job_attachments] = {}
     termination: AgentTermination | None = None
+    current_tool_call_index: int | None = None
 
 
 class AgentGuardrailsGraphState(AgentGraphState):
@@ -41,6 +45,7 @@ class AgentGraphNode(StrEnum):
     GUARDED_INIT = "guarded-init"
     AGENT = "agent"
     LLM = "llm"
+    ORCHESTRATOR = "orchestrator"
     TOOLS = "tools"
     TERMINATE = "terminate"
     GUARDED_TERMINATE = "guarded-terminate"

--- a/src/uipath_langchain/agent/react/utils.py
+++ b/src/uipath_langchain/agent/react/utils.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Sequence
 
-from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.messages import AIMessage, AnyMessage, BaseMessage
 from pydantic import BaseModel
 from uipath.agent.react import END_EXECUTION_TOOL
 from uipath.platform.attachments import Attachment
@@ -73,3 +73,18 @@ def add_job_attachments(
         return right
 
     return {**left, **right}
+
+
+def find_latest_ai_message(messages: list[AnyMessage]) -> AIMessage | None:
+    """Find and return the latest AIMessage from a list of messages.
+
+    Args:
+        messages: List of messages to search through
+
+    Returns:
+        The latest AIMessage found, or None if no AIMessage exists
+    """
+    for message in reversed(messages):
+        if isinstance(message, AIMessage):
+            return message
+    return None

--- a/src/uipath_langchain/agent/tools/orchestrator_node.py
+++ b/src/uipath_langchain/agent/tools/orchestrator_node.py
@@ -1,0 +1,111 @@
+from typing import Any
+
+from langchain_core.messages import ToolCall
+
+from uipath_langchain.agent.exceptions import AgentNodeRoutingException
+from uipath_langchain.agent.react.types import FLOW_CONTROL_TOOLS, AgentGraphState
+from uipath_langchain.agent.react.utils import (
+    count_consecutive_thinking_messages,
+    find_latest_ai_message,
+)
+
+
+def __filter_control_flow_tool_calls(tool_calls: list[ToolCall]) -> list[ToolCall]:
+    """Remove control flow tools when multiple tool calls exist."""
+    if len(tool_calls) <= 1:
+        return tool_calls
+
+    return [tc for tc in tool_calls if tc.get("name") not in FLOW_CONTROL_TOOLS]
+
+
+def create_orchestrator_node(thinking_messages_limit: int = 0):
+    """Create an orchestrator node responsible for sequencing tool calls.
+
+    Args:
+        thinking_messages_limit: Max consecutive thinking messages before error
+    """
+
+    def orchestrator_node(state: AgentGraphState) -> dict[str, Any]:
+        current_index = state.current_tool_call_index
+
+        if current_index is None:
+            # new batch of tool calls
+            if not state.messages:
+                raise AgentNodeRoutingException(
+                    "No messages in state - cannot process tool calls"
+                )
+
+            # check consecutive thinking messages limit
+            if thinking_messages_limit >= 0:
+                consecutive_thinking = count_consecutive_thinking_messages(
+                    state.messages
+                )
+                if consecutive_thinking > thinking_messages_limit:
+                    raise AgentNodeRoutingException(
+                        f"Too many consecutive thinking messages ({consecutive_thinking}). "
+                        f"Limit is {thinking_messages_limit}. Agent must use tools."
+                    )
+
+            latest_ai_message = find_latest_ai_message(state.messages)
+
+            if latest_ai_message is None or not latest_ai_message.tool_calls:
+                return {"current_tool_call_index": None}
+
+            # apply flow control tool filtering
+            original_tool_calls = list(latest_ai_message.tool_calls)
+            filtered_tool_calls = __filter_control_flow_tool_calls(original_tool_calls)
+
+            if len(filtered_tool_calls) != len(original_tool_calls):
+                modified_message = latest_ai_message.model_copy()
+                modified_message.tool_calls = filtered_tool_calls
+
+                # we need to filter out the content within the message as well, otherwise the LLM will raise an error
+                filtered_tool_call_ids = {tc["id"] for tc in filtered_tool_calls}
+                if isinstance(modified_message.content, list):
+                    modified_message.content = [
+                        block
+                        for block in modified_message.content
+                        if (
+                            isinstance(block, dict)
+                            and (
+                                block.get("call_id") in filtered_tool_call_ids
+                                or block.get("call_id") is None  # keep non-tool blocks
+                            )
+                        )
+                        or not isinstance(block, dict)
+                    ]
+
+                return {
+                    "current_tool_call_index": 0,
+                    "messages": [modified_message],
+                }
+
+            return {"current_tool_call_index": 0}
+
+        # in the middle of processing a batch
+        if not state.messages:
+            raise AgentNodeRoutingException(
+                "No messages in state during batch processing"
+            )
+
+        latest_ai_message = find_latest_ai_message(state.messages)
+
+        if latest_ai_message is None:
+            raise AgentNodeRoutingException(
+                "No AI message found during batch processing"
+            )
+
+        if not latest_ai_message.tool_calls:
+            raise AgentNodeRoutingException(
+                "No tool calls found in AI message during batch processing"
+            )
+
+        total_tool_calls = len(latest_ai_message.tool_calls)
+        next_index = current_index + 1
+
+        if next_index >= total_tool_calls:
+            return {"current_tool_call_index": None}
+        else:
+            return {"current_tool_call_index": next_index}
+
+    return orchestrator_node

--- a/tests/agent/tools/test_orchestrator_node.py
+++ b/tests/agent/tools/test_orchestrator_node.py
@@ -1,0 +1,230 @@
+"""Tests for orchestrator_node.py module."""
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from uipath_langchain.agent.exceptions import AgentNodeRoutingException
+from uipath_langchain.agent.react.types import AgentGraphState
+from uipath_langchain.agent.tools.orchestrator_node import create_orchestrator_node
+
+
+class TestOrchestratorNode:
+    """Test cases for orchestrator node."""
+
+    def test_no_messages_throws_exception(self):
+        """Test that empty messages throw exception."""
+        orchestrator = create_orchestrator_node()
+        state = AgentGraphState(messages=[])
+
+        with pytest.raises(AgentNodeRoutingException):
+            orchestrator(state)
+
+    def test_no_ai_message_returns_none(self):
+        """Test that no AI message returns current_tool_call_index None to route back to LLM."""
+        orchestrator = create_orchestrator_node()
+        human_message = HumanMessage(content="Hello")
+        state = AgentGraphState(messages=[human_message], current_tool_call_index=None)
+
+        result = orchestrator(state)
+
+        assert result == {"current_tool_call_index": None}
+
+    def test_new_tool_call_batch_sets_index_to_zero(self):
+        """Test that new tool call batch sets current_tool_call_index to 0."""
+        orchestrator = create_orchestrator_node()
+        tool_call = {
+            "name": "test_tool",
+            "args": {"input": "test"},
+            "id": "call_1",
+        }
+        ai_message = AIMessage(content="Using tool", tool_calls=[tool_call])
+        state = AgentGraphState(messages=[ai_message], current_tool_call_index=None)
+
+        result = orchestrator(state)
+
+        assert result == {"current_tool_call_index": 0}
+
+    def test_thinking_messages_limit_enforcement(self):
+        """Test that thinking messages limit is enforced."""
+        orchestrator = create_orchestrator_node(thinking_messages_limit=2)
+
+        # Create multiple AI messages without tool calls (thinking messages)
+        messages = [
+            AIMessage(content="Thinking 1"),
+            AIMessage(content="Thinking 2"),
+            AIMessage(content="Still thinking 3"),
+        ]
+        state = AgentGraphState(messages=messages, current_tool_call_index=None)
+
+        with pytest.raises(AgentNodeRoutingException):
+            orchestrator(state)
+
+    def test_thinking_messages_limit_zero_throws_immediately(self):
+        """Test that thinking_messages_limit=0 throws on any AI message without tool calls."""
+        orchestrator = create_orchestrator_node(thinking_messages_limit=0)
+
+        # Single AI message without tool calls should throw
+        messages = [AIMessage(content="Just thinking")]
+        state = AgentGraphState(messages=messages, current_tool_call_index=None)
+
+        with pytest.raises(AgentNodeRoutingException):
+            orchestrator(state)
+
+    def test_flow_control_tool_filtering_single_tool(self):
+        """Test that single flow control tool is not filtered."""
+        orchestrator = create_orchestrator_node()
+        tool_call = {
+            "name": "end_execution",
+            "args": {"result": "done"},
+            "id": "call_1",
+        }
+        ai_message = AIMessage(content="Ending", tool_calls=[tool_call])
+        state = AgentGraphState(messages=[ai_message], current_tool_call_index=None)
+
+        result = orchestrator(state)
+
+        assert result == {"current_tool_call_index": 0}
+
+    def test_flow_control_tool_filtering_multiple_tools(self):
+        """Test that flow control tools are filtered when multiple tools exist."""
+        orchestrator = create_orchestrator_node()
+        tool_calls = [
+            {
+                "name": "regular_tool",
+                "args": {"input": "test"},
+                "id": "call_1",
+            },
+            {
+                "name": "end_execution",
+                "args": {"result": "done"},
+                "id": "call_2",
+            },
+        ]
+        ai_message = AIMessage(content="Using tools", tool_calls=tool_calls)
+        state = AgentGraphState(messages=[ai_message], current_tool_call_index=None)
+
+        result = orchestrator(state)
+
+        assert "messages" in result
+        assert result["current_tool_call_index"] == 0
+
+        modified_message = result["messages"][0]
+        assert len(modified_message.tool_calls) == 1
+        assert modified_message.tool_calls[0]["name"] == "regular_tool"
+
+    def test_content_filtering_with_tool_calls(self):
+        """Test that content blocks are filtered along with tool calls."""
+        orchestrator = create_orchestrator_node()
+        tool_calls = [
+            {
+                "name": "regular_tool",
+                "args": {"input": "test"},
+                "id": "call_1",
+            },
+            {
+                "name": "end_execution",
+                "args": {"result": "done"},
+                "id": "call_2",
+            },
+        ]
+        content_blocks: list[str | dict[Any, Any]] = [
+            {"type": "text", "text": "Using tools"},
+            {"type": "tool_use", "call_id": "call_1", "name": "regular_tool"},
+            {"type": "tool_use", "call_id": "call_2", "name": "end_execution"},
+        ]
+        ai_message = AIMessage(content=content_blocks, tool_calls=tool_calls)
+        state = AgentGraphState(messages=[ai_message], current_tool_call_index=None)
+
+        print(ai_message.content)
+        result = orchestrator(state)
+
+        assert "messages" in result
+        modified_message = result["messages"][0]
+        assert len(modified_message.tool_calls) == 1
+        assert modified_message.tool_calls[0]["name"] == "regular_tool"
+
+        # Check content is filtered
+        filtered_content = modified_message.content
+        print(filtered_content)
+        assert len(filtered_content) == 2  # text block + regular_tool block
+        tool_use_blocks = [
+            block
+            for block in filtered_content
+            if isinstance(block, dict) and block.get("call_id") is not None
+        ]
+        assert len(tool_use_blocks) == 1
+        assert tool_use_blocks[0]["call_id"] == "call_1"
+
+    def test_processing_batch_advancement(self):
+        """Test advancement through tool call batch."""
+        orchestrator = create_orchestrator_node()
+        tool_calls = [
+            {
+                "name": "tool_1",
+                "args": {"input": "test1"},
+                "id": "call_1",
+            },
+            {
+                "name": "tool_2",
+                "args": {"input": "test2"},
+                "id": "call_2",
+            },
+        ]
+        ai_message = AIMessage(content="Using tools", tool_calls=tool_calls)
+        state = AgentGraphState(messages=[ai_message], current_tool_call_index=0)
+
+        result = orchestrator(state)
+
+        assert result == {"current_tool_call_index": 1}
+
+    def test_processing_batch_completion(self):
+        """Test completion of tool call batch."""
+        orchestrator = create_orchestrator_node()
+        tool_calls = [
+            {
+                "name": "tool_1",
+                "args": {"input": "test1"},
+                "id": "call_1",
+            },
+            {
+                "name": "tool_2",
+                "args": {"input": "test2"},
+                "id": "call_2",
+            },
+        ]
+        ai_message = AIMessage(content="Using tools", tool_calls=tool_calls)
+        state = AgentGraphState(messages=[ai_message], current_tool_call_index=1)
+
+        result = orchestrator(state)
+
+        assert result == {"current_tool_call_index": None}
+
+    def test_no_latest_ai_message_in_batch_throws_exception(self):
+        """Test that no latest AI message during batch processing throws exception."""
+        orchestrator = create_orchestrator_node()
+        human_message = HumanMessage(content="Hello")
+        state = AgentGraphState(messages=[human_message], current_tool_call_index=0)
+
+        with pytest.raises(AgentNodeRoutingException):
+            orchestrator(state)
+
+    def test_latest_ai_message_with_tool_responses_mixed(self):
+        """Test finding latest AI message when mixed with tool responses."""
+        orchestrator = create_orchestrator_node()
+        tool_call = {
+            "name": "test_tool",
+            "args": {"input": "test"},
+            "id": "call_1",
+        }
+        messages = [
+            AIMessage(content="Using tool", tool_calls=[tool_call]),
+            HumanMessage(content="Some response"),
+            AIMessage(content="Another tool call", tool_calls=[tool_call]),
+        ]
+        state = AgentGraphState(messages=messages, current_tool_call_index=None)
+
+        result = orchestrator(state)
+
+        assert result == {"current_tool_call_index": 0}

--- a/uv.lock
+++ b/uv.lock
@@ -3260,7 +3260,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Added support for parallel tool calls, by executing them sequentially.
This is achieved via an orchestrator node (name subject to change if we decide it's confusing due to similarity with Orchestrator service) responsible for keeping track of the current tool call and incrementing.
The conditional edge can then route to the correct tool node based on the tool call index.
Also fixed tool call filtering. It now modifies to state to completely erase the filtered system tool calls.