### PR TITLE
fix: use folder_key on ephemeral index creation [ECS-1745]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.9.30"
+version = "0.9.31"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/internal_tools/batch_transform_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/batch_transform_tool.py
@@ -25,7 +25,6 @@ from uipath.platform.context_grounding.context_grounding_index import (
 )
 from uipath.runtime.errors import UiPathErrorCategory
 
-from uipath_langchain._utils import get_execution_folder_path
 from uipath_langchain._utils.durable_interrupt import (
     SkipInterruptValue,
     durable_interrupt,
@@ -138,7 +137,7 @@ def create_batch_transform_tool(
                     await uipath.context_grounding.create_ephemeral_index_async(
                         usage=EphemeralIndexUsage.BATCH_RAG,
                         attachments=[attachment_id],
-                        folder_path=get_execution_folder_path(),
+                        folder_key=UiPathConfig.folder_key,
                     )
                 )
                 if ephemeral_index.in_progress_ingestion():

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -11,7 +11,7 @@ from uipath.agent.models.agent import (
 )
 from uipath.eval.mocks import mockable
 from uipath.platform import UiPath
-from uipath.platform.common import CreateDeepRag, WaitEphemeralIndex, UiPathConfig
+from uipath.platform.common import CreateDeepRag, UiPathConfig, WaitEphemeralIndex
 from uipath.platform.context_grounding import (
     CitationMode,
     EphemeralIndexUsage,

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -11,7 +11,7 @@ from uipath.agent.models.agent import (
 )
 from uipath.eval.mocks import mockable
 from uipath.platform import UiPath
-from uipath.platform.common import CreateDeepRag, WaitEphemeralIndex
+from uipath.platform.common import CreateDeepRag, WaitEphemeralIndex, UiPathConfig
 from uipath.platform.context_grounding import (
     CitationMode,
     EphemeralIndexUsage,
@@ -21,7 +21,6 @@ from uipath.platform.context_grounding.context_grounding_index import (
 )
 from uipath.runtime.errors import UiPathErrorCategory
 
-from uipath_langchain._utils import get_execution_folder_path
 from uipath_langchain._utils.durable_interrupt import (
     SkipInterruptValue,
     durable_interrupt,
@@ -119,7 +118,7 @@ def create_deeprag_tool(
                     await uipath.context_grounding.create_ephemeral_index_async(
                         usage=EphemeralIndexUsage.DEEP_RAG,
                         attachments=[attachment_id],
-                        folder_path=get_execution_folder_path(),
+                        folder_key=UiPathConfig.folder_key,
                     )
                 )
                 if ephemeral_index.in_progress_ingestion():

--- a/tests/agent/tools/internal_tools/test_batch_transform_tool.py
+++ b/tests/agent/tools/internal_tools/test_batch_transform_tool.py
@@ -557,8 +557,8 @@ class TestCreateBatchTransformTool:
         "uipath_langchain.agent.tools.internal_tools.batch_transform_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
-    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Shared/TestFolder"})
-    async def test_create_ephemeral_index_passes_folder_path(
+    @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "test-folder-key"})
+    async def test_create_ephemeral_index_passes_folder_key(
         self,
         mock_interrupt,
         mock_uipath_class,
@@ -566,7 +566,7 @@ class TestCreateBatchTransformTool:
         resource_config_static,
         mock_llm,
     ):
-        """Test that create_ephemeral_index_async receives folder_path from the execution environment."""
+        """Test that create_ephemeral_index_async receives folder_key from the execution environment."""
         mock_uipath = AsyncMock()
         mock_uipath_class.return_value = mock_uipath
         mock_uipath_config = Mock()
@@ -597,7 +597,7 @@ class TestCreateBatchTransformTool:
         call_kwargs = (
             mock_uipath.context_grounding.create_ephemeral_index_async.call_args.kwargs
         )
-        assert call_kwargs["folder_path"] == "/Shared/TestFolder"
+        assert call_kwargs["folder_key"] == "test-folder-key"
 
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"

--- a/tests/agent/tools/internal_tools/test_deeprag_tool.py
+++ b/tests/agent/tools/internal_tools/test_deeprag_tool.py
@@ -379,8 +379,8 @@ class TestCreateDeepRagTool:
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
-    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Shared/TestFolder"})
-    async def test_create_ephemeral_index_passes_folder_path(
+    @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "test-folder-key"})
+    async def test_create_ephemeral_index_passes_folder_key(
         self,
         mock_interrupt,
         mock_uipath_class,
@@ -388,7 +388,7 @@ class TestCreateDeepRagTool:
         resource_config_static,
         mock_llm,
     ):
-        """Test that create_ephemeral_index_async receives folder_path from the execution environment."""
+        """Test that create_ephemeral_index_async receives folder_key from the execution environment."""
         mock_uipath = AsyncMock()
         mock_uipath_class.return_value = mock_uipath
 
@@ -416,4 +416,4 @@ class TestCreateDeepRagTool:
         call_kwargs = (
             mock_uipath.context_grounding.create_ephemeral_index_async.call_args.kwargs
         )
-        assert call_kwargs["folder_path"] == "/Shared/TestFolder"
+        assert call_kwargs["folder_key"] == "test-folder-key"

--- a/uv.lock
+++ b/uv.lock
@@ -3437,7 +3437,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.9.30"
+version = "0.9.31"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
after checking with Andrei, seems like the folder_path is only available for local runs. therefore - switched to reuse the UiPathConfiguration instead for getting the current execution's folder key.