### PR TITLE
fix: use UiPathChatBedrockConverse in template agent

### DIFF
--- a/template/main.py
+++ b/template/main.py
@@ -12,14 +12,14 @@ from uipath_langchain.chat import (
     BedrockModels,
     GeminiModels,
     OpenAIModels,
-    UiPathChatBedrock,
+    UiPathChatBedrockConverse,
     UiPathChatOpenAI,
     UiPathChatVertex,
 )
 
 # Choose your LLM provider by uncommenting one of the following:
-llm = UiPathChatVertex(model_name=GeminiModels.gemini_2_5_flash)
-# llm = UiPathChatBedrock(model_name=BedrockModels.anthropic_claude_haiku_4_5)
+llm = UiPathChatBedrockConverse(model_name=BedrockModels.anthropic_claude_haiku_4_5)
+# llm = UiPathChatVertex(model_name=GeminiModels.gemini_2_5_flash)
 # llm = UiPathChatOpenAI(model_name=OpenAIModels.gpt_4_1_mini_2025_04_14)
 
 SYSTEM_PROMPT = (

--- a/testcases/template-agent/expected_traces.json
+++ b/testcases/template-agent/expected_traces.json
@@ -9,7 +9,7 @@
     },
     {
       "name": [
-        "UiPathChatBedrock",
+        "UiPathChatBedrockConverse",
         "UiPathChatOpenAI",
         "UiPathChatVertex"
       ],


### PR DESCRIPTION
## Summary
- switch template agent bedrock provider from \`UiPathChatBedrock\` to \`UiPathChatBedrockConverse\`

## Why
`UiPathChatBedrock` does not support structured responses

`botocore.exceptions.ClientError: An error occurred (400) when calling the InvokeModelWithResponseStream operation: response_format: Extra inputs are not permitted`

Fixes: https://github.com/UiPath/uipath-langchain-python/issues/781