### PR TITLE
chore: bump langgraph minimum version to 1.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.9.29"
+version = "0.9.30"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -9,7 +9,7 @@ dependencies = [
     "uipath-core>=0.5.2, <0.6.0",
     "uipath-platform>=0.1.30, <0.2.0",
     "uipath-runtime>=0.10.0, <0.11.0",
-    "langgraph>=1.0.0, <2.0.0",
+    "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.11, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",
     "langchain-openai>=1.0.0, <2.0.0",

--- a/template/main.py
+++ b/template/main.py
@@ -18,9 +18,9 @@ from uipath_langchain.chat import (
 )
 
 # Choose your LLM provider by uncommenting one of the following:
-llm = UiPathChatBedrock(model_name=BedrockModels.anthropic_claude_haiku_4_5)
+llm = UiPathChatVertex(model_name=GeminiModels.gemini_2_5_flash)
+# llm = UiPathChatBedrock(model_name=BedrockModels.anthropic_claude_haiku_4_5)
 # llm = UiPathChatOpenAI(model_name=OpenAIModels.gpt_4_1_mini_2025_04_14)
-# llm = UiPathChatVertex(model_name=GeminiModels.gemini_2_5_flash)
 
 SYSTEM_PROMPT = (
     "You are a helpful assistant. "

--- a/tests/agent/tools/test_langgraph_interrupt_contract.py
+++ b/tests/agent/tools/test_langgraph_interrupt_contract.py
@@ -16,7 +16,7 @@ Verified assumptions:
 import dataclasses
 import itertools
 import operator
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -314,8 +314,8 @@ class TestParallelNodesSeparateScratchpads:
 
         app = graph.compile(checkpointer=MemorySaver())
         result = app.invoke(
-            {"results": []},  # type: ignore[arg-type]
-            config={"configurable": {"thread_id": "test-parallel"}},
+            cast(Any, {"results": []}),
+            config=RunnableConfig(configurable={"thread_id": "test-parallel"}),
         )
 
         assert len(captured_scratchpad_ids) == 2
@@ -352,8 +352,8 @@ class TestParallelNodesSeparateScratchpads:
 
         app = graph.compile(checkpointer=MemorySaver())
         app.invoke(
-            {"results": []},  # type: ignore[arg-type]
-            config={"configurable": {"thread_id": "test-counters"}},
+            cast(Any, {"results": []}),
+            config=RunnableConfig(configurable={"thread_id": "test-counters"}),
         )
 
         assert len(captured_counters) == 2

--- a/tests/cli/mocks/parity_agent_middleware.py
+++ b/tests/cli/mocks/parity_agent_middleware.py
@@ -253,7 +253,7 @@ async def joke_node(state: Input) -> Output:
             content=f"Generate a family-friendly joke based on the topic: {state.topic}"
         )
     ]
-    result = await agent.ainvoke({"messages": messages})  # type: ignore[arg-type]
+    result = await agent.ainvoke({"messages": messages})  # type: ignore[call-overload]
     joke = result["messages"][-1].content
     return Output(joke=joke)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1253,16 +1253,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.10"
+version = "1.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/22/a4d4ac98fc2e393537130bbfba0d71a8113e6f884d96f935923e247397fe/langchain-1.2.10.tar.gz", hash = "sha256:bdcd7218d9c79a413cf15e106e4eb94408ac0963df9333ccd095b9ed43bf3be7", size = 570071, upload-time = "2026-02-10T14:56:49.74Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/06/c3394327f815fade875724c0f6cff529777c96a1e17fea066deb997f8cf5/langchain-1.2.10-py3-none-any.whl", hash = "sha256:e07a377204451fffaed88276b8193e894893b1003e25c5bca6539288ccca3698", size = 111738, upload-time = "2026-02-10T14:56:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
 ]
 
 [[package]]
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.13"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1294,9 +1294,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/bb/c501ca60556c11ac80d1454bdcac63cb33583ce4e64fc4535ad5a7d5c6ba/langchain_core-1.2.13.tar.gz", hash = "sha256:d2773d0d0130a356378db9a858cfeef64c3d64bc03722f1d4d6c40eb46fdf01b", size = 831612, upload-time = "2026-02-15T07:45:57.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/ab/60fd69e5d55f67d422baefddaaca523c42cd7510ab6aeb17db6ae57fb107/langchain_core-1.2.13-py3-none-any.whl", hash = "sha256:b31823e28d3eff1e237096d0bd3bf80c6f9624eb471a9496dbfbd427779f8d82", size = 500485, upload-time = "2026-02-15T07:45:55.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]
@@ -1344,7 +1344,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.0.8"
+version = "1.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1354,9 +1354,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/49/e9551965d8a44dd9afdc55cbcdc5a9bd18bee6918cc2395b225d40adb77c/langgraph-1.0.8.tar.gz", hash = "sha256:2630fc578846995114fd659f8b14df9eff5a4e78c49413f67718725e88ceb544", size = 498708, upload-time = "2026-02-06T12:31:13.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/02/196eff4f673fd461f8780930c3bfa7f27d6533a48e4f1104d544e843b093/langgraph-1.1.8.tar.gz", hash = "sha256:a97b8248129f2e007b81eef8277009ad1e1280b75fa2175889ab5aff5dcc4578", size = 560389, upload-time = "2026-04-17T19:45:50.301Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/b0d7fc1007821a08dfc03ce232f39f209aa4aa46414ea3d125b24e35093a/langgraph-1.0.8-py3-none-any.whl", hash = "sha256:da737177c024caad7e5262642bece4f54edf4cba2c905a1d1338963f41cf0904", size = 158144, upload-time = "2026-02-06T12:31:12.489Z" },
+    { url = "https://files.pythonhosted.org/packages/22/38/c72e795f6f8fd05a8e7c3be32c04ea8534294decc6785f3b04e0ce932e8a/langgraph-1.1.8-py3-none-any.whl", hash = "sha256:3278c7e335da25eac3327bb474c502d4cab94ae6dcc685fbf93be2bbf7664cd5", size = 173678, upload-time = "2026-04-17T19:45:48.991Z" },
 ]
 
 [[package]]
@@ -1388,15 +1388,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.7"
+version = "1.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/59/711aecd1a50999456850dc328f3cad72b4372d8218838d8d5326f80cb76f/langgraph_prebuilt-1.0.7.tar.gz", hash = "sha256:38e097e06de810de4d0e028ffc0e432bb56d1fb417620fb1dfdc76c5e03e4bf9", size = 163692, upload-time = "2026-01-22T16:45:22.801Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/01471b1b5601f2e9c9a69c39fc9a2fb8611613ede0002e5a2b81c0acd850/langgraph_prebuilt-1.0.10.tar.gz", hash = "sha256:5a6fc513f8907074563b6218ff991c4ed9db19ac63101314919686e8029ddb07", size = 169769, upload-time = "2026-04-17T17:59:45.373Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/49/5e37abb3f38a17a3487634abc2a5da87c208cc1d14577eb8d7184b25c886/langgraph_prebuilt-1.0.7-py3-none-any.whl", hash = "sha256:e14923516504405bb5edc3977085bc9622c35476b50c1808544490e13871fe7c", size = 35324, upload-time = "2026-01-22T16:45:21.784Z" },
+    { url = "https://files.pythonhosted.org/packages/50/49/d073375beabdc6955df6cbe570ba7786836bd4c817ae998955d35037f2fd/langgraph_prebuilt-1.0.10-py3-none-any.whl", hash = "sha256:e3baa1977d819982e690a357ba5bb77ccc1d4d8d4a029c48e502a3b6d171185f", size = 36086, upload-time = "2026-04-17T17:59:44.395Z" },
 ]
 
 [[package]]
@@ -3437,7 +3437,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.9.29"
+version = "0.9.30"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -3501,7 +3501,7 @@ requires-dist = [
     { name = "langchain-google-genai", marker = "extra == 'vertex'", specifier = ">=2.0.0" },
     { name = "langchain-mcp-adapters", specifier = "==0.2.1" },
     { name = "langchain-openai", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langgraph", specifier = ">=1.0.0,<2.0.0" },
+    { name = "langgraph", specifier = ">=1.1.8,<2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.3,<4.0.0" },
     { name = "mcp", specifier = "==1.26.0" },
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.56" },
@@ -3533,7 +3533,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.30"
+version = "0.1.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3543,9 +3543,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/2c/d16d49157c7ff1eebac5620748671c90f4d529e552f8b58f86022745bb55/uipath_platform-0.1.30.tar.gz", hash = "sha256:b2b4e05f4a2bdc09c6192a6986236db94c848fd75485a7b3887a5d8c7ec38fbc", size = 315693, upload-time = "2026-04-17T13:49:10.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/f6/d847c24bd06deea31beadd345c49c21203ef39028df861d4e01156294f3e/uipath_platform-0.1.31.tar.gz", hash = "sha256:4c8a4c8915718134dc49311ac8acf87b20fbc956089f82d282d1ee4fcbe1630e", size = 322249, upload-time = "2026-04-17T17:45:50.292Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/b1/a0fa2a73ca2e1a5b54591b04b51614a9a8913abf8c89393fcff2f2114564/uipath_platform-0.1.30-py3-none-any.whl", hash = "sha256:1a691dc98d89fe5096a1047c60a80be84f4b541f62920be5be483b3907132930", size = 206164, upload-time = "2026-04-17T13:49:08.912Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/87/fed39302f3fada4036fb2d97ba6612f17279e0cc5e05d84e1ea565b5026e/uipath_platform-0.1.31-py3-none-any.whl", hash = "sha256:01d47736c1d4a70ee68d89a58cf3a721f89ff5845a67ebe15123d7f4149ede70", size = 211056, upload-time = "2026-04-17T17:45:48.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump \`langgraph\` minimum version from \`>=1.0.0\` to \`>=1.1.8\`
- fix test invoke calls to use `RunnableConfig` and `cast(Any, ...)` for input, as `1.1.8` tightened overload signatures
- changed llm provider to vertex in template https://github.com/UiPath/uipath-langchain-python/issues/781

## Why
[langgraph 1.1.8](https://github.com/langchain-ai/langgraph/releases/tag/1.1.8) fixed a [regression](https://github.com/langchain-ai/langgraph/issues/7543) where \`opentelemetry-instrumentation-langchain\` would crash with \`TypeError: handlers must inherit GraphCallbackHandler\` on agent invocation

langgraph PR: https://github.com/langchain-ai/langgraph/pull/7544