### PR TITLE
refactor: remove agent termination graph specific handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.4.13"
+version = "0.4.14"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/terminate_node.py
+++ b/src/uipath_langchain/agent/react/terminate_node.py
@@ -13,7 +13,7 @@ from ..exceptions import (
     AgentNodeRoutingException,
     AgentTerminationException,
 )
-from .types import AgentGraphState, AgentTermination
+from .types import AgentGraphState
 
 
 def _handle_end_execution(
@@ -36,30 +36,17 @@ def _handle_raise_error(args: dict[str, Any]) -> NoReturn:
     )
 
 
-def _handle_agent_termination(termination: AgentTermination) -> NoReturn:
-    """Handle Command-based termination."""
-    raise AgentTerminationException(
-        code=UiPathErrorCode.EXECUTION_ERROR,
-        title=termination.title,
-        detail=termination.detail,
-    )
-
-
 def create_terminate_node(
     response_schema: type[BaseModel] | None = None, is_conversational: bool = False
 ):
     """Handles Agent Graph termination for multiple sources and output or error propagation to Orchestrator.
 
     Termination scenarios:
-    1. Command based termination with information in state (e.g: escalation)
-    2. LLM-initiated termination (END_EXECUTION_TOOL)
-    3. LLM-initiated error (RAISE_ERROR_TOOL)
+    1. LLM-initiated termination (END_EXECUTION_TOOL)
+    2. LLM-initiated error (RAISE_ERROR_TOOL)
     """
 
     def terminate_node(state: AgentGraphState):
-        if state.inner_state.termination:
-            _handle_agent_termination(state.inner_state.termination)
-
         if not is_conversational:
             last_message = state.messages[-1]
             if not isinstance(last_message, AIMessage):

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -12,21 +12,8 @@ from uipath_langchain.agent.react.reducers import add_job_attachments, merge_obj
 FLOW_CONTROL_TOOLS = [END_EXECUTION_TOOL.name, RAISE_ERROR_TOOL.name]
 
 
-class AgentTerminationSource(StrEnum):
-    ESCALATION = "escalation"
-
-
-class AgentTermination(BaseModel):
-    """Agent Graph Termination model."""
-
-    source: AgentTerminationSource
-    title: str
-    detail: str = ""
-
-
 class InnerAgentGraphState(BaseModel):
     job_attachments: Annotated[dict[str, Attachment], add_job_attachments] = {}
-    termination: AgentTermination | None = None
 
 
 class InnerAgentGuardrailsGraphState(InnerAgentGraphState):

--- a/src/uipath_langchain/agent/wrappers/job_attachment_wrapper.py
+++ b/src/uipath_langchain/agent/wrappers/job_attachment_wrapper.py
@@ -11,10 +11,12 @@ from uipath_langchain.agent.react.job_attachments import (
     replace_job_attachment_ids,
 )
 from uipath_langchain.agent.react.types import AgentGraphState
-from uipath_langchain.agent.tools.tool_node import AsyncToolWrapperType
+from uipath_langchain.agent.tools.tool_node import AsyncToolWrapperWithState
 
 
-def get_job_attachment_wrapper(output_type: Any | None = None) -> AsyncToolWrapperType:
+def get_job_attachment_wrapper(
+    output_type: Any | None = None,
+) -> AsyncToolWrapperWithState:
     """Create a tool wrapper that handles job attachments in both tool inputs and outputs.
 
     This wrapper performs two main functions:

--- a/uv.lock
+++ b/uv.lock
@@ -3297,7 +3297,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.4.13"
+version = "0.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## What changed?

- remove agent termination from state and propagation from escalation_tool
- refactor wrappers to not enforce state in the contract if not needed 