### PR TITLE
feat: support parallel calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/aggregator_node.py
+++ b/src/uipath_langchain/agent/react/aggregator_node.py
@@ -1,0 +1,125 @@
+"""Aggregator node for merging substates back into main state."""
+
+from typing import Any
+
+from langchain_core.messages import AIMessage, AnyMessage
+from langgraph.types import Overwrite
+
+from uipath_langchain.agent.react.types import AgentGraphState, InnerAgentGraphState
+
+
+def _aggregate_messages(
+    original_messages: list[AnyMessage], substate_messages: dict[str, list[AnyMessage]]
+) -> list[AnyMessage]:
+    aggregated_by_id: dict[str, AnyMessage] = {}
+    original_order: list[str] = []
+
+    for msg in original_messages:
+        aggregated_by_id[msg.id] = msg
+        original_order.append(msg.id)
+
+    new_messages: list[AnyMessage] = []
+
+    for tool_call_id, substate_msgs in substate_messages.items():
+        for msg in substate_msgs:
+            if msg.id in aggregated_by_id:
+                # existing message
+                original_msg = aggregated_by_id[msg.id]
+                if (
+                    isinstance(msg, AIMessage)
+                    and msg.tool_calls
+                    and len(msg.tool_calls) > 0
+                ):
+                    updated_tool_call = next(
+                        (tc for tc in msg.tool_calls if tc["id"] == tool_call_id), None
+                    )
+                    if updated_tool_call:
+                        # update the specific tool call in the original message
+                        new_tool_calls = [
+                            updated_tool_call if tc["id"] == tool_call_id else tc
+                            for tc in original_msg.tool_calls
+                        ]
+                        aggregated_by_id[msg.id].tool_calls = new_tool_calls
+            else:
+                # new message, add it
+                new_messages.append(msg)
+
+    result = []
+    for msg_id in original_order:
+        result.append(aggregated_by_id[msg_id])
+    result.extend(new_messages)
+
+    return result
+
+
+def create_aggregator_node() -> callable:
+    """Create an aggregator node that merges substates back into main state."""
+
+    def aggregator_node(state: AgentGraphState) -> dict[str, Any] | Overwrite:
+        """
+        Aggregate substates back into main state.
+
+        If substates is empty, no-op and continue.
+        If substates is non-empty:
+        - for messages, leave placeholder for message aggregation logic
+        - for each field in inner state, get its reducer and apply updates
+        - lastly, overwrite the state and clear substates
+        """
+        if not state.substates:
+            return {}
+
+        # message aggregation
+        substate_messages = {}
+        for tool_call_id, substate in state.substates.items():
+            if "messages" in substate:
+                substate_messages[tool_call_id] = substate["messages"]
+
+        aggregated_messages = _aggregate_messages(state.messages, substate_messages)
+
+        # inner state fields aggregation
+        aggregated_inner_dict = state.inner_state.model_dump()
+
+        inner_state_fields = InnerAgentGraphState.model_fields
+        for substate in state.substates.values():
+            if "inner_state" in substate:
+                substate_inner_data = substate["inner_state"]
+
+                if isinstance(substate_inner_data, InnerAgentGraphState):
+                    substate_inner_dict = substate_inner_data.model_dump()
+                else:
+                    substate_inner_dict = substate_inner_data
+
+                # for each field, apply reducer if defined
+                for field_name, field_info in inner_state_fields.items():
+                    if field_name in substate_inner_dict:
+                        substate_field_value = substate_inner_dict[field_name]
+                        current_field_value = aggregated_inner_dict[field_name]
+
+                        if field_info.metadata and callable(field_info.metadata[-1]):
+                            reducer_func = field_info.metadata[-1]
+                            merged_value = reducer_func(
+                                current_field_value, substate_field_value
+                            )
+                        else:
+                            # no reducer, just replace
+                            merged_value = substate_field_value
+
+                        aggregated_inner_dict[field_name] = merged_value
+
+        aggregated_inner_state = InnerAgentGraphState.model_validate(
+            aggregated_inner_dict
+        )
+
+        state.messages = aggregated_messages
+        state.inner_state = aggregated_inner_state
+        state.substates = {}
+
+        # return overwrite command to replace the state
+        return {
+            **state.model_dump(exclude={"messages", "inner_state", "substates"}),
+            "messages": Overwrite(aggregated_messages),
+            "inner_state": Overwrite(aggregated_inner_state),
+            "substates": Overwrite({}),
+        }
+
+    return aggregator_node

--- a/src/uipath_langchain/agent/react/utils.py
+++ b/src/uipath_langchain/agent/react/utils.py
@@ -3,10 +3,12 @@
 from typing import Any, Sequence
 
 from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.messages.tool import ToolCall
 from pydantic import BaseModel
 from uipath.agent.react import END_EXECUTION_TOOL
 
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
+from uipath_langchain.agent.react.types import AgentGraphState
 
 
 def resolve_input_model(
@@ -48,3 +50,52 @@ def count_consecutive_thinking_messages(messages: Sequence[BaseMessage]) -> int:
         count += 1
 
     return count
+
+
+def extract_tool_call_from_state(
+    state: AgentGraphState,
+    tool_name: str,
+    tool_call_id: str | None = None,
+    return_message: bool = False,
+) -> ToolCall | None | tuple[ToolCall | None, AIMessage | None]:
+    """
+    Extract tool call from state using consistent logic.
+
+    Search order:
+    1. If tool_call_id is provided, search for tool call with matching id and name
+    2. Otherwise, find first tool call with matching name from the last AI message
+
+    Args:
+        state: The agent graph state
+        tool_name: Name of the tool to find
+        tool_call_id: Optional tool call id to search for
+        return_message: If True, returns tuple of (tool_call, message) instead of just tool_call
+
+    Returns:
+        The matching ToolCall if found, None otherwise. If return_message is True,
+        returns tuple of (ToolCall | None, AIMessage | None).
+    """
+    if not state.messages:
+        return (None, None) if return_message else None
+
+    # 1. If tool_call_id is provided, search for tool call with matching id and name
+    if tool_call_id is not None:
+        for message in reversed(state.messages):
+            if isinstance(message, AIMessage):
+                for tool_call in message.tool_calls:
+                    if (
+                        tool_call["id"] == tool_call_id
+                        and tool_call["name"] == tool_name
+                    ):
+                        return (tool_call, message) if return_message else tool_call
+        return (None, None) if return_message else None
+
+    # 2. Find first tool call with matching name from the last AI message
+    for message in reversed(state.messages):
+        if isinstance(message, AIMessage):
+            for tool_call in message.tool_calls:
+                if tool_call["name"] == tool_name:
+                    return (tool_call, message) if return_message else tool_call
+            break
+
+    return (None, None) if return_message else None

--- a/uv.lock
+++ b/uv.lock
@@ -3282,7 +3282,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Rough implementation draft to support parallel subgraphs. Successfully ran two IS tools with pre-execution guardrails in parallel.

Not yet done:
- fix all guardrail actions to correctly extract the tool call. Only done filter to be able to test, also need to do escalate
- fix message updating. This is an existing bug in all our code. If you update message.tool_calls, that does not actually change what gets sent to the LLM. 
- test more scenarios, like tools with job attachments and so on
- clean up implementation, add more error checking, fix linting
- add and fix existing tests