### PR TITLE
fix: retrieve the routing context to be derived from folders_map and …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath-langchain"
-version = "0.9.23"
+version = "0.9.24"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
     "uipath>=2.10.29, <2.11.0",
     "uipath-core>=0.5.2, <0.6.0",
-    "uipath-platform>=0.1.23, <0.2.0",
+    "uipath-platform>=0.1.24, <0.2.0",
     "uipath-runtime>=0.10.0, <0.11.0",
     "langgraph>=1.0.0, <2.0.0",
     "langchain-core>=1.2.11, <2.0.0",

--- a/src/uipath_langchain/agent/tools/__init__.py
+++ b/src/uipath_langchain/agent/tools/__init__.py
@@ -1,9 +1,6 @@
 """Tool creation and management for LowCode agents."""
 
 from .context_tool import create_context_tool
-from .datafabric_tool import (
-    fetch_entity_schemas,
-)
 from .escalation_tool import create_escalation_tool
 from .extraction_tool import create_ixp_extraction_tool
 from .integration_tool import create_integration_tool
@@ -30,7 +27,6 @@ __all__ = [
     "create_escalation_tool",
     "create_ixp_extraction_tool",
     "create_ixp_escalation_tool",
-    "fetch_entity_schemas",
     "UiPathToolNode",
     "ToolWrapperMixin",
     "wrap_tools_with_error_handling",

--- a/src/uipath_langchain/agent/tools/datafabric_tool/__init__.py
+++ b/src/uipath_langchain/agent/tools/datafabric_tool/__init__.py
@@ -2,10 +2,8 @@
 
 from .datafabric_tool import (
     create_datafabric_query_tool,
-    fetch_entity_schemas,
 )
 
 __all__ = [
     "create_datafabric_query_tool",
-    "fetch_entity_schemas",
 ]

--- a/src/uipath_langchain/agent/tools/datafabric_tool/datafabric_subgraph.py
+++ b/src/uipath_langchain/agent/tools/datafabric_tool/datafabric_subgraph.py
@@ -23,7 +23,7 @@ from langgraph.graph import StateGraph
 from langgraph.graph.message import add_messages
 from langgraph.graph.state import CompiledStateGraph
 from pydantic import BaseModel
-from uipath.platform.entities import Entity, QueryRoutingOverrideContext
+from uipath.platform.entities import EntitiesService, Entity
 
 from ..datafabric_query_tool import DataFabricQueryTool
 from . import datafabric_prompt_builder
@@ -42,18 +42,14 @@ class DataFabricSubgraphState(BaseModel):
 class QueryExecutor:
     """Executes SQL queries against Data Fabric."""
 
-    def __init__(self, routing_context: QueryRoutingOverrideContext) -> None:
-        from uipath.platform import UiPath
-
-        self._sdk = UiPath()
-        self._routing_context = routing_context
+    def __init__(self, entities_service: EntitiesService) -> None:
+        self._entities = entities_service
 
     async def __call__(self, sql_query: str) -> dict[str, Any]:
         logger.debug("execute_sql called with SQL: %s", sql_query)
         try:
-            records = await self._sdk.entities.query_entity_records_async(
+            records = await self._entities.query_entity_records_async(
                 sql_query=sql_query,
-                routing_context=self._routing_context,
             )
             return {
                 "records": records,
@@ -81,14 +77,14 @@ class DataFabricGraph:
         self,
         llm: BaseChatModel,
         entities: list[Entity],
-        routing_context: QueryRoutingOverrideContext,
+        entities_service: EntitiesService,
         max_iterations: int = 25,
         resource_description: str = "",
         base_system_prompt: str = "",
     ) -> None:
         self._max_iterations = max_iterations
         self._execute_sql_tool = self._create_execute_sql_tool(
-            routing_context, entities
+            entities_service, entities
         )
         self._system_message = SystemMessage(
             content=datafabric_prompt_builder.build(
@@ -175,7 +171,7 @@ class DataFabricGraph:
 
     def _create_execute_sql_tool(
         self,
-        routing_context: QueryRoutingOverrideContext,
+        entities_service: EntitiesService,
         entities: list[Entity],
     ) -> BaseTool:
         """Create the inner ``execute_sql`` tool."""
@@ -188,7 +184,7 @@ class DataFabricGraph:
                 "tables and columns. Retry with a corrected query on errors."
             ),
             args_schema=DataFabricExecuteSqlInput,
-            coroutine=QueryExecutor(routing_context),
+            coroutine=QueryExecutor(entities_service),
             metadata={"tool_type": "datafabric_sql"},
         )
 
@@ -196,7 +192,7 @@ class DataFabricGraph:
     def create(
         llm: BaseChatModel,
         entities: list[Entity],
-        routing_context: QueryRoutingOverrideContext,
+        entities_service: EntitiesService,
         max_iterations: int = 25,
         resource_description: str = "",
         base_system_prompt: str = "",
@@ -205,7 +201,7 @@ class DataFabricGraph:
         graph = DataFabricGraph(
             llm,
             entities,
-            routing_context,
+            entities_service,
             max_iterations,
             resource_description,
             base_system_prompt,

--- a/src/uipath_langchain/agent/tools/datafabric_tool/datafabric_tool.py
+++ b/src/uipath_langchain/agent/tools/datafabric_tool/datafabric_tool.py
@@ -1,8 +1,7 @@
 """Data Fabric tool creation and resource detection.
 
-This module provides:
-1. An agentic ``query_datafabric`` tool with inner LLM sub-graph
-2. Entity schema fetching from the Data Fabric API
+This module provides an agentic ``query_datafabric`` tool with an inner
+LLM sub-graph.
 
 The tool accepts natural language queries, runs an inner LangGraph
 sub-graph for SQL generation + execution + self-correction, and
@@ -21,7 +20,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from langgraph.graph.state import CompiledStateGraph
 from uipath.agent.models.agent import AgentContextResourceConfig
-from uipath.platform.entities import Entity, EntityRouting, QueryRoutingOverrideContext
+from uipath.platform.entities import DataFabricEntityItem
 
 from ..base_uipath_structured_tool import BaseUiPathStructuredTool
 from .models import DataFabricQueryInput
@@ -34,20 +33,19 @@ BASE_SYSTEM_PROMPT = "base_system_prompt"
 class DataFabricTextQueryHandler:
     """Manages lazy initialization and invocation of the Data Fabric sub-graph.
 
-    On first call, fetches entity schemas from the DF API and compiles
-    the inner LangGraph sub-graph. Subsequent calls reuse the cached graph.
+    On first call, resolves entity schemas and routing via the platform
+    layer and compiles the inner LangGraph sub-graph. Subsequent calls
+    reuse the cached graph.
     """
 
     def __init__(
         self,
-        entity_identifiers: list[str],
-        routing_context: QueryRoutingOverrideContext,
+        entity_set: list[DataFabricEntityItem],
         llm: BaseChatModel,
         resource_description: str = "",
         base_system_prompt: str = "",
     ) -> None:
-        self._entity_identifiers = entity_identifiers
-        self._routing_context = routing_context
+        self._entity_set = entity_set
         self._llm = llm
         self._resource_description = resource_description
         self._base_system_prompt = base_system_prompt
@@ -55,7 +53,7 @@ class DataFabricTextQueryHandler:
         self._init_lock = asyncio.Lock()
 
     async def _ensure_datafabric_graph(self) -> CompiledStateGraph[Any]:
-        """Lazy-init: fetch schemas + build sub-graph on first call.
+        """Lazy-init: resolve entities + build sub-graph on first call.
 
         Uses asyncio.Lock because the outer agent supports parallel
         tool calls — two concurrent invocations could race on first call.
@@ -67,18 +65,21 @@ class DataFabricTextQueryHandler:
             if self._compiled is not None:
                 return self._compiled
 
+            from uipath.platform import UiPath
+
             from .datafabric_subgraph import DataFabricGraph
 
-            entities = await fetch_entity_schemas(self._entity_identifiers)
-            if not entities:
+            sdk = UiPath()
+            resolution = await sdk.entities.resolve_entity_set_async(self._entity_set)
+            if not resolution.entities:
                 raise ValueError(
                     "No Data Fabric entity schemas could be fetched. "
                     "Check entity identifiers and permissions."
                 )
             self._compiled = DataFabricGraph.create(
                 llm=self._llm,
-                entities=entities,
-                routing_context=self._routing_context,
+                entities=resolution.entities,
+                entities_service=resolution.entities_service,
                 resource_description=self._resource_description,
                 base_system_prompt=self._base_system_prompt,
             )
@@ -98,44 +99,6 @@ class DataFabricTextQueryHandler:
         return "Unable to generate an answer from the available data."
 
 
-async def _fetch_single_entity(sdk: Any, identifier: str) -> Entity | None:
-    """Fetch a single entity by identifier, returning None on failure."""
-    try:
-        entity = await sdk.entities.retrieve_async(identifier)
-        logger.info("Fetched schema for entity '%s'", entity.display_name)
-        return entity
-    except Exception:
-        logger.warning("Failed to fetch entity '%s'", identifier, exc_info=True)
-        return None
-
-
-async def fetch_entity_schemas(entity_identifiers: list[str]) -> list[Entity]:
-    """Fetch entity metadata from Data Fabric concurrently."""
-    from uipath.platform import UiPath
-
-    sdk = UiPath()
-    results = await asyncio.gather(
-        *[_fetch_single_entity(sdk, eid) for eid in entity_identifiers]
-    )
-    return [e for e in results if e is not None]
-
-
-def _build_routing_context(
-    resource: AgentContextResourceConfig,
-) -> QueryRoutingOverrideContext:
-    """Build query routing context from entity set items.
-
-    Maps each entity to its folder so the backend resolves
-    entities at folder level instead of tenant level.
-    """
-    return QueryRoutingOverrideContext(
-        entity_routings=[
-            EntityRouting(entity_name=item.name, folder_id=item.folder_id)
-            for item in (resource.entity_set or [])
-        ]
-    )
-
-
 def create_datafabric_query_tool(
     resource: AgentContextResourceConfig,
     llm: BaseChatModel,
@@ -152,9 +115,12 @@ def create_datafabric_query_tool(
             Key ``base_system_prompt`` carries the outer agent's system prompt.
     """
     config = agent_config or {}
+    entity_set = [
+        DataFabricEntityItem.model_validate(item.model_dump(by_alias=True))
+        for item in (resource.entity_set or [])
+    ]
     handler = DataFabricTextQueryHandler(
-        entity_identifiers=resource.datafabric_entity_identifiers,
-        routing_context=_build_routing_context(resource),
+        entity_set=entity_set,
         llm=llm,
         resource_description=resource.description or "",
         base_system_prompt=config.get(BASE_SYSTEM_PROMPT, ""),

--- a/uv.lock
+++ b/uv.lock
@@ -3420,7 +3420,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.9.23"
+version = "0.9.24"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -3491,7 +3491,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "uipath", specifier = ">=2.10.29,<2.11.0" },
     { name = "uipath-core", specifier = ">=0.5.2,<0.6.0" },
-    { name = "uipath-platform", specifier = ">=0.1.23,<0.2.0" },
+    { name = "uipath-platform", specifier = ">=0.1.24,<0.2.0" },
     { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
 ]
 provides-extras = ["vertex", "bedrock"]
@@ -3514,7 +3514,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.23"
+version = "0.1.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3524,9 +3524,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/09/eb165f7613cada14f488664816a2dc90c77c6cc3614906aeffae25aedee5/uipath_platform-0.1.23.tar.gz", hash = "sha256:7c13787239878f6f8d3263ceaa3f2a1516f9e0eb3b90cca28db6dba810b260ff", size = 306384, upload-time = "2026-04-08T20:44:52.044Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/52/142a5a856e97c8dc7cc38f18e08d316f08f4d623d834bbcd68cc23456f27/uipath_platform-0.1.24.tar.gz", hash = "sha256:bae0e83dbb339b6cc17a36ab7c10d19966460b79312d1f4e50b64dcc72346d14", size = 311975, upload-time = "2026-04-09T12:04:22.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/48/5e6881b24cb2424233d18b46cd4e21b1b87637c9534f37b7bc3e283e4af2/uipath_platform-0.1.23-py3-none-any.whl", hash = "sha256:f43f9640c3dcf316bd7f2c649fa88f9ad82b95f822a5ecc33f3aa8900dac1eab", size = 196580, upload-time = "2026-04-08T20:44:50.234Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/0b05b99b6436a3d644999c7384dec24aaea5e54c7c46827362aee7f82446/uipath_platform-0.1.24-py3-none-any.whl", hash = "sha256:434778e2c37c7ad3d88370da6384e4bb653770adb7ac78f4fbb718b42ee9ad10", size = 201782, upload-time = "2026-04-09T12:04:21.053Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Related PR : https://github.com/UiPath/uipath-python/pull/1548

This pull request refactors the way folder context is managed for Data Fabric entity queries. Instead of passing a `QueryRoutingOverrideContext` throughout the code, the logic now builds and uses a direct mapping (`folders_map`) from entity names to folder IDs. This simplifies context handling, enables support for resource overwrites, and improves clarity in how folder resolution is performed.

**Refactoring of folder context handling:**

* Replaced all usage of `QueryRoutingOverrideContext` with a `folders_map` (`dict[str, str]`) throughout the Data Fabric subgraph and tool classes, updating constructors, method signatures, and internal logic accordingly. [[1]](diffhunk://#diff-d48f6e1cee9ceb6d6c0f64cd76f5ab0ed3a233c3a118cc5ee6386593958e15a4L26-R26) [[2]](diffhunk://#diff-d48f6e1cee9ceb6d6c0f64cd76f5ab0ed3a233c3a118cc5ee6386593958e15a4L45-L56) [[3]](diffhunk://#diff-d48f6e1cee9ceb6d6c0f64cd76f5ab0ed3a233c3a118cc5ee6386593958e15a4L84-R90) [[4]](diffhunk://#diff-d48f6e1cee9ceb6d6c0f64cd76f5ab0ed3a233c3a118cc5ee6386593958e15a4L178-R177) [[5]](diffhunk://#diff-d48f6e1cee9ceb6d6c0f64cd76f5ab0ed3a233c3a118cc5ee6386593958e15a4L191-R198) [[6]](diffhunk://#diff-d48f6e1cee9ceb6d6c0f64cd76f5ab0ed3a233c3a118cc5ee6386593958e15a4L208-R207) [[7]](diffhunk://#diff-756b873b668e978d51d956f6c8323a8a358e38827e31fc18e783c947dd61cecaL24-R24) [[8]](diffhunk://#diff-756b873b668e978d51d956f6c8323a8a358e38827e31fc18e783c947dd61cecaL44-R50) [[9]](diffhunk://#diff-756b873b668e978d51d956f6c8323a8a358e38827e31fc18e783c947dd61cecaL81-R81)

* Updated the helper function from `_build_routing_context` to `_build_folders_map`, which now constructs an entity-name-to-folder-ID map, applying resource overwrites when present. The docstring and implementation were revised to reflect this new behavior.

**Tool and handler creation updates:**

* Modified the creation and initialization of `DataFabricTextQueryHandler` and related classes to use `folders_map` instead of `routing_context`, ensuring the new context handling flows throughout the toolchain.

This refactor makes folder resolution more explicit and adaptable, especially in environments with resource overwrites.…passing it through to SDK