### PR TITLE
chore: bump version to 0.9.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.9.27"
+version = "0.9.28"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3437,7 +3437,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.9.27"
+version = "0.9.28"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Bumps `uipath-langchain` from `0.9.27` → `0.9.28`

This PR bumps to `0.9.28` so CD can publish the changes from #735.

## What gets published in 0.9.28

- `resolve_recipient_value()` handles `ArgumentEmail` and `ArgumentGroupName` recipient types at runtime by looking up the argument path in agent input kwargs
- Guardrails escalation path (`escalate_action.py`) passes `input_args` to `resolve_recipient_value`