### PR TITLE
fix(llm): fix vertex streaming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.5.7"
+version = "0.5.8"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3297,7 +3297,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.5.7"
+version = "0.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Description

ChatVertex  was simulating streaming because of a bug in llm gateway. We simulated `stream` with a simple `invoke` in the past. This Pr removes the fake `stream` and `astream` to allow the base to use actuall streaming.