### PR TITLE
feat: conversational agent support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath-langchain"
-version = "0.3.5"
+version = "0.4.0"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.4.14, <2.5.0",
-    "uipath-runtime>=0.4.1, <0.5.0",
+    "uipath>=2.5.0, <2.6.0",
+    "uipath-runtime>=0.5.0,<0.6.0",
     "langgraph>=1.0.0, <2.0.0",
     "langchain-core>=1.2.5, <2.0.0",
     "aiosqlite==0.21.0",

--- a/src/uipath_langchain/agent/react/init_node.py
+++ b/src/uipath_langchain/agent/react/init_node.py
@@ -3,6 +3,7 @@
 from typing import Any, Callable, Sequence
 
 from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.types import Overwrite
 from pydantic import BaseModel
 
 from .job_attachments import (
@@ -14,12 +15,26 @@ def create_init_node(
     messages: Sequence[SystemMessage | HumanMessage]
     | Callable[[Any], Sequence[SystemMessage | HumanMessage]],
     input_schema: type[BaseModel] | None,
+    is_conversational: bool = False,
 ):
     def graph_state_init(state: Any) -> Any:
+        resolved_messages: Sequence[SystemMessage | HumanMessage] | Overwrite
         if callable(messages):
-            resolved_messages = messages(state)
+            resolved_messages = list(messages(state))
         else:
-            resolved_messages = messages
+            resolved_messages = list(messages)
+        if is_conversational:
+            # For conversational agents we need to reorder the messages so that the system message is first, followed by
+            # the initial user message. When resuming the conversation, the state will have the entire message history,
+            # including the system message. In this case, we need to replace the system message from the state with the
+            # newly generated one. It will have the current date/time and reflect any changes to user settings. The add
+            # reducer is used for the messages property in the state, so by default new messages are appended to the end
+            # and using Overwrite will cause LangGraph to replace the entire array instead.
+            if len(state.messages) > 0 and isinstance(state.messages[0], SystemMessage):
+                preserved_messages = state.messages[1:]
+            else:
+                preserved_messages = state.messages
+            resolved_messages = Overwrite([*resolved_messages, *preserved_messages])
 
         schema = input_schema if input_schema is not None else BaseModel
         job_attachments = get_job_attachments(schema, state)
@@ -28,7 +43,7 @@ def create_init_node(
         }
 
         return {
-            "messages": list(resolved_messages),
+            "messages": resolved_messages,
             "inner_state": {
                 "job_attachments": job_attachments_dict,
             },

--- a/src/uipath_langchain/agent/react/llm_node.py
+++ b/src/uipath_langchain/agent/react/llm_node.py
@@ -37,6 +37,7 @@ def create_llm_node(
     model: BaseChatModel,
     tools: Sequence[BaseTool] | None = None,
     thinking_messages_limit: int = MAX_CONSECUTIVE_THINKING_MESSAGES,
+    is_conversational: bool = False,
 ):
     """Create LLM node with dynamic tool_choice enforcement.
 
@@ -58,7 +59,11 @@ def create_llm_node(
 
         consecutive_thinking_messages = count_consecutive_thinking_messages(messages)
 
-        if bindable_tools and consecutive_thinking_messages >= thinking_messages_limit:
+        if (
+            not is_conversational
+            and bindable_tools
+            and consecutive_thinking_messages >= thinking_messages_limit
+        ):
             llm = base_llm.bind(tool_choice=tool_choice_required_value)
         else:
             llm = base_llm

--- a/src/uipath_langchain/agent/react/router_conversational.py
+++ b/src/uipath_langchain/agent/react/router_conversational.py
@@ -1,0 +1,43 @@
+"""Routing functions for conditional edges in the agent graph."""
+
+import logging
+from typing import Literal
+
+from uipath_langchain.agent.react.router_utils import validate_last_message_is_AI
+
+from .types import AgentGraphNode, AgentGraphState
+
+logger = logging.getLogger(__name__)
+
+
+def create_route_agent_conversational():
+    """Create a routing function for conversational agents. It routes between agent and tool calls until
+    the agent response has no tool calls, then it routes to the USER_MESSAGE_WAIT node which does an interrupt.
+
+    Returns:
+        Routing function for LangGraph conditional edges
+    """
+
+    def route_agent_conversational(
+        state: AgentGraphState,
+    ) -> list[str] | Literal[AgentGraphNode.TERMINATE]:
+        """Route after agent
+
+        Routing logic:
+        3. If tool calls, route to specific tool nodes (return list of tool names)
+        4. If no tool calls, route to user message wait node
+
+        Returns:
+            - list[str]: Tool node names for parallel execution
+            - AgentGraphNode.USER_MESSAGE_WAIT: When there are no tool calls
+
+        Raises:
+            AgentNodeRoutingException: When encountering unexpected state (empty messages, non-AIMessage, or excessive completions)
+        """
+        last_message = validate_last_message_is_AI(state.messages)
+        if last_message.tool_calls:
+            return [tc["name"] for tc in last_message.tool_calls]
+        else:
+            return AgentGraphNode.TERMINATE
+
+    return route_agent_conversational

--- a/src/uipath_langchain/agent/react/router_utils.py
+++ b/src/uipath_langchain/agent/react/router_utils.py
@@ -1,0 +1,25 @@
+"""Routing functions for conditional edges in the agent graph."""
+
+from langchain_core.messages import AIMessage, AnyMessage
+
+from ..exceptions import AgentNodeRoutingException
+
+
+def validate_last_message_is_AI(messages: list[AnyMessage]) -> AIMessage:
+    """Validate and return last message from state.
+
+    Raises:
+        AgentNodeRoutingException: If messages are empty or last message is not AIMessage
+    """
+    if not messages:
+        raise AgentNodeRoutingException(
+            "No messages in state - cannot route after agent"
+        )
+
+    last_message = messages[-1]
+    if not isinstance(last_message, AIMessage):
+        raise AgentNodeRoutingException(
+            f"Last message is not AIMessage (type: {type(last_message).__name__}) - cannot route after agent"
+        )
+
+    return last_message

--- a/src/uipath_langchain/agent/react/terminate_node.py
+++ b/src/uipath_langchain/agent/react/terminate_node.py
@@ -46,7 +46,7 @@ def _handle_agent_termination(termination: AgentTermination) -> NoReturn:
 
 
 def create_terminate_node(
-    response_schema: type[BaseModel] | None = None,
+    response_schema: type[BaseModel] | None = None, is_conversational: bool = False
 ):
     """Handles Agent Graph termination for multiple sources and output or error propagation to Orchestrator.
 
@@ -60,23 +60,24 @@ def create_terminate_node(
         if state.inner_state.termination:
             _handle_agent_termination(state.inner_state.termination)
 
-        last_message = state.messages[-1]
-        if not isinstance(last_message, AIMessage):
+        if not is_conversational:
+            last_message = state.messages[-1]
+            if not isinstance(last_message, AIMessage):
+                raise AgentNodeRoutingException(
+                    f"Expected last message to be AIMessage, got {type(last_message).__name__}"
+                )
+
+            for tool_call in last_message.tool_calls:
+                tool_name = tool_call["name"]
+
+                if tool_name == END_EXECUTION_TOOL.name:
+                    return _handle_end_execution(tool_call["args"], response_schema)
+
+                if tool_name == RAISE_ERROR_TOOL.name:
+                    _handle_raise_error(tool_call["args"])
+
             raise AgentNodeRoutingException(
-                f"Expected last message to be AIMessage, got {type(last_message).__name__}"
+                "No control flow tool call found in terminate node. Unexpected state."
             )
-
-        for tool_call in last_message.tool_calls:
-            tool_name = tool_call["name"]
-
-            if tool_name == END_EXECUTION_TOOL.name:
-                return _handle_end_execution(tool_call["args"], response_schema)
-
-            if tool_name == RAISE_ERROR_TOOL.name:
-                _handle_raise_error(tool_call["args"])
-
-        raise AgentNodeRoutingException(
-            "No control flow tool call found in terminate node. Unexpected state."
-        )
 
     return terminate_node

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -61,3 +61,6 @@ class AgentGraphConfig(BaseModel):
         ge=0,
         description="Max consecutive thinking messages before enforcing tool usage. 0 = force tools every time.",
     )
+    is_conversational: bool = Field(
+        default=False, description="If set, creates a graph for conversational agents"
+    )

--- a/src/uipath_langchain/chat/mapper.py
+++ b/src/uipath_langchain/chat/mapper.py
@@ -307,21 +307,8 @@ class UiPathChatMessagesMapper:
                 )
             ]
 
