### PR TITLE
feat: isolate inner schema to avoid name collisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/exceptions/__init__.py
+++ b/src/uipath_langchain/agent/exceptions/__init__.py
@@ -1,4 +1,7 @@
-from .exceptions import AgentNodeRoutingException, AgentTerminationException
+from .exceptions import (
+    AgentNodeRoutingException,
+    AgentTerminationException,
+)
 
 __all__ = [
     "AgentNodeRoutingException",

--- a/src/uipath_langchain/agent/react/agent.py
+++ b/src/uipath_langchain/agent/react/agent.py
@@ -36,14 +36,14 @@ OutputT = TypeVar("OutputT", bound=BaseModel)
 
 
 def create_state_with_input(input_schema: Type[InputT]):
-    InnerAgentGraphState = type(
-        "InnerAgentGraphState",
+    CompleteAgentGraphState = type(
+        "CompleteAgentGraphState",
         (AgentGraphState, input_schema),
         {},
     )
 
-    cast(type[BaseModel], InnerAgentGraphState).model_rebuild()
-    return InnerAgentGraphState
+    cast(type[BaseModel], CompleteAgentGraphState).model_rebuild()
+    return CompleteAgentGraphState
 
 
 def create_agent(
@@ -85,12 +85,12 @@ def create_agent(
     )
     terminate_node = create_terminate_node(output_schema)
 
-    InnerAgentGraphState = create_state_with_input(
+    CompleteAgentGraphState = create_state_with_input(
         input_schema if input_schema is not None else BaseModel
     )
 
     builder: StateGraph[AgentGraphState, None, InputT, OutputT] = StateGraph(
-        InnerAgentGraphState, input_schema=input_schema, output_schema=output_schema
+        CompleteAgentGraphState, input_schema=input_schema, output_schema=output_schema
     )
     init_with_guardrails_subgraph = create_agent_init_guardrails_subgraph(
         (AgentGraphNode.GUARDED_INIT, init_node),

--- a/src/uipath_langchain/agent/react/init_node.py
+++ b/src/uipath_langchain/agent/react/init_node.py
@@ -15,7 +15,7 @@ def create_init_node(
     | Callable[[Any], Sequence[SystemMessage | HumanMessage]],
     input_schema: type[BaseModel] | None,
 ):
-    def graph_state_init(state: Any):
+    def graph_state_init(state: Any) -> Any:
         if callable(messages):
             resolved_messages = messages(state)
         else:
@@ -29,7 +29,9 @@ def create_init_node(
 
         return {
             "messages": list(resolved_messages),
-            "job_attachments": job_attachments_dict,
+            "inner_state": {
+                "job_attachments": job_attachments_dict,
+            },
         }
 
     return graph_state_init

--- a/src/uipath_langchain/agent/react/reducers.py
+++ b/src/uipath_langchain/agent/react/reducers.py
@@ -1,0 +1,90 @@
+"""Dict-like object reducers for merging state with field-specific reducers."""
+
+from typing import Any
+
+from pydantic import BaseModel
+from uipath.platform.attachments import Attachment
+
+
+def add_job_attachments(
+    left: dict[str, Attachment], right: dict[str, Attachment]
+) -> dict[str, Attachment]:
+    """Merge attachment dictionaries, with right values taking precedence.
+
+    This reducer function merges two dictionaries of attachments by UUID string.
+    If the same UUID exists in both dictionaries, the value from 'right' takes precedence.
+
+    Args:
+        left: Existing dictionary of attachments keyed by UUID string
+        right: New dictionary of attachments to merge
+
+    Returns:
+        Merged dictionary with right values overriding left values for duplicate keys
+    """
+    if not right:
+        return left
+
+    if not left:
+        return right
+
+    return {**left, **right}
+
+
+def merge_objects(left: Any, right: Any) -> Any:
+    """Merge a Pydantic model with another model or dict, with right values taking precedence.
+
+    Applies field-specific reducers from annotation metadata when merging values.
+
+    Args:
+        left: Existing Pydantic BaseModel instance
+        right: New Pydantic BaseModel instance or dict to merge
+
+    Returns:
+        New Pydantic model instance with merged values
+
+    Raises:
+        TypeError: If left is not a Pydantic BaseModel or right is not a BaseModel or dict
+    """
+    if not right:
+        return left
+
+    if not left:
+        return right
+
+    # validate input types
+    if not isinstance(left, BaseModel):
+        raise TypeError("Left object must be a Pydantic BaseModel")
+
+    if not isinstance(right, (BaseModel, dict)):
+        raise TypeError("Right object must be a Pydantic BaseModel or dict")
+
+    model_fields = type(left).model_fields
+    merged_values = {}
+
+    for field_name in model_fields:
+        merged_values[field_name] = getattr(left, field_name)
+
+    for field_name in model_fields:
+        if isinstance(right, BaseModel):
+            if hasattr(right, field_name):
+                right_value = getattr(right, field_name)
+            else:
+                continue  # field not present in right
+        else:
+            # right is dict
+            if field_name not in right:
+                continue  # field not present in right
+            right_value = right[field_name]
+
+        field_info = model_fields[field_name]
+        left_value = merged_values[field_name]
+
+        # apply reducer if defined
+        if field_info.metadata and callable(field_info.metadata[0]):
+            reducer_func = field_info.metadata[0]
+            merged_values[field_name] = reducer_func(left_value, right_value)
+        else:
+            merged_values[field_name] = right_value
+
+    # return new model instance with merged values
+    return type(left)(**merged_values)

--- a/src/uipath_langchain/agent/react/terminate_node.py
+++ b/src/uipath_langchain/agent/react/terminate_node.py
@@ -57,8 +57,8 @@ def create_terminate_node(
     """
 
     def terminate_node(state: AgentGraphState):
-        if state.termination:
-            _handle_agent_termination(state.termination)
+        if state.inner_state.termination:
+            _handle_agent_termination(state.inner_state.termination)
 
         last_message = state.messages[-1]
         if not isinstance(last_message, AIMessage):

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -6,7 +6,7 @@ from langgraph.graph.message import add_messages
 from pydantic import BaseModel, Field
 from uipath.platform.attachments import Attachment
 
-from uipath_langchain.agent.react.utils import add_job_attachments
+from uipath_langchain.agent.react.reducers import add_job_attachments, merge_objects
 
 
 class AgentTerminationSource(StrEnum):
@@ -21,12 +21,18 @@ class AgentTermination(BaseModel):
     detail: str = ""
 
 
+class InnerAgentGraphState(BaseModel):
+    job_attachments: Annotated[dict[str, Attachment], add_job_attachments] = {}
+    termination: AgentTermination | None = None
+
+
 class AgentGraphState(BaseModel):
     """Agent Graph state for standard loop execution."""
 
     messages: Annotated[list[AnyMessage], add_messages] = []
-    job_attachments: Annotated[dict[str, Attachment], add_job_attachments] = {}
-    termination: AgentTermination | None = None
+    inner_state: Annotated[InnerAgentGraphState, merge_objects] = Field(
+        default_factory=InnerAgentGraphState
+    )
 
 
 class AgentGuardrailsGraphState(AgentGraphState):

--- a/src/uipath_langchain/agent/react/utils.py
+++ b/src/uipath_langchain/agent/react/utils.py
@@ -5,7 +5,6 @@ from typing import Any, Sequence
 from langchain_core.messages import AIMessage, BaseMessage
 from pydantic import BaseModel
 from uipath.agent.react import END_EXECUTION_TOOL
-from uipath.platform.attachments import Attachment
 
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
 
@@ -49,27 +48,3 @@ def count_consecutive_thinking_messages(messages: Sequence[BaseMessage]) -> int:
         count += 1
 
     return count
-
-
-def add_job_attachments(
-    left: dict[str, Attachment], right: dict[str, Attachment]
-) -> dict[str, Attachment]:
-    """Merge attachment dictionaries, with right values taking precedence.
-
-    This reducer function merges two dictionaries of attachments by UUID string.
-    If the same UUID exists in both dictionaries, the value from 'right' takes precedence.
-
-    Args:
-        left: Existing dictionary of attachments keyed by UUID string
-        right: New dictionary of attachments to merge
-
-    Returns:
-        Merged dictionary with right values overriding left values for duplicate keys
-    """
-    if not right:
-        return left
-
-    if not left:
-        return right
-
-    return {**left, **right}

--- a/src/uipath_langchain/agent/tools/escalation_tool.py
+++ b/src/uipath_langchain/agent/tools/escalation_tool.py
@@ -114,10 +114,12 @@ def create_escalation_tool(resource: AgentEscalationResourceConfig) -> BaseTool:
                             tool_call_id=call["id"],
                         )
                     ],
-                    "termination": {
-                        "source": AgentTerminationSource.ESCALATION,
-                        "title": termination_title,
-                        "detail": output_detail,
+                    "inner_state": {
+                        "termination": {
+                            "source": AgentTerminationSource.ESCALATION,
+                            "title": termination_title,
+                            "detail": output_detail,
+                        }
                     },
                 },
                 goto=AgentGraphNode.TERMINATE,

--- a/src/uipath_langchain/agent/wrappers/job_attachment_wrapper.py
+++ b/src/uipath_langchain/agent/wrappers/job_attachment_wrapper.py
@@ -51,7 +51,7 @@ def get_job_attachment_wrapper() -> AsyncToolWrapperType:
             errors: list[str] = []
             paths = get_job_attachment_paths(tool.args_schema)
             modified_input_args = replace_job_attachment_ids(
-                paths, input_args, state.job_attachments, errors
+                paths, input_args, state.inner_state.job_attachments, errors
             )
 
             if errors:

--- a/tests/agent/react/test_job_attachments.py
+++ b/tests/agent/react/test_job_attachments.py
@@ -1,12 +1,13 @@
 import uuid
 from typing import Any
 
+from jsonschema_pydantic_converter import transform_with_modules
 from pydantic import BaseModel
 from uipath.platform.attachments import Attachment
 
 from uipath_langchain.agent.react.job_attachments import get_job_attachments
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
-from uipath_langchain.agent.react.utils import (
+from uipath_langchain.agent.react.reducers import (
     add_job_attachments,
 )
 
@@ -343,7 +344,7 @@ class TestGetJobAttachments:
                 }
             },
         }
-        model = create_model(schema)
+        model, _ = transform_with_modules(schema)
         test_uuid = "550e8400-e29b-41d4-a716-446655440200"
         data = {
             "result": {

--- a/tests/agent/react/test_merge_objects.py
+++ b/tests/agent/react/test_merge_objects.py
@@ -1,0 +1,186 @@
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel
+
+from uipath_langchain.agent.react.reducers import merge_objects
+
+
+# Simple test models with annotations
+def merge_strings(left: str, right: str) -> str:
+    """Simple reducer that concatenates strings."""
+    return f"{left or ''},{right or ''}"
+
+
+def merge_lists(left: list[str], right: list[str]) -> list[str]:
+    """Simple reducer that combines lists."""
+    return (left or []) + (right or [])
+
+
+def merge_dicts(left: dict[str, str], right: dict[str, str]) -> dict[str, str]:
+    """Simple reducer that merges dicts with right precedence."""
+    return {**(left or {}), **(right or {})}
+
+
+class SimpleModel(BaseModel):
+    name: str = "default"
+    value: int = 0
+
+
+class ModelWithReducer(BaseModel):
+    text: Annotated[str, merge_strings] = ""
+    items: Annotated[list[str], merge_lists] = []
+    mapping: Annotated[dict[str, str], merge_dicts] = {}
+    count: int = 0
+
+
+class TestMergeObjects:
+    """Test merge_objects reducer function."""
+
+    def test_empty_right_returns_left(self):
+        """Should return left when right is empty."""
+        left = SimpleModel()
+        result = merge_objects(left, {})
+        assert result is left
+
+    def test_empty_left_returns_right(self):
+        """Should return right when left is empty."""
+        right = SimpleModel()
+        result = merge_objects(None, right)
+        assert result is right
+
+    def test_left_not_basemodel_raises_error(self):
+        """Should raise TypeError when left is not a BaseModel."""
+        with pytest.raises(TypeError, match="Left object must be a Pydantic BaseModel"):
+            merge_objects({"key": "value"}, {"some": "data"})
+
+    def test_right_not_basemodel_or_dict_raises_error(self):
+        """Should raise TypeError when right is not a BaseModel or dict."""
+        left = SimpleModel()
+        with pytest.raises(
+            TypeError, match="Right object must be a Pydantic BaseModel or dict"
+        ):
+            merge_objects(left, "invalid")
+
+    def test_simple_field_override_with_dict(self):
+        """Should override simple fields when merging with dict."""
+        left = SimpleModel(name="original", value=10)
+        right = {"name": "updated", "value": 20}
+
+        result = merge_objects(left, right)
+
+        assert result.name == "updated"
+        assert result.value == 20
+
+    def test_simple_field_override_with_basemodel(self):
+        """Should override simple fields when merging with BaseModel."""
+        left = SimpleModel(name="original", value=10)
+        right = SimpleModel(name="updated", value=20)
+
+        result = merge_objects(left, right)
+
+        assert result.name == "updated"
+        assert result.value == 20
+
+    def test_annotation_reducer_applied_with_dict(self):
+        """Should apply annotation reducer when merging with dict."""
+        left = ModelWithReducer(text="hello", items=["a", "b"], count=10)
+        right = {"text": "world", "items": ["c", "d"], "count": 20}
+
+        result = merge_objects(left, right)
+
+        # text should be merged using string reducer
+        assert result.text == "hello,world"
+        # items should be merged using list reducer
+        assert result.items == ["a", "b", "c", "d"]
+        # count should be overridden (no reducer)
+        assert result.count == 20
+
+    def test_annotation_reducer_applied_with_basemodel(self):
+        """Should apply annotation reducer when merging with BaseModel."""
+        left = ModelWithReducer(text="hello", items=["a", "b"], count=10)
+        right = ModelWithReducer(text="world", items=["c", "d"], count=20)
+
+        result = merge_objects(left, right)
+
+        # text should be merged using string reducer
+        assert result.text == "hello,world"
+        # items should be merged using list reducer
+        assert result.items == ["a", "b", "c", "d"]
+        # count should be overridden (no reducer)
+        assert result.count == 20
+
+    def test_dict_reducer_merges_correctly(self):
+        """Should apply dict reducer correctly."""
+        left = ModelWithReducer(mapping={"a": "1", "b": "2"})
+        right = {"mapping": {"b": "3", "c": "4"}}
+
+        result = merge_objects(left, right)
+
+        # mapping should be merged with right precedence
+        assert result.mapping == {"a": "1", "b": "3", "c": "4"}
+
+    def test_mixed_fields_with_and_without_reducers(self):
+        """Should handle fields with reducers and simple override fields in same merge."""
+        left = ModelWithReducer(
+            text="hello", items=["a", "b"], mapping={"x": "1"}, count=10
+        )
+        right = ModelWithReducer(
+            text="world", items=["c", "d"], mapping={"y": "2"}, count=20
+        )
+
+        result = merge_objects(left, right)
+
+        # Fields with reducers should be merged
+        assert result.text == "hello,world"
+        assert result.items == ["a", "b", "c", "d"]
+        assert result.mapping == {"x": "1", "y": "2"}
+        # Field without reducer should be overridden
+        assert result.count == 20
+
+    def test_field_not_present_in_right_keeps_left_value(self):
+        """Should keep left value when field is not present in right."""
+        left = ModelWithReducer(text="hello", items=["a", "b"], count=10)
+        right: dict[str, object] = {}  # Empty dict
+
+        result = merge_objects(left, right)
+
+        # All left values should be preserved
+        assert result.text == "hello"
+        assert result.items == ["a", "b"]
+        assert result.count == 10
+
+    def test_custom_model_with_annotation_reducer(self):
+        """Should work with custom models that have annotation reducers."""
+        left = ModelWithReducer(items=["a", "b"], text="left")
+        right = ModelWithReducer(items=["c", "d"], text="right")
+
+        result = merge_objects(left, right)
+
+        # items should be merged using list reducer
+        assert result.items == ["a", "b", "c", "d"]
+        # text should be merged using string reducer
+        assert result.text == "left,right"
+
+    def test_empty_values_handled_correctly(self):
+        """Should handle empty values correctly in reducer application."""
+        left = ModelWithReducer()  # All defaults
+        right = ModelWithReducer(text="hello", items=["a", "b"])
+
+        result = merge_objects(left, right)
+
+        # Should handle empty left values correctly
+        assert result.text == ",hello"  # Empty string + "hello"
+        assert result.items == ["a", "b"]  # Empty list + ["a", "b"]
+
+    def test_invalid_field_names_ignored(self):
+        """Should ignore fields in right dict that don't exist in left model."""
+        left = SimpleModel(name="test", value=10)
+        right = {"name": "updated", "invalid_field": "should be ignored"}
+
+        result = merge_objects(left, right)
+
+        # Valid field should be set
+        assert result.name == "updated"
+        # Invalid field should not exist
+        assert not hasattr(result, "invalid_field")

--- a/tests/agent/wrappers/test_job_attachment_wrapper.py
+++ b/tests/agent/wrappers/test_job_attachment_wrapper.py
@@ -10,7 +10,7 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 from uipath.platform.attachments import Attachment
 
-from uipath_langchain.agent.react.types import AgentGraphState
+from uipath_langchain.agent.react.types import AgentGraphState, InnerAgentGraphState
 from uipath_langchain.agent.wrappers.job_attachment_wrapper import (
     get_job_attachment_wrapper,
 )
@@ -46,7 +46,8 @@ class TestGetJobAttachmentWrapper:
     def mock_state(self):
         """Create a mock agent graph state."""
         state = MagicMock(spec=AgentGraphState)
-        state.job_attachments = {}
+        state.inner_state = InnerAgentGraphState()
+        state.inner_state.job_attachments = {}
         state.messages = []
         return state
 
@@ -138,7 +139,9 @@ class TestGetJobAttachmentWrapper:
         mock_get_paths.return_value = ["$.attachment"]
 
         # Setup state with valid attachment (string keys)
-        mock_state.job_attachments = {str(mock_attachment.id): mock_attachment}
+        mock_state.inner_state.job_attachments = {
+            str(mock_attachment.id): mock_attachment
+        }
 
         # Setup tool call with attachment ID
         tool_call = cast(
@@ -185,7 +188,7 @@ class TestGetJobAttachmentWrapper:
         )
 
         # Empty state - attachment not found
-        mock_state.job_attachments = {}
+        mock_state.inner_state.job_attachments = {}
 
         wrapper = get_job_attachment_wrapper()
         result = await wrapper(mock_tool, tool_call, mock_state)
@@ -229,7 +232,7 @@ class TestGetJobAttachmentWrapper:
         )
 
         # Empty state - both attachments not found
-        mock_state.job_attachments = {}
+        mock_state.inner_state.job_attachments = {}
 
         wrapper = get_job_attachment_wrapper()
         result = await wrapper(mock_tool, tool_call, mock_state)
@@ -271,7 +274,7 @@ class TestGetJobAttachmentWrapper:
             },
         )
 
-        mock_state.job_attachments = {}
+        mock_state.inner_state.job_attachments = {}
 
         wrapper = get_job_attachment_wrapper()
         result = await wrapper(mock_tool, tool_call, mock_state)
@@ -297,7 +300,9 @@ class TestGetJobAttachmentWrapper:
         mock_get_paths.return_value = ["$.attachments[*]"]
 
         # One valid, one invalid (string keys)
-        mock_state.job_attachments = {str(mock_attachment.id): mock_attachment}
+        mock_state.inner_state.job_attachments = {
+            str(mock_attachment.id): mock_attachment
+        }
         invalid_id = uuid.uuid4()
 
         tool_call = cast(
@@ -374,7 +379,7 @@ class TestGetJobAttachmentWrapper:
         )
 
         # Setup state with available attachments (string keys)
-        mock_state.job_attachments = {
+        mock_state.inner_state.job_attachments = {
             str(attachment1_id): attachment1,
             str(attachment2_id): attachment2,
             str(attachment3_id): attachment3,
@@ -498,7 +503,7 @@ class TestGetJobAttachmentWrapper:
         )
 
         # Setup state with all attachments (string keys)
-        mock_state.job_attachments = {
+        mock_state.inner_state.job_attachments = {
             str(attachment1_id): attachment1,
             str(attachment2_id): attachment2,
             str(attachment3_id): attachment3,

--- a/uv.lock
+++ b/uv.lock
@@ -3282,7 +3282,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Context:
- Agent Builder agents have no restrictions to input / output argument names (other than the recently added reserved "messages"
- Due to how LangGraph state works, input and output args could conflict with internal state fields (ie: job attachments)"
- After lengthy debates, this has been the best solution left.
- Integrating the Guardrails state will come later.