### PR TITLE
feat: handle guardrail validation reason

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.4.5"
+version = "0.4.6"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3297,7 +3297,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
# Handle Guardrail Validation Reason

## Summary
Updated `_create_validation_command` to properly handle guardrail validation reason with strict typing.

## Changes
- **Strict type annotation**: Function parameter now uses `GuardrailValidationResult` type instead of untyped `result`
- **Parameter rename**: Changed `result` to `guardrail_result` to avoid confusion with the `result` attribute
- **Simplified logic**: Removed unnecessary fallback handling, now directly accesses `guardrail_result.reason`

## Benefits
- **Type safety**: Strict typing ensures correct usage and better IDE support
- **Clearer code**: More descriptive parameter name and direct access to reason field
- **Proper handling**: Validation reason is now properly extracted and passed to the command

<img width="1480" height="633" alt="Screenshot 2026-01-16 at 12 54 33" src="https://github.com/user-attachments/assets/bcc2161b-fd73-415c-b539-9c8a6f079b36" />