-        # --- Fallback for other BaseMessage types ---
-        text_content = self._extract_text(message.content)
-        return [
-            UiPathConversationMessageEvent(
-                message_id=message.id,
-                start=UiPathConversationMessageStartEvent(
-                    role="assistant", timestamp=timestamp
-                ),
-                content_part=UiPathConversationContentPartEvent(
-                    content_part_id=f"cp-{message.id}",
-                    chunk=UiPathConversationContentPartChunkEvent(data=text_content),
-                ),
-                end=UiPathConversationMessageEndEvent(),
-            )
-        ]
+        # Don't send events for system or user messages. Agent messages are handled above.
+        return []
 
 
 __all__ = ["UiPathChatMessagesMapper"]

--- a/src/uipath_langchain/runtime/factory.py
+++ b/src/uipath_langchain/runtime/factory.py
@@ -62,9 +62,16 @@ class UiPathLangGraphRuntimeFactory:
 
     def _get_connection_string(self) -> str:
         """Get the database connection string."""
+        if self.context.state_file_path is not None:
+            return self.context.state_file_path
+
         if self.context.runtime_dir and self.context.state_file:
             path = os.path.join(self.context.runtime_dir, self.context.state_file)
-            if not self.context.resume and self.context.job_id is None:
+            if (
+                not self.context.resume
+                and self.context.job_id is None
+                and not self.context.keep_state_file
+            ):
                 # If not resuming and no job id, delete the previous state file
                 if os.path.exists(path):
                     os.remove(path)

--- a/tests/agent/react/test_init_node.py
+++ b/tests/agent/react/test_init_node.py
@@ -1,0 +1,216 @@
+"""Tests for init_node.py module with conversational agent support."""
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.types import Overwrite
+from pydantic import BaseModel
+
+from uipath_langchain.agent.react.init_node import create_init_node
+
+
+class MockState(BaseModel):
+    """Mock state for testing init node."""
+
+    messages: list[Any] = []
+
+
+class TestCreateInitNodeConversational:
+    """Test cases for create_init_node with is_conversational=True."""
+
+    @pytest.fixture
+    def system_message(self):
+        """Fixture for a system message."""
+        return SystemMessage(
+            content="You are a helpful assistant. Current date: 2024-01-15"
+        )
+
+    @pytest.fixture
+    def new_system_message(self):
+        """Fixture for a new system message (simulating resume with new date)."""
+        return SystemMessage(
+            content="You are a helpful assistant. Current date: 2024-01-16"
+        )
+
+    @pytest.fixture
+    def user_message(self):
+        """Fixture for a user message."""
+        return HumanMessage(content="Hello, how are you?")
+
+    @pytest.fixture
+    def empty_state(self):
+        """Fixture for state with no messages."""
+        return MockState(messages=[])
+
+    def test_conversational_empty_state_returns_overwrite(
+        self, system_message, user_message
+    ):
+        """Conversational mode with empty state should use Overwrite with new messages."""
+        messages = [system_message, user_message]
+        init_node = create_init_node(
+            messages, input_schema=None, is_conversational=True
+        )
+        state = MockState(messages=[])
+
+        result = init_node(state)
+
+        assert "messages" in result
+        assert isinstance(result["messages"], Overwrite)
+        # The Overwrite wraps the message list
+        overwrite_value = result["messages"].value
+        assert len(overwrite_value) == 2
+        assert overwrite_value[0] == system_message
+        assert overwrite_value[1] == user_message
+
+    def test_conversational_resume_replaces_system_message(
+        self, new_system_message, user_message
+    ):
+        """Conversational mode should replace old SystemMessage when resuming."""
+        old_system_message = SystemMessage(content="Old system prompt")
+        old_human_message = HumanMessage(content="Previous user message")
+
+        # State has existing conversation with system message at position 0
+        state = MockState(messages=[old_system_message, old_human_message])
+
+        # New messages to be applied (new system message with updated date)
+        new_messages = [new_system_message, user_message]
+        init_node = create_init_node(
+            new_messages, input_schema=None, is_conversational=True
+        )
+
+        result = init_node(state)
+
+        assert isinstance(result["messages"], Overwrite)
+        overwrite_value = result["messages"].value
+        # Should have: new_system_message, user_message, old_human_message (old system message removed)
+        assert len(overwrite_value) == 3
+        assert overwrite_value[0] == new_system_message
+        assert overwrite_value[1] == user_message
+        assert overwrite_value[2] == old_human_message
+
+    def test_conversational_resume_preserves_non_system_first_message(
+        self, system_message, user_message
+    ):
+        """Conversational mode should preserve all messages if first is not SystemMessage."""
+        # State starts with HumanMessage (not SystemMessage)
+        existing_human_message = HumanMessage(content="Previous query")
+        state = MockState(messages=[existing_human_message])
+
+        new_messages = [system_message, user_message]
+        init_node = create_init_node(
+            new_messages, input_schema=None, is_conversational=True
+        )
+
+        result = init_node(state)
+
+        assert isinstance(result["messages"], Overwrite)
+        overwrite_value = result["messages"].value
+        # Should have: system_message, user_message, existing_human_message
+        assert len(overwrite_value) == 3
+        assert overwrite_value[0] == system_message
+        assert overwrite_value[1] == user_message
+        assert overwrite_value[2] == existing_human_message
+
+    def test_conversational_with_callable_messages(self):
+        """Conversational mode should work with callable message generators."""
+
+        def message_generator(state):
+            return [
+                SystemMessage(
+                    content=f"System for state with {len(state.messages)} messages"
+                ),
+                HumanMessage(content="New query"),
+            ]
+
+        state = MockState(messages=[])
+        init_node = create_init_node(
+            message_generator, input_schema=None, is_conversational=True
+        )
+
+        result = init_node(state)
+
+        assert isinstance(result["messages"], Overwrite)
+        overwrite_value = result["messages"].value
+        assert len(overwrite_value) == 2
+        assert "System for state with 0 messages" in overwrite_value[0].content
+
+
+class TestCreateInitNodeNonConversational:
+    """Test cases for create_init_node with is_conversational=False (default)."""
+
+    @pytest.fixture
+    def system_message(self):
+        """Fixture for a system message."""
+        return SystemMessage(content="You are a helpful assistant.")
+
+    @pytest.fixture
+    def user_message(self):
+        """Fixture for a user message."""
+        return HumanMessage(content="Hello")
+
+    def test_non_conversational_returns_list_not_overwrite(
+        self, system_message, user_message
+    ):
+        """Non-conversational mode should return list, not Overwrite."""
+        messages = [system_message, user_message]
+        init_node = create_init_node(
+            messages, input_schema=None, is_conversational=False
+        )
+        state = MockState(messages=[])
+
+        result = init_node(state)
+
+        assert "messages" in result
+        # Non-conversational mode returns a list (for add_messages reducer to append)
+        assert isinstance(result["messages"], list)
+        assert not isinstance(result["messages"], Overwrite)
+        assert len(result["messages"]) == 2
+
+    def test_non_conversational_default_behavior(self, system_message, user_message):
+        """Default behavior (no is_conversational param) should be non-conversational."""
+        messages = [system_message, user_message]
+        init_node = create_init_node(messages, input_schema=None)
+        state = MockState(messages=[])
+
+        result = init_node(state)
+
+        assert isinstance(result["messages"], list)
+        assert not isinstance(result["messages"], Overwrite)
+
+
+class TestCreateInitNodeInnerState:
+    """Test cases for init node inner_state initialization."""
+
+    def test_returns_inner_state_with_job_attachments(self):
+        """Init node should return inner_state with job_attachments dict."""
+        messages: list[SystemMessage | HumanMessage] = [
+            SystemMessage(content="System"),
+            HumanMessage(content="Query"),
+        ]
+        init_node = create_init_node(
+            messages, input_schema=None, is_conversational=False
+        )
+        state = MockState(messages=[])
+
+        result = init_node(state)
+
+        assert "inner_state" in result
+        assert "job_attachments" in result["inner_state"]
+        assert isinstance(result["inner_state"]["job_attachments"], dict)
+
+    def test_inner_state_present_in_conversational_mode(self):
+        """Inner state should also be present in conversational mode."""
+        messages: list[SystemMessage | HumanMessage] = [
+            SystemMessage(content="System"),
+            HumanMessage(content="Query"),
+        ]
+        init_node = create_init_node(
+            messages, input_schema=None, is_conversational=True
+        )
+        state = MockState(messages=[])
+
+        result = init_node(state)
+
+        assert "inner_state" in result
+        assert "job_attachments" in result["inner_state"]

--- a/tests/agent/react/test_router_conversational.py
+++ b/tests/agent/react/test_router_conversational.py
@@ -1,0 +1,172 @@
+"""Tests for router_conversational.py module."""
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import BaseModel
+
+from uipath_langchain.agent.exceptions import AgentNodeRoutingException
+from uipath_langchain.agent.react.router_conversational import (
+    create_route_agent_conversational,
+)
+from uipath_langchain.agent.react.types import AgentGraphNode
+
+
+class MockInnerState(BaseModel):
+    """Mock inner state for testing."""
+
+    termination: Any = None
+    job_attachments: dict[str, Any] = {}
+
+
+class MockAgentGraphState(BaseModel):
+    """Mock state compatible with AgentGraphState structure."""
+
+    messages: list[Any] = []
+    inner_state: MockInnerState = MockInnerState()
+
+
+class TestCreateRouteAgentConversational:
+    """Test cases for create_route_agent_conversational function."""
+
+    @pytest.fixture
+    def route_function(self):
+        """Fixture for the conversational routing function."""
+        return create_route_agent_conversational()
+
+    @pytest.fixture
+    def state_with_single_tool_call(self):
+        """Fixture for state with a single tool call."""
+        ai_message = AIMessage(
+            content="Using tool",
+            tool_calls=[
+                {"name": "search_tool", "args": {"query": "test"}, "id": "call_1"}
+            ],
+        )
+        return MockAgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+    @pytest.fixture
+    def state_with_multiple_tool_calls(self):
+        """Fixture for state with multiple parallel tool calls."""
+        ai_message = AIMessage(
+            content="Using multiple tools",
+            tool_calls=[
+                {"name": "search_tool", "args": {"query": "test"}, "id": "call_1"},
+                {"name": "calculator_tool", "args": {"expr": "2+2"}, "id": "call_2"},
+                {"name": "weather_tool", "args": {"city": "NYC"}, "id": "call_3"},
+            ],
+        )
+        return MockAgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+    @pytest.fixture
+    def state_with_no_tool_calls(self):
+        """Fixture for state with AI message but no tool calls."""
+        ai_message = AIMessage(content="I have answered your question.")
+        return MockAgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+    @pytest.fixture
+    def state_with_empty_tool_calls(self):
+        """Fixture for state with empty tool_calls list."""
+        ai_message = AIMessage(content="Response", tool_calls=[])
+        return MockAgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+    @pytest.fixture
+    def empty_state(self):
+        """Fixture for state with no messages."""
+        return MockAgentGraphState(messages=[])
+
+    @pytest.fixture
+    def state_with_human_last(self):
+        """Fixture for state with HumanMessage as last message."""
+        return MockAgentGraphState(
+            messages=[
+                AIMessage(content="response"),
+                HumanMessage(content="follow-up"),
+            ]
+        )
+
+    def test_routes_to_single_tool_node(
+        self, route_function, state_with_single_tool_call
+    ):
+        """Should return list with single tool name when AI message has one tool call."""
+        result = route_function(state_with_single_tool_call)
+
+        assert result == ["search_tool"]
+        assert isinstance(result, list)
+
+    def test_routes_to_multiple_tool_nodes(
+        self, route_function, state_with_multiple_tool_calls
+    ):
+        """Should return list of tool names for parallel execution."""
+        result = route_function(state_with_multiple_tool_calls)
+
+        assert result == ["search_tool", "calculator_tool", "weather_tool"]
+        assert len(result) == 3
+
+    def test_routes_to_terminate_when_no_tool_calls(
+        self, route_function, state_with_no_tool_calls
+    ):
+        """Should route to TERMINATE when AI message has no tool calls."""
+        result = route_function(state_with_no_tool_calls)
+
+        assert result == AgentGraphNode.TERMINATE
+
+    def test_routes_to_terminate_when_empty_tool_calls(
+        self, route_function, state_with_empty_tool_calls
+    ):
+        """Should route to TERMINATE when tool_calls list is empty."""
+        result = route_function(state_with_empty_tool_calls)
+
+        assert result == AgentGraphNode.TERMINATE
+
+    def test_empty_messages_raises_exception(self, route_function, empty_state):
+        """Should raise AgentNodeRoutingException for empty messages."""
+        with pytest.raises(
+            AgentNodeRoutingException,
+            match="No messages in state",
+        ):
+            route_function(empty_state)
+
+    def test_non_ai_last_message_raises_exception(
+        self, route_function, state_with_human_last
+    ):
+        """Should raise AgentNodeRoutingException when last message is not AIMessage."""
+        with pytest.raises(
+            AgentNodeRoutingException,
+            match="Last message is not AIMessage",
+        ):
+            route_function(state_with_human_last)
+
+    def test_preserves_tool_call_order(self, route_function):
+        """Should preserve the order of tool calls in the result."""
+        ai_message = AIMessage(
+            content="Using tools in order",
+            tool_calls=[
+                {"name": "first_tool", "args": {}, "id": "call_1"},
+                {"name": "second_tool", "args": {}, "id": "call_2"},
+                {"name": "third_tool", "args": {}, "id": "call_3"},
+            ],
+        )
+        state = MockAgentGraphState(messages=[ai_message])
+
+        result = route_function(state)
+
+        assert result == ["first_tool", "second_tool", "third_tool"]
+
+
+class TestRouteAgentConversationalFactory:
+    """Test cases for the factory function behavior."""
+
+    def test_returns_callable(self):
+        """Should return a callable routing function."""
+        result = create_route_agent_conversational()
+
+        assert callable(result)
+
+    def test_each_call_returns_new_function(self):
+        """Should return a new function instance each time."""
+        func1 = create_route_agent_conversational()
+        func2 = create_route_agent_conversational()
+
+        assert func1 is not func2

--- a/tests/agent/react/test_router_utils.py
+++ b/tests/agent/react/test_router_utils.py
@@ -1,0 +1,92 @@
+"""Tests for router_utils.py module."""
+
+import pytest
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage
+
+from uipath_langchain.agent.exceptions import AgentNodeRoutingException
+from uipath_langchain.agent.react.router_utils import validate_last_message_is_AI
+
+
+class TestValidateLastMessageIsAI:
+    """Test cases for validate_last_message_is_AI function."""
+
+    def test_empty_messages_raises_exception(self):
+        """Should raise AgentNodeRoutingException for empty message list."""
+        with pytest.raises(
+            AgentNodeRoutingException,
+            match="No messages in state - cannot route after agent",
+        ):
+            validate_last_message_is_AI([])
+
+    def test_human_message_raises_exception(self):
+        """Should raise AgentNodeRoutingException when last message is HumanMessage."""
+        messages: list[AnyMessage] = [HumanMessage(content="Hello")]
+
+        with pytest.raises(
+            AgentNodeRoutingException,
+            match="Last message is not AIMessage \\(type: HumanMessage\\)",
+        ):
+            validate_last_message_is_AI(messages)
+
+    def test_system_message_raises_exception(self):
+        """Should raise AgentNodeRoutingException when last message is SystemMessage."""
+        messages: list[AnyMessage] = [
+            SystemMessage(content="You are a helpful assistant")
+        ]
+
+        with pytest.raises(
+            AgentNodeRoutingException,
+            match="Last message is not AIMessage \\(type: SystemMessage\\)",
+        ):
+            validate_last_message_is_AI(messages)
+
+    def test_ai_message_returns_message(self):
+        """Should return the AIMessage when it is the last message."""
+        ai_message = AIMessage(content="Hello, how can I help?")
+        messages: list[AnyMessage] = [ai_message]
+
+        result = validate_last_message_is_AI(messages)
+
+        assert result is ai_message
+        assert isinstance(result, AIMessage)
+
+    def test_ai_message_with_tool_calls_returns_message(self):
+        """Should return AIMessage with tool calls when it is the last message."""
+        ai_message = AIMessage(
+            content="Using tool",
+            tool_calls=[{"name": "test_tool", "args": {}, "id": "call_1"}],
+        )
+        messages: list[AnyMessage] = [HumanMessage(content="query"), ai_message]
+
+        result = validate_last_message_is_AI(messages)
+
+        assert result is ai_message
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "test_tool"
+        assert result.tool_calls[0]["id"] == "call_1"
+
+    def test_mixed_messages_with_ai_last(self):
+        """Should return the last AIMessage in a mixed message list."""
+        ai_message = AIMessage(content="Final response")
+        messages: list[AnyMessage] = [
+            SystemMessage(content="System prompt"),
+            HumanMessage(content="User query"),
+            ai_message,
+        ]
+
+        result = validate_last_message_is_AI(messages)
+
+        assert result is ai_message
+
+    def test_mixed_messages_with_human_last_raises_exception(self):
+        """Should raise when HumanMessage follows AIMessage."""
+        messages: list[AnyMessage] = [
+            AIMessage(content="AI response"),
+            HumanMessage(content="Follow-up question"),
+        ]
+
+        with pytest.raises(
+            AgentNodeRoutingException,
+            match="Last message is not AIMessage \\(type: HumanMessage\\)",
+        ):
+            validate_last_message_is_AI(messages)

--- a/tests/agent/react/test_terminate_node.py
+++ b/tests/agent/react/test_terminate_node.py
@@ -1,0 +1,284 @@
+"""Tests for terminate_node.py module with conversational agent support."""
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import BaseModel
+from uipath.agent.react import END_EXECUTION_TOOL, RAISE_ERROR_TOOL
+
+from uipath_langchain.agent.exceptions import (
+    AgentNodeRoutingException,
+    AgentTerminationException,
+)
+from uipath_langchain.agent.react.terminate_node import create_terminate_node
+from uipath_langchain.agent.react.types import (
+    AgentTermination,
+    AgentTerminationSource,
+)
+
+
+class MockInnerState(BaseModel):
+    """Mock inner state for testing."""
+
+    termination: AgentTermination | None = None
+    job_attachments: dict[str, Any] = {}
+
+
+class MockAgentGraphState(BaseModel):
+    """Mock state compatible with AgentGraphState structure."""
+
+    messages: list[Any] = []
+    inner_state: MockInnerState = MockInnerState()
+
+
+class TestTerminateNodeConversational:
+    """Test cases for create_terminate_node with is_conversational=True."""
+
+    @pytest.fixture
+    def terminate_node(self):
+        """Fixture for conversational terminate node."""
+        return create_terminate_node(response_schema=None, is_conversational=True)
+
+    @pytest.fixture
+    def state_with_ai_message(self):
+        """Fixture for state with AI message (no tool calls)."""
+        return MockAgentGraphState(
+            messages=[AIMessage(content="Here is my response to your question.")]
+        )
+
+    @pytest.fixture
+    def state_with_human_message(self):
+        """Fixture for state with human message as last."""
+        return MockAgentGraphState(messages=[HumanMessage(content="User message")])
+
+    @pytest.fixture
+    def state_with_termination(self):
+        """Fixture for state with termination set (e.g., escalation)."""
+        termination = AgentTermination(
+            source=AgentTerminationSource.ESCALATION,
+            title="Escalation required",
+            detail="User requested human assistance",
+        )
+        return MockAgentGraphState(
+            messages=[AIMessage(content="response")],
+            inner_state=MockInnerState(termination=termination),
+        )
+
+    def test_conversational_returns_none_no_tool_calls(
+        self, terminate_node, state_with_ai_message
+    ):
+        """Conversational mode should return None when AI has no tool calls."""
+        result = terminate_node(state_with_ai_message)
+
+        assert result is None
+
+    def test_conversational_skips_ai_message_validation(
+        self, terminate_node, state_with_human_message
+    ):
+        """Conversational mode should not validate that last message is AIMessage."""
+        # This should not raise, unlike non-conversational mode
+        result = terminate_node(state_with_human_message)
+
+        assert result is None
+
+    def test_conversational_handles_termination(
+        self, terminate_node, state_with_termination
+    ):
+        """Conversational mode should still handle state.inner_state.termination."""
+        with pytest.raises(AgentTerminationException) as exc_info:
+            terminate_node(state_with_termination)
+
+        assert "Escalation required" in exc_info.value.error_info.title
+
+    def test_conversational_ignores_end_execution_tool(self):
+        """Conversational mode should ignore END_EXECUTION tool calls."""
+        terminate_node = create_terminate_node(
+            response_schema=None, is_conversational=True
+        )
+        ai_message = AIMessage(
+            content="Done",
+            tool_calls=[
+                {
+                    "name": END_EXECUTION_TOOL.name,
+                    "args": {"result": "completed"},
+                    "id": "call_1",
+                }
+            ],
+        )
+        state = MockAgentGraphState(messages=[ai_message])
+
+        # Should return None, not process the tool call
+        result = terminate_node(state)
+
+        assert result is None
+
+
+class TestTerminateNodeNonConversational:
+    """Test cases for create_terminate_node with is_conversational=False (default)."""
+
+    @pytest.fixture
+    def terminate_node(self):
+        """Fixture for non-conversational terminate node."""
+        return create_terminate_node(response_schema=None, is_conversational=False)
+
+    @pytest.fixture
+    def state_with_end_execution(self):
+        """Fixture for state with END_EXECUTION tool call."""
+        ai_message = AIMessage(
+            content="Task completed",
+            tool_calls=[
+                {
+                    "name": END_EXECUTION_TOOL.name,
+                    "args": {"success": True, "message": "Task completed successfully"},
+                    "id": "call_1",
+                }
+            ],
+        )
+        return MockAgentGraphState(messages=[ai_message])
+
+    @pytest.fixture
+    def state_with_raise_error(self):
+        """Fixture for state with RAISE_ERROR tool call."""
+        ai_message = AIMessage(
+            content="Error occurred",
+            tool_calls=[
+                {
+                    "name": RAISE_ERROR_TOOL.name,
+                    "args": {
+                        "message": "Something went wrong",
+                        "details": "Additional info",
+                    },
+                    "id": "call_1",
+                }
+            ],
+        )
+        return MockAgentGraphState(messages=[ai_message])
+
+    @pytest.fixture
+    def state_with_human_last(self):
+        """Fixture for state with HumanMessage as last message."""
+        return MockAgentGraphState(messages=[HumanMessage(content="User message")])
+
+    @pytest.fixture
+    def state_with_no_control_flow_tool(self):
+        """Fixture for state with AI message but no control flow tool."""
+        ai_message = AIMessage(
+            content="Using regular tool",
+            tool_calls=[{"name": "regular_tool", "args": {}, "id": "call_1"}],
+        )
+        return MockAgentGraphState(messages=[ai_message])
+
+    @pytest.fixture
+    def state_with_termination(self):
+        """Fixture for state with escalation termination."""
+        termination = AgentTermination(
+            source=AgentTerminationSource.ESCALATION,
+            title="Needs human review",
+            detail="Complex issue",
+        )
+        return MockAgentGraphState(
+            messages=[AIMessage(content="response")],
+            inner_state=MockInnerState(termination=termination),
+        )
+
+    def test_non_conversational_handles_end_execution(
+        self, terminate_node, state_with_end_execution
+    ):
+        """Non-conversational mode should process END_EXECUTION tool and return validated output."""
+        result = terminate_node(state_with_end_execution)
+
+        assert result is not None
+        assert isinstance(result, dict)
+        assert "success" in result
+        assert result["success"] is True
+        assert result["message"] == "Task completed successfully"
+
+    def test_non_conversational_handles_raise_error(
+        self, terminate_node, state_with_raise_error
+    ):
+        """Non-conversational mode should process RAISE_ERROR tool and raise exception."""
+        with pytest.raises(AgentTerminationException) as exc_info:
+            terminate_node(state_with_raise_error)
+
+        assert "Something went wrong" in exc_info.value.error_info.title
+
+    def test_non_conversational_validates_ai_message(
+        self, terminate_node, state_with_human_last
+    ):
+        """Non-conversational mode should raise if last message is not AIMessage."""
+        with pytest.raises(
+            AgentNodeRoutingException,
+            match="Expected last message to be AIMessage, got HumanMessage",
+        ):
+            terminate_node(state_with_human_last)
+
+    def test_non_conversational_raises_on_no_control_flow_tool(
+        self, terminate_node, state_with_no_control_flow_tool
+    ):
+        """Non-conversational mode should raise if no control flow tool found."""
+        with pytest.raises(
+            AgentNodeRoutingException,
+            match="No control flow tool call found in terminate node",
+        ):
+            terminate_node(state_with_no_control_flow_tool)
+
+    def test_non_conversational_handles_termination_first(
+        self, terminate_node, state_with_termination
+    ):
+        """Non-conversational mode should check termination before tool calls."""
+        with pytest.raises(AgentTerminationException) as exc_info:
+            terminate_node(state_with_termination)
+
+        assert "Needs human review" in exc_info.value.error_info.title
+
+
+class TestTerminateNodeWithResponseSchema:
+    """Test cases for terminate node with custom response schema."""
+
+    def test_end_execution_with_custom_schema(self):
+        """Should validate output against custom response schema."""
+
+        class CustomOutput(BaseModel):
+            status: str
+            count: int
+
+        terminate_node = create_terminate_node(
+            response_schema=CustomOutput, is_conversational=False
+        )
+        ai_message = AIMessage(
+            content="Done",
+            tool_calls=[
+                {
+                    "name": END_EXECUTION_TOOL.name,
+                    "args": {"status": "completed", "count": 42},
+                    "id": "call_1",
+                }
+            ],
+        )
+        state = MockAgentGraphState(messages=[ai_message])
+
+        result = terminate_node(state)
+
+        assert result == {"status": "completed", "count": 42}
+
+
+class TestTerminateNodeFactory:
+    """Test cases for the factory function behavior."""
+
+    def test_returns_callable(self):
+        """Should return a callable terminate node function."""
+        result = create_terminate_node(response_schema=None, is_conversational=False)
+
+        assert callable(result)
+
+    def test_default_is_non_conversational(self):
+        """Default should be non-conversational mode."""
+        # Create without is_conversational param
+        terminate_node = create_terminate_node(response_schema=None)
+
+        # Should behave as non-conversational (raise on non-AI last message)
+        state = MockAgentGraphState(messages=[HumanMessage(content="test")])
+
+        with pytest.raises(AgentNodeRoutingException):
+            terminate_node(state)

--- a/uv.lock
+++ b/uv.lock
@@ -3250,7 +3250,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.14"
+version = "2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -3271,9 +3271,9 @@ dependencies = [
     { name = "uipath-core" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/a7/31ab1ead2d40bf966476a888803f8b4d213b7248a2259aa2cf1ebd05f7b9/uipath-2.4.14.tar.gz", hash = "sha256:8fa1fd39c87ea61fccf7dd61add0ba574912ea2b2b600f33baf433f651759b19", size = 3653781, upload-time = "2026-01-13T16:30:43.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/62/de6137c448a4436876e0e57c3cbd08718a7b45c998bdb9e81865ce0c082c/uipath-2.5.tar.gz", hash = "sha256:6ef338d27763e03098d65318fbf126f8a0010f5aa07136ee0486a8283e951ad1", size = 3883309, upload-time = "2026-01-15T07:02:16.8Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/f0/321e006b7af7a84195332a7d40f26ed0d07812c92512b90aa38fd2d1e827/uipath-2.4.14-py3-none-any.whl", hash = "sha256:613f4af6ed5823c2e60e973364e47798e8d187393290fb1f95d7267455b42614", size = 431605, upload-time = "2026-01-13T16:30:40.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/8254f1941351b3ee9386d0b073fb3c033e7de9c67ba588a47d5511506e17/uipath-2.5-py3-none-any.whl", hash = "sha256:19f6b5d7408e32e0a9df869dc041a158919758288fdd26bbfe337b9dea12373c", size = 437244, upload-time = "2026-01-15T07:02:14.911Z" },
 ]
 
 [[package]]
@@ -3292,7 +3292,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.3.5"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -3359,8 +3359,8 @@ requires-dist = [
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.56" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.4.14,<2.5.0" },
-    { name = "uipath-runtime", specifier = ">=0.4.1,<0.5.0" },
+    { name = "uipath", specifier = ">=2.5.0,<2.6.0" },
+    { name = "uipath-runtime", specifier = ">=0.5.0,<0.6.0" },
 ]
 provides-extras = ["vertex", "bedrock"]
 
@@ -3382,14 +3382,14 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.4.1"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/2a/8373a1c1118442b000c5a89e864a61e8548e6e1575c30fb21501b0e60652/uipath_runtime-0.4.1.tar.gz", hash = "sha256:ddcb26c02833993432a4c19c3306a55858a14afecaffcf32195601564bb44585", size = 102875, upload-time = "2026-01-13T13:34:50.803Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/e3/ee386d7de03efe8708a561e52b9a417bfdef61fc87b79fae8b72d6e1e2e6/uipath_runtime-0.5.0.tar.gz", hash = "sha256:e2340a74195b9f665e64e2cb8ca8fd3bfff5e6d062d92000270604758c12145a", size = 103202, upload-time = "2026-01-15T05:01:26.04Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/58/14c89ba528c4e69683d0e19b43026bc8102dab02ec66c4a0d9f2a0fc4ae9/uipath_runtime-0.4.1-py3-none-any.whl", hash = "sha256:b10c7072246066c8e525eb602a9e04f5497a7da6af871d1bd27693fb9e910d7b", size = 39834, upload-time = "2026-01-13T13:34:49.421Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3e/57464bb5ef65145cd898592fab4b5219256e6a2f96c5056b221bf6fe9cbc/uipath_runtime-0.5.0-py3-none-any.whl", hash = "sha256:3de704e691efab9338658c897e9a50eafa498fab15d622ef4de28df586989fdb", size = 40185, upload-time = "2026-01-15T05:01:24.661Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Depends on https://github.com/UiPath/uipath-python/pull/1087 and https://github.com/UiPath/uipath-runtime-python/pull/65 (is causing checks to fail)

Adds support for conversation agents:
* state is initialized with input messages received when the job is started. init node overwrites messages in state so that the system prompt message comes first.
* no tools are bound, the agent can just respond without invoking a tool
* only agent response messages are sent to cas (or both coded and autonomous conversational agents). CAS doesn't expect the system message and the user message is sent from the client.
*  don't delete state.db if keep_state_file context option is set (the cli can set this using --keep-state-file). This allows conversational agents to accumulate conversation history across multiple runs.
