### PR TITLE
fix: fix hitl redirect link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.5.3"
+version = "0.5.4"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.6.4,<2.7.0",
+    "uipath>=2.6.6,<2.7.0",
     "uipath-runtime>=0.6.0, <0.7.0",
     "langgraph>=1.0.0, <2.0.0",
     "langchain-core>=1.2.5, <2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3255,7 +3255,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.6.4"
+version = "2.6.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -3276,9 +3276,9 @@ dependencies = [
     { name = "uipath-core" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/51/47a3dfced6fbcdede0b3108840a0589221a6b56a13b657cf6f0615c26361/uipath-2.6.4.tar.gz", hash = "sha256:a817d7c0c2559067602cfc9bced20cf69abf024927f1bb8b7042ff63f38aae07", size = 3913050, upload-time = "2026-01-26T13:59:09.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/49d5d9435d67a3e57d8d4057494268df380c0d613fab5b061247fa6b1973/uipath-2.6.13.tar.gz", hash = "sha256:db87c08670a7d111916541eb654100441a8978bad5e1d039b176499643ca12f1", size = 3921257, upload-time = "2026-01-27T12:25:50.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/73/52eda03edc9e3e86ce0cfd11d4768a190af61c48a546f04bb723097ade4c/uipath-2.6.4-py3-none-any.whl", hash = "sha256:76e41d955ff42f11889cea62af0c46d78f6c64a319468a67880e8be445b6f499", size = 453435, upload-time = "2026-01-26T13:59:07.799Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8a/0a0dd2a2d6adbe31e1d7b86e144470293db0a5ec9350b6deb6c8ae8d7e6b/uipath-2.6.13-py3-none-any.whl", hash = "sha256:aca4ca8dbf9f8abebeda91fb1cbd1a794f2d03b31f2653a53064eb7ead84c3f6", size = 457987, upload-time = "2026-01-27T12:25:48.723Z" },
 ]
 
 [[package]]
@@ -3297,7 +3297,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -3364,7 +3364,7 @@ requires-dist = [
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.56" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.6.4,<2.7.0" },
+    { name = "uipath", specifier = ">=2.6.6,<2.7.0" },
     { name = "uipath-runtime", specifier = ">=0.6.0,<0.7.0" },
 ]
 provides-extras = ["vertex", "bedrock"]
@@ -3387,14 +3387,14 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e3/eb104949fd2bcd2a96870ca3ebda0229f23ff3768db3b6c1e0f33864283c/uipath_runtime-0.6.0.tar.gz", hash = "sha256:3b000ffe72ab2126ba6fa9f818220e35f60ea120412a8bbd2e18119b4b730184", size = 103627, upload-time = "2026-01-25T15:19:04.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/48/3c518940ddf54b675930c8aa1e1dade9aa99a42840ebe849e91e9f73edc1/uipath_runtime-0.6.1.tar.gz", hash = "sha256:af6753ee233a887ac1d88724bdd656a2105a2e3b5d75fb88fd24e96ec33398b9", size = 103622, upload-time = "2026-01-27T11:41:11.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/d1/2207f96ee870ca2fd1a76ec5c4ae864f55813f4562adab606cd9d30f4b35/uipath_runtime-0.6.0-py3-none-any.whl", hash = "sha256:cb78420475fa355d57c98fcbe731b5c8213a44cdc886b14ee2ed7fd78da0d7a8", size = 40764, upload-time = "2026-01-25T15:19:02.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/96/c1bbee3f82ccbffe650d51f1ab4e1f578bb83bebb44eacf9407ab9ef9de7/uipath_runtime-0.6.1-py3-none-any.whl", hash = "sha256:7ff5d0794611b30de02c9ef41960baa5f569beb997e89e98761be0c8bbf0b33c", size = 40762, upload-time = "2026-01-27T11:41:10.334Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Generate the hitl link based on new env variables https://github.com/UiPath/uipath-python/pull/1149 

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.5.4.dev1004242246",

  # Any version from PR
  "uipath-langchain>=0.5.4.dev1004240000,<0.5.4.dev1004250000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }
```