### PR TITLE
fix(ToolNode): pass correct inputs to tool nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -2,6 +2,7 @@ from enum import StrEnum
 from typing import Annotated, Any, Optional
 
 from langchain_core.messages import AnyMessage
+from langchain_core.messages.tool import ToolCall
 from langgraph.graph.message import add_messages
 from pydantic import BaseModel, Field
 from uipath.platform.attachments import Attachment
@@ -32,6 +33,9 @@ class AgentGraphState(BaseModel):
     messages: Annotated[list[AnyMessage], add_messages] = []
     inner_state: Annotated[InnerAgentGraphState, merge_objects] = Field(
         default_factory=InnerAgentGraphState
+    )
+    tool_call: Optional[ToolCall] = (
+        None  # This field is used to pass tool inputs to tool nodes.
     )
 
 

--- a/tests/agent/tools/test_tool_node.py
+++ b/tests/agent/tools/test_tool_node.py
@@ -1,6 +1,6 @@
 """Tests for tool_node.py module."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
@@ -55,6 +55,7 @@ class MockState(BaseModel):
     messages: list[Any] = []
     user_id: str = "test_user"
     session_id: str = "test_session"
+    tool_call: Optional[ToolCall] = None
 
 
 def mock_wrapper(
@@ -101,7 +102,7 @@ class TestUiPathToolNode:
             "id": "test_call_id",
         }
         ai_message = AIMessage(content="Using tool", tool_calls=[tool_call])
-        return MockState(messages=[ai_message])
+        return MockState(messages=[ai_message], tool_call=tool_call)
 
     @pytest.fixture
     def empty_state(self):
@@ -197,26 +198,6 @@ class TestUiPathToolNode:
         node = UiPathToolNode(mock_tool)
 
         result = node._func(empty_state)
-
-        assert result is None
-
-    def test_non_ai_message_raises_error(self, mock_tool, non_ai_state):
-        """Test that non-AI messages raise ValueError."""
-        node = UiPathToolNode(mock_tool)
-
-        with pytest.raises(
-            ValueError, match="Last message in message stack is not an AIMessage"
-        ):
-            node._func(non_ai_state)
-
-    def test_mismatched_tool_name_returns_none(self, mock_tool, mock_state):
-        """Test that mismatched tool names return None."""
-        # Change the tool call name to something different
-        mock_state.messages[-1].tool_calls[0]["name"] = "different_tool"
-
-        node = UiPathToolNode(mock_tool)
-
-        result = node._func(mock_state)
 
         assert result is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -3282,7 +3282,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Scenario:

1. LLM invokes multiple instances of the same tool, such as ["Web Search", "Web Search"]
1. [This line](https://github.com/UiPath/uipath-langchain-python/blob/main/src/uipath_langchain/agent/react/router.py#L89) schedules multiple tool nodes to run in parallel.
1. Each tool node picks up the [first matching tool call](https://github.com/UiPath/uipath-langchain-python/blob/main/src/uipath_langchain/agent/tools/tool_node.py#L86-L88) from the state. This means that both of the web search tools will execute the first tool call.

Fix is to send the correct `ToolCall` details to the tool node. This also simplifies the tool node implementation.


## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.3.3.dev1003891788",

  # Any version from PR
  "uipath-langchain>=0.3.3.dev1003890000,<0.3.3.dev1003900000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }
```