### PR TITLE
fix: handle overwrite serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath-langchain"
-version = "0.4.7"
+version = "0.4.8"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.5.6, <2.6.0",
-    "uipath-runtime>=0.5.0,<0.6.0",
+    "uipath>=2.5.9, <2.6.0",
+    "uipath-runtime>=0.5.1,<0.6.0",
     "langgraph>=1.0.0, <2.0.0",
     "langchain-core>=1.2.5, <2.0.0",
     "aiosqlite==0.21.0",

--- a/src/uipath_langchain/runtime/_serialize.py
+++ b/src/uipath_langchain/runtime/_serialize.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Any
 
+from langgraph.types import Overwrite
+
 
 def serialize_output(output: Any) -> Any:
     """
@@ -14,6 +16,10 @@ def serialize_output(output: Any) -> Any:
     """
     if output is None:
         return {}
+
+    # Handle LangGraph types
+    if isinstance(output, Overwrite):
+        return serialize_output(output.value)
 
     # Handle Pydantic models
     if hasattr(output, "model_dump"):

--- a/uv.lock
+++ b/uv.lock
@@ -3255,7 +3255,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.6"
+version = "2.5.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -3276,28 +3276,28 @@ dependencies = [
     { name = "uipath-core" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/7f/571e67d9290cb759c1596d914a17e7fca7b332fd2873607ae1b3ebec7ed8/uipath-2.5.6.tar.gz", hash = "sha256:69216863602c52df962e48a608aa9b207c8031ae7deed4d81af595851ed851d1", size = 3885366, upload-time = "2026-01-16T15:02:19.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/7f/9130cb7aeda2707f97934f06ba3c8b99e976554fa0091c6bcb1552a5646e/uipath-2.5.9.tar.gz", hash = "sha256:a86938070cf9cb6017ba28da9e73cbff49059f75437332c2a923deb6ac4d48ed", size = 3886104, upload-time = "2026-01-17T08:55:53.921Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/d9/4c3646e996f8deb4c0ee0a566f62890e88a7fc83780d42188cbdd818abaa/uipath-2.5.6-py3-none-any.whl", hash = "sha256:87f7b60d4ddf9db2e7bb23a47b7eba9b656407dccbf57ec8079c95957ff37272", size = 439150, upload-time = "2026-01-16T15:02:16.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/20/ea8d56df09a570fb2e397212857e2dc7acb7077406e4909cfd06cc54ab41/uipath-2.5.9-py3-none-any.whl", hash = "sha256:e94c1ac1713629fb8efd7bae47012bf36e82404235cece7bd03f5bc07d4090ed", size = 439441, upload-time = "2026-01-17T08:55:52.531Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.1.6"
+version = "0.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/da/842e9cbc70ce396fa8369803174d6ce58f9c85d1c9b57e1b96440d86ed77/uipath_core-0.1.6.tar.gz", hash = "sha256:0d1e2f305326d58e655c236bdd2755b6855cbeed2a8acf61e30bab3d056c83dd", size = 97409, upload-time = "2026-01-15T08:10:07.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c0/eb507053d9c90cdc7aea80c9df8bad9564b88622341e1996d4282583b1a3/uipath_core-0.1.8.tar.gz", hash = "sha256:e6d376a34b689774992c466e0d7c6e706c6669022d4cd2e66aafb114461140f8", size = 100928, upload-time = "2026-01-17T05:55:26.951Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/2f/611e5443d0bb4b570768db60c80df8a9fba197205a646ca2c0b67b3f236d/uipath_core-0.1.6-py3-none-any.whl", hash = "sha256:fb514a9b15d57ea9464e62c04f83e86e1b21cb0865012ecca947d2a458805a4a", size = 31238, upload-time = "2026-01-15T08:10:06.289Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/bf/327c4f052320227bbdf7636c902ac82e1424abda38288efef5d490a05766/uipath_core-0.1.8-py3-none-any.whl", hash = "sha256:0647b93c8629cd3af24a4e0b9b92bb346cb6b49a3867eccd24cb289c5c04109f", size = 31662, upload-time = "2026-01-17T05:55:25.361Z" },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -3364,8 +3364,8 @@ requires-dist = [
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.56" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.5.6,<2.6.0" },
-    { name = "uipath-runtime", specifier = ">=0.5.0,<0.6.0" },
+    { name = "uipath", specifier = ">=2.5.9,<2.6.0" },
+    { name = "uipath-runtime", specifier = ">=0.5.1,<0.6.0" },
 ]
 provides-extras = ["vertex", "bedrock"]
 
@@ -3387,14 +3387,14 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.5.0"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/e3/ee386d7de03efe8708a561e52b9a417bfdef61fc87b79fae8b72d6e1e2e6/uipath_runtime-0.5.0.tar.gz", hash = "sha256:e2340a74195b9f665e64e2cb8ca8fd3bfff5e6d062d92000270604758c12145a", size = 103202, upload-time = "2026-01-15T05:01:26.04Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/ce/d59fb6213c5a0d2efef0f2fa8274052187512d5e12703f6fd2fa5a66f132/uipath_runtime-0.5.1.tar.gz", hash = "sha256:04e649d07fc8caed134eec69ac6544eb6aa46ddf5bbc1b2191f2d599d627fd58", size = 103226, upload-time = "2026-01-17T00:16:43.961Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/3e/57464bb5ef65145cd898592fab4b5219256e6a2f96c5056b221bf6fe9cbc/uipath_runtime-0.5.0-py3-none-any.whl", hash = "sha256:3de704e691efab9338658c897e9a50eafa498fab15d622ef4de28df586989fdb", size = 40185, upload-time = "2026-01-15T05:01:24.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/cf/ddc5251090b640f11d7be85a6e7b78e95133d024ecd580e5f9dd20e3bc8e/uipath_runtime-0.5.1-py3-none-any.whl", hash = "sha256:0335326430952f31f30a79a989a93a9ad56bd8a69664539ecabd325fd1ac4adc", size = 40209, upload-time = "2026-01-17T00:16:42.3Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Fix Overwrite serialization in state events

`Overwrite` is a LangGraph type that bypasses the default reducer and replaces a channel's value directly instead of appending to it. We use it in conversational agents to replace the system message at the start of each turn.

The `serialize_output` function wasn't handling `Overwrite` properly — it fell through to the generic iterable handler, which failed to convert it and returned the raw object. This caused `json.dumps` to fail downstream.