### PR TITLE
fix: pass argument properties to mcp tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.16"
+version = "0.10.17"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
+++ b/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
@@ -10,8 +10,8 @@ from uipath.agent.models.agent import (
 )
 from uipath.eval.mocks import mockable
 
-from uipath_langchain.agent.tools.base_uipath_structured_tool import (
-    BaseUiPathStructuredTool,
+from uipath_langchain.agent.tools.structured_tool_with_argument_properties import (
+    StructuredToolWithArgumentProperties,
 )
 
 from ..utils import sanitize_tool_name
@@ -73,6 +73,8 @@ async def create_mcp_tools(
         f"(dynamic_tools={dynamic_tools.value})"
     )
 
+    config_tools_by_name = {t.name: t for t in config.available_tools}
+
     if dynamic_tools in (DynamicToolsMode.SCHEMA, DynamicToolsMode.ALL):
         logger.info(f"Fetching tools from MCP server '{config.slug}' via list_tools")
         result = await mcpClient.list_tools()
@@ -96,15 +98,19 @@ async def create_mcp_tools(
                 f"Filtered to {len(server_tools)} tools matching availableTools"
             )
 
-        mcp_tools = [
-            AgentMcpTool(
-                name=tool.name,
-                description=tool.description or "",
-                input_schema=tool.inputSchema,
-                output_schema=tool.outputSchema,
+        mcp_tools = []
+        for tool in server_tools:
+            config_tool = config_tools_by_name.get(tool.name)
+            argument_properties = config_tool.argument_properties if config_tool else {}
+            mcp_tools.append(
+                AgentMcpTool(
+                    name=tool.name,
+                    description=tool.description or "",
+                    input_schema=tool.inputSchema,
+                    output_schema=tool.outputSchema,
+                    argument_properties=argument_properties,
+                )
             )
-            for tool in server_tools
-        ]
     else:
         mcp_tools = config.available_tools
         logger.info(
@@ -112,21 +118,25 @@ async def create_mcp_tools(
             f"server '{config.slug}'"
         )
 
-    return [
-        BaseUiPathStructuredTool(
-            name=sanitize_tool_name(mcp_tool.name),
-            description=mcp_tool.description,
-            args_schema=mcp_tool.input_schema,
-            coroutine=build_mcp_tool(mcp_tool, mcpClient),
-            metadata={
-                "tool_type": "mcp",
-                "display_name": mcp_tool.name,
-                "folder_path": config.folder_path,
-                "slug": config.slug,
-            },
+    tools: list[BaseTool] = []
+    for mcp_tool in mcp_tools:
+        tools.append(
+            StructuredToolWithArgumentProperties(
+                name=sanitize_tool_name(mcp_tool.name),
+                description=mcp_tool.description,
+                args_schema=mcp_tool.input_schema,
+                coroutine=build_mcp_tool(mcp_tool, mcpClient),
+                output_type=Any,
+                metadata={
+                    "tool_type": "mcp",
+                    "display_name": mcp_tool.name,
+                    "folder_path": config.folder_path,
+                    "slug": config.slug,
+                },
+                argument_properties=mcp_tool.argument_properties,
+            )
         )
-        for mcp_tool in mcp_tools
-    ]
+    return tools
 
 
 def build_mcp_tool(mcp_tool: AgentMcpTool, mcpClient: McpClient) -> Any:

--- a/tests/agent/tools/test_mcp/test_mcp_tool.py
+++ b/tests/agent/tools/test_mcp/test_mcp_tool.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,6 +20,9 @@ from uipath_langchain.agent.tools.mcp.mcp_tool import (
     create_mcp_tools,
     create_mcp_tools_and_clients,
     open_mcp_tools,
+)
+from uipath_langchain.agent.tools.structured_tool_with_argument_properties import (
+    StructuredToolWithArgumentProperties,
 )
 
 logger = logging.getLogger(__name__)
@@ -1005,3 +1008,116 @@ class TestCreateMcpToolsFromConfig:
                     raise RuntimeError("boom")
 
             mock_client.dispose.assert_awaited_once()
+
+
+class TestMcpToolArgumentProperties:
+    """Test that argument_properties from config are applied to MCP tools."""
+
+    @pytest.fixture
+    def mock_mcp_client(self):
+        return MagicMock(spec=McpClient)
+
+    @pytest.mark.asyncio
+    async def test_none_mode_passes_argument_properties_to_tool(self, mock_mcp_client):
+        """In none mode, argument_properties from config must reach the built tool."""
+        resource = AgentMcpResourceConfig(
+            name="test_server",
+            description="Test",
+            folder_path="/Shared",
+            slug="test",
+            available_tools=[
+                AgentMcpTool(
+                    name="divide",
+                    description="Divide two numbers",
+                    input_schema={
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number"},
+                            "b": {"type": "number"},
+                        },
+                        "required": ["a", "b"],
+                    },
+                    argument_properties={
+                        "$['a']": {
+                            "variant": "static",
+                            "value": 76,
+                            "isSensitive": False,
+                        }
+                    },
+                ),
+            ],
+        )
+
+        tools = await create_mcp_tools(resource, mock_mcp_client)
+
+        assert len(tools) == 1
+        tool = tools[0]
+        assert hasattr(tool, "argument_properties")
+        assert "$['a']" in tool.argument_properties
+
+    @pytest.mark.asyncio
+    async def test_all_mode_carries_over_argument_properties_for_matching_tools(
+        self, mock_mcp_client
+    ):
+        """In all mode, argument_properties from config must attach to matching server tools."""
+        mock_mcp_client.list_tools = AsyncMock(
+            return_value=ListToolsResult(
+                tools=[
+                    Tool(
+                        name="divide",
+                        description="Divide from server",
+                        inputSchema={
+                            "type": "object",
+                            "properties": {
+                                "a": {"type": "number"},
+                                "b": {"type": "number"},
+                            },
+                        },
+                    ),
+                    Tool(
+                        name="new_tool",
+                        description="New tool not in config",
+                        inputSchema={"type": "object", "properties": {}},
+                    ),
+                ]
+            )
+        )
+
+        resource = AgentMcpResourceConfig(
+            name="test_server",
+            description="Test",
+            folder_path="/Shared",
+            slug="test",
+            dynamic_tools=DynamicToolsMode.ALL,
+            available_tools=[
+                AgentMcpTool(
+                    name="divide",
+                    description="Divide (stale)",
+                    input_schema={"type": "object", "properties": {}},
+                    argument_properties={
+                        "$['a']": {
+                            "variant": "static",
+                            "value": 76,
+                            "isSensitive": False,
+                        }
+                    },
+                ),
+            ],
+        )
+
+        tools = await create_mcp_tools(resource, mock_mcp_client)
+
+        assert len(tools) == 2
+        divide_tool = next(
+            cast(StructuredToolWithArgumentProperties, t)
+            for t in tools
+            if t.name == "divide"
+        )
+        new_tool = next(
+            cast(StructuredToolWithArgumentProperties, t)
+            for t in tools
+            if t.name == "new_tool"
+        )
+
+        assert "$['a']" in divide_tool.argument_properties
+        assert not new_tool.argument_properties

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
`AgentMcpTool.argument_properties` was parsed from `agent.json` but never passed to the constructed tool, so MCP tools with Argument / Text Builder / Static input variants ran as if nothing was configured. The LLM filled those args itself.

This switches MCP tools to `StructuredToolWithArgumentProperties` so the existing `StaticArgsHandler` in `llm_node` picks them up. In schema and all modes, the same `argumentProperties` from `agent.json` are matched onto server-discovered tools by name.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.10.17.dev1006874458",

  # Any version from PR
  "uipath-langchain>=0.10.17.dev1006870000,<0.10.17.dev1006880000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath-langchain>=0.10.17.dev1006870000,<0.10.17.dev1006880000",
]
```
<!-- DEV_PACKAGE_END -->