### PR TITLE
fix: add correct guardrail validation info on the node state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.4.23"
+version = "0.4.24"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/guardrails/actions/escalate_action.py
+++ b/src/uipath_langchain/agent/guardrails/actions/escalate_action.py
@@ -89,7 +89,7 @@ class EscalateAction(GuardrailAction):
                 "GuardrailDescription": guardrail.description,
                 "Component": _build_component_name(scope, guarded_component_name),
                 "ExecutionStage": _execution_stage_to_string(execution_stage),
-                "GuardrailResult": state.inner_state.guardrail_validation_result,
+                "GuardrailResult": state.inner_state.guardrail_validation_details,
             }
 
             # Add tenant and trace URL if base_url is configured

--- a/src/uipath_langchain/agent/guardrails/actions/log_action.py
+++ b/src/uipath_langchain/agent/guardrails/actions/log_action.py
@@ -49,7 +49,7 @@ class LogAction(GuardrailAction):
         async def _node(_state: AgentGuardrailsGraphState) -> dict[str, Any]:
             message = (
                 self.message
-                or f"Guardrail [{guardrail.name}] validation failed for [{scope.name}] [{execution_stage.name}] with the following reason: {_state.inner_state.guardrail_validation_result}"
+                or f"Guardrail [{guardrail.name}] validation failed for [{scope.name}] [{execution_stage.name}] with the following reason: {_state.inner_state.guardrail_validation_details}"
             )
 
             logger.log(self.level, message)

--- a/src/uipath_langchain/agent/guardrails/guardrail_nodes.py
+++ b/src/uipath_langchain/agent/guardrails/guardrail_nodes.py
@@ -109,7 +109,10 @@ def _create_validation_command(
         return Command(
             goto=success_node,
             update={
-                "inner_state": {"guardrail_validation_result": guardrail_result.reason}
+                "inner_state": {
+                    "guardrail_validation_result": True,
+                    "guardrail_validation_details": guardrail_result.reason,
+                }
             },
         )
 
@@ -117,7 +120,10 @@ def _create_validation_command(
         return Command(
             goto=failure_node,
             update={
-                "inner_state": {"guardrail_validation_result": guardrail_result.reason}
+                "inner_state": {
+                    "guardrail_validation_result": False,
+                    "guardrail_validation_details": guardrail_result.reason,
+                }
             },
         )
 

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -28,7 +28,8 @@ class InnerAgentGraphState(BaseModel):
 class InnerAgentGuardrailsGraphState(InnerAgentGraphState):
     """Extended inner state for guardrails subgraph."""
 
-    guardrail_validation_result: Optional[str] = None
+    guardrail_validation_result: Optional[bool] = None
+    guardrail_validation_details: Optional[str] = None
     agent_result: Optional[dict[str, Any]] = None
 
 

--- a/tests/agent/guardrails/actions/test_escalate_action.py
+++ b/tests/agent/guardrails/actions/test_escalate_action.py
@@ -160,7 +160,7 @@ class TestEscalateAction:
             state = AgentGuardrailsGraphState(
                 messages=[HumanMessage(content="Test message")],
                 inner_state=InnerAgentGuardrailsGraphState(
-                    guardrail_validation_result="Validation failed"
+                    guardrail_validation_details="Validation failed"
                 ),
             )
         else:
@@ -171,7 +171,7 @@ class TestEscalateAction:
                     HumanMessage(content="Output message"),
                 ],
                 inner_state=InnerAgentGuardrailsGraphState(
-                    guardrail_validation_result="Validation failed"
+                    guardrail_validation_details="Validation failed"
                 ),
             )
 
@@ -238,7 +238,7 @@ class TestEscalateAction:
             ],
             inner_state=InnerAgentGuardrailsGraphState(
                 agent_result={"ok": True},
-                guardrail_validation_result="Validation failed",
+                guardrail_validation_details="Validation failed",
             ),
         )
 
@@ -855,7 +855,7 @@ class TestEscalateAction:
         )
         state = AgentGuardrailsGraphState(
             messages=[ai_message],
-            guardrail_validation_result="Validation failed",
+            guardrail_validation_details="Validation failed",
         )
 
         await node(state)

--- a/tests/agent/guardrails/actions/test_log_action.py
+++ b/tests/agent/guardrails/actions/test_log_action.py
@@ -39,7 +39,10 @@ class TestLogAction:
         with caplog.at_level(logging.ERROR):
             result = await node(
                 AgentGuardrailsGraphState(
-                    messages=[], guardrail_validation_result="ignored"
+                    messages=[],
+                    inner_state=InnerAgentGuardrailsGraphState(
+                        guardrail_validation_details="ignored"
+                    ),
                 )
             )
 
@@ -88,7 +91,8 @@ class TestLogAction:
                 AgentGuardrailsGraphState(
                     messages=[],
                     inner_state=InnerAgentGuardrailsGraphState(
-                        guardrail_validation_result="bad input"
+                        guardrail_validation_result=False,
+                        guardrail_validation_details="bad input",
                     ),
                 )
             )

--- a/tests/agent/guardrails/test_guardrail_nodes.py
+++ b/tests/agent/guardrails/test_guardrail_nodes.py
@@ -106,7 +106,10 @@ class TestLlmGuardrailNodes:
         cmd = await node(state)
         assert cmd.goto == "ok"
         assert cmd.update == {
-            "inner_state": {"guardrail_validation_result": "validation passed"}
+            "inner_state": {
+                "guardrail_validation_result": True,
+                "guardrail_validation_details": "validation passed",
+            }
         }
 
     @pytest.mark.asyncio
@@ -142,7 +145,10 @@ class TestLlmGuardrailNodes:
         cmd = await node(state)
         assert cmd.goto == "nope"
         assert cmd.update == {
-            "inner_state": {"guardrail_validation_result": "policy_violation"}
+            "inner_state": {
+                "guardrail_validation_result": False,
+                "guardrail_validation_details": "policy_violation",
+            }
         }
 
 
@@ -183,7 +189,10 @@ class TestAgentInitGuardrailNodes:
         cmd = await node(state)
         assert cmd.goto == "ok"
         assert cmd.update == {
-            "inner_state": {"guardrail_validation_result": "validation passed"}
+            "inner_state": {
+                "guardrail_validation_result": True,
+                "guardrail_validation_details": "validation passed",
+            }
         }
         assert fake.guardrails.last_text == "payload"
 
@@ -223,7 +232,10 @@ class TestAgentInitGuardrailNodes:
         cmd = await node(state)
         assert cmd.goto == "nope"
         assert cmd.update == {
-            "inner_state": {"guardrail_validation_result": "policy_violation"}
+            "inner_state": {
+                "guardrail_validation_result": False,
+                "guardrail_validation_details": "policy_violation",
+            }
         }
 
 
@@ -268,7 +280,10 @@ class TestAgentTerminateGuardrailNodes:
         cmd = await node(state)
         assert cmd.goto == "ok"
         assert cmd.update == {
-            "inner_state": {"guardrail_validation_result": "validation passed"}
+            "inner_state": {
+                "guardrail_validation_result": True,
+                "guardrail_validation_details": "validation passed",
+            }
         }
         assert fake.guardrails.last_text == str(agent_result)
 
@@ -311,7 +326,10 @@ class TestAgentTerminateGuardrailNodes:
         cmd = await node(state)
         assert cmd.goto == "nope"
         assert cmd.update == {
-            "inner_state": {"guardrail_validation_result": "policy_violation"}
+            "inner_state": {
+                "guardrail_validation_result": False,
+                "guardrail_validation_details": "policy_violation",
+            }
         }
 
 
@@ -360,7 +378,12 @@ class TestToolGuardrailNodes:
             )
             cmd = await node(state)
             assert cmd.goto == "ok"
-            assert cmd.update == {"inner_state": {"guardrail_validation_result": ""}}
+            assert cmd.update == {
+                "inner_state": {
+                    "guardrail_validation_result": True,
+                    "guardrail_validation_details": "",
+                }
+            }
             assert json.loads(fake.guardrails.last_text or "{}") == {"x": 1}
         else:
             state = AgentGuardrailsGraphState(
@@ -368,7 +391,12 @@ class TestToolGuardrailNodes:
             )
             cmd = await node(state)
             assert cmd.goto == "ok"
-            assert cmd.update == {"inner_state": {"guardrail_validation_result": ""}}
+            assert cmd.update == {
+                "inner_state": {
+                    "guardrail_validation_result": True,
+                    "guardrail_validation_details": "",
+                }
+            }
             assert fake.guardrails.last_text == "tool output"
 
     @pytest.mark.asyncio
@@ -423,7 +451,10 @@ class TestToolGuardrailNodes:
         cmd = await node(state)
         assert cmd.goto == "nope"
         assert cmd.update == {
-            "inner_state": {"guardrail_validation_result": "policy_violation"}
+            "inner_state": {
+                "guardrail_validation_result": False,
+                "guardrail_validation_details": "policy_violation",
+            }
         }
 
 
@@ -552,7 +583,10 @@ class TestGuardrailHelperFunctions:
 
         assert command.goto == "success_node"
         assert command.update == {
-            "inner_state": {"guardrail_validation_result": "validation passed"}
+            "inner_state": {
+                "guardrail_validation_result": True,
+                "guardrail_validation_details": "validation passed",
+            }
         }
 
     def test_create_validation_command_failure(self):
@@ -569,7 +603,10 @@ class TestGuardrailHelperFunctions:
 
         assert command.goto == "failure_node"
         assert command.update == {
-            "inner_state": {"guardrail_validation_result": "policy_violation"}
+            "inner_state": {
+                "guardrail_validation_result": False,
+                "guardrail_validation_details": "policy_violation",
+            }
         }
 
     def test_create_validation_command_feature_disabled_raises_exception(self):

--- a/uv.lock
+++ b/uv.lock
@@ -3297,7 +3297,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.4.23"
+version = "0.4.24"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
We need to have both props on the state, so that we can know for sure when the guardrail passed or failed. Just the reason is not enough.