### PR TITLE
feat: add timeout param to all chat model providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.9.31"
+version = "0.9.32"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/_utils/_environment.py
+++ b/src/uipath_langchain/_utils/_environment.py
@@ -4,3 +4,7 @@ import os
 def get_execution_folder_path() -> str | None:
     """Reads the agent's executing folder path from the runtime environment."""
     return os.environ.get("UIPATH_FOLDER_PATH")
+
+
+def get_default_timeout() -> float:
+    return float(os.getenv("UIPATH_TIMEOUT_SECONDS", "300"))

--- a/src/uipath_langchain/_utils/_request_mixin.py
+++ b/src/uipath_langchain/_utils/_request_mixin.py
@@ -27,6 +27,7 @@ from uipath.runtime.errors import (
     UiPathRuntimeError,
 )
 
+from uipath_langchain._utils._environment import get_default_timeout
 from uipath_langchain._utils._settings import (
     UiPathClientFactorySettings,
     UiPathClientSettings,
@@ -129,8 +130,7 @@ class UiPathRequestMixin(BaseModel):
     )
     default_request_timeout: Any = Field(
         default_factory=lambda data: float(
-            getattr(data["settings"], "timeout_seconds", None)
-            or os.getenv("UIPATH_TIMEOUT_SECONDS", "120")
+            getattr(data["settings"], "timeout_seconds", None) or get_default_timeout()
         ),
         alias="timeout",
     )

--- a/src/uipath_langchain/_utils/_settings.py
+++ b/src/uipath_langchain/_utils/_settings.py
@@ -42,7 +42,7 @@ class UiPathClientSettings(BaseSettings):
     requesting_feature: str = Field(
         default="langgraph-agent", alias="UIPATH_REQUESTING_FEATURE"
     )
-    timeout_seconds: str = Field(default="120", alias="UIPATH_TIMEOUT_SECONDS")
+    timeout_seconds: str = Field(default="300", alias="UIPATH_TIMEOUT_SECONDS")
     action_name: str = Field(default="DefaultActionName", alias="UIPATH_ACTION_NAME")
     action_id: str = Field(default="DefaultActionId", alias="UIPATH_ACTION_ID")
 

--- a/src/uipath_langchain/chat/bedrock.py
+++ b/src/uipath_langchain/chat/bedrock.py
@@ -13,6 +13,8 @@ from uipath.platform.common import (
     resource_override,
 )
 
+from uipath_langchain._utils._environment import get_default_timeout
+
 from .http_client import build_uipath_headers, resolve_gateway_url
 from .http_client.header_capture import HeaderCapture
 from .http_client.retryers.bedrock import AsyncBedrockRetryer, BedrockRetryer
@@ -68,6 +70,7 @@ class AwsBedrockCompletionsPassthroughClient:
         agenthub_config: Optional[str] = None,
         byo_connection_id: Optional[str] = None,
         header_capture: HeaderCapture | None = None,
+        timeout: float | None = None,
     ):
         self.model = model
         self.token = token
@@ -78,6 +81,7 @@ class AwsBedrockCompletionsPassthroughClient:
         self._url: Optional[str] = None
         self._is_override: bool = False
         self.header_capture = header_capture
+        self.timeout = timeout if timeout is not None else get_default_timeout()
 
     @property
     def endpoint(self) -> str:
@@ -120,7 +124,7 @@ class AwsBedrockCompletionsPassthroughClient:
             verify=ca_bundle if ca_bundle is not None else False,
             config=self._unsigned_config(
                 retries={"total_max_attempts": 1},
-                read_timeout=300,
+                read_timeout=self.timeout,
             ),
         )
         client.meta.events.register(
@@ -180,6 +184,7 @@ class UiPathChatBedrockConverse(ChatBedrockConverse):
         byo_connection_id: Optional[str] = None,
         retryer: Optional[Retrying] = None,
         aretryer: Optional[AsyncRetrying] = None,
+        timeout: float | None = None,
         **kwargs,
     ):
         org_id = org_id or os.getenv("UIPATH_ORGANIZATION_ID")
@@ -205,6 +210,7 @@ class UiPathChatBedrockConverse(ChatBedrockConverse):
             api_flavor="converse",
             agenthub_config=agenthub_config,
             byo_connection_id=byo_connection_id,
+            timeout=timeout,
         )
 
         kwargs["client"] = passthrough_client.get_client()
@@ -242,6 +248,7 @@ class UiPathChatBedrock(ChatBedrock):
         byo_connection_id: Optional[str] = None,
         retryer: Optional[Retrying] = None,
         aretryer: Optional[AsyncRetrying] = None,
+        timeout: float | None = None,
         **kwargs,
     ):
         org_id = org_id or os.getenv("UIPATH_ORGANIZATION_ID")
@@ -270,6 +277,7 @@ class UiPathChatBedrock(ChatBedrock):
             agenthub_config=agenthub_config,
             byo_connection_id=byo_connection_id,
             header_capture=header_capture,
+            timeout=timeout,
         )
 
         kwargs["client"] = passthrough_client.get_client()

--- a/src/uipath_langchain/chat/openai.py
+++ b/src/uipath_langchain/chat/openai.py
@@ -11,6 +11,8 @@ from uipath.platform.common import (
     resource_override,
 )
 
+from uipath_langchain._utils._environment import get_default_timeout
+
 from .http_client import build_uipath_headers, resolve_gateway_url
 from .supported_models import OpenAIModels
 from .types import APIFlavor, LLMProvider
@@ -119,6 +121,7 @@ class UiPathChatOpenAI(AzureChatOpenAI):
         agenthub_config: Optional[str] = None,
         extra_headers: Optional[dict[str, str]] = None,
         byo_connection_id: Optional[str] = None,
+        timeout: float | None = None,
         **kwargs,
     ):
         org_id = org_id or os.getenv("UIPATH_ORGANIZATION_ID")
@@ -148,7 +151,9 @@ class UiPathChatOpenAI(AzureChatOpenAI):
         url, is_override = self._resolve_url()
 
         client_kwargs = get_httpx_client_kwargs()
-        client_kwargs["timeout"] = 300.0
+        client_kwargs["timeout"] = (
+            timeout if timeout is not None else get_default_timeout()
+        )
         verify = client_kwargs.get("verify", True)
 
         api_flavor = (
@@ -160,6 +165,7 @@ class UiPathChatOpenAI(AzureChatOpenAI):
         super().__init__(
             azure_endpoint=url,
             model_name=model_name,
+            timeout=client_kwargs["timeout"],
             default_headers=self._build_headers(token, inject_routing=is_override),
             http_async_client=httpx.AsyncClient(
                 transport=UiPathURLRewriteTransport(verify=verify),

--- a/src/uipath_langchain/chat/vertex.py
+++ b/src/uipath_langchain/chat/vertex.py
@@ -15,6 +15,8 @@ from uipath._utils import resource_override
 from uipath._utils._ssl_context import get_httpx_client_kwargs
 from uipath.platform.common import EndpointManager
 
+from uipath_langchain._utils._environment import get_default_timeout
+
 from .http_client import build_uipath_headers, resolve_gateway_url
 from .http_client.header_capture import HeaderCapture
 from .http_client.retryers.vertex import AsyncVertexRetryer, VertexRetryer
@@ -165,6 +167,7 @@ class UiPathChatVertex(ChatGoogleGenerativeAI):
         byo_connection_id: Optional[str] = None,
         retryer: Optional[Retrying] = None,
         aretryer: Optional[AsyncRetrying] = None,
+        timeout: float | None = None,
         **kwargs: Any,
     ):
         org_id = org_id or os.getenv("UIPATH_ORGANIZATION_ID")
@@ -194,11 +197,13 @@ class UiPathChatVertex(ChatGoogleGenerativeAI):
 
         header_capture = HeaderCapture(name=f"vertex_headers_{id(self)}")
         client_kwargs = get_httpx_client_kwargs(headers=headers)
-        client_kwargs["timeout"] = 300.0
+        resolved_timeout = timeout if timeout is not None else get_default_timeout()
+        client_kwargs["timeout"] = resolved_timeout
         verify = client_kwargs.get("verify", True)
         merged_headers = client_kwargs.pop("headers", {})
 
         http_options = genai_types.HttpOptions(
+            timeout=int(resolved_timeout * 1000),
             httpx_client=httpx.Client(
                 transport=_UrlRewriteTransport(
                     uipath_url, verify=verify, header_capture=header_capture

--- a/tests/chat/test_timeout.py
+++ b/tests/chat/test_timeout.py
@@ -1,0 +1,76 @@
+"""Tests that the timeout parameter propagates correctly to the underlying HTTP clients."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+BASE_ENV = {
+    "UIPATH_URL": "https://cloud.uipath.com/org/tenant",
+    "UIPATH_ORGANIZATION_ID": "org-id",
+    "UIPATH_TENANT_ID": "tenant-id",
+    "UIPATH_ACCESS_TOKEN": "test-token",
+}
+
+
+class TestUiPathChatOpenAITimeout:
+    def _make(self, timeout: float):
+        from uipath_langchain.chat.openai import UiPathChatOpenAI
+
+        with patch.dict(os.environ, BASE_ENV, clear=False):
+            return UiPathChatOpenAI(timeout=timeout)
+
+    def test_default_timeout(self):
+        llm = self._make(300.0)
+        assert llm.http_async_client.timeout.read == 300.0
+        assert llm.http_client.timeout.read == 300.0
+
+    def test_custom_timeout_propagates_to_async_client(self):
+        llm = self._make(600.0)
+        assert llm.http_async_client.timeout.read == 600.0
+
+    def test_custom_timeout_propagates_to_sync_client(self):
+        llm = self._make(120.0)
+        assert llm.http_client.timeout.read == 120.0
+
+
+@pytest.mark.skipif(
+    pytest.importorskip("google.genai", reason="google-genai not installed") is None,
+    reason="google-genai not installed",
+)
+class TestUiPathChatVertexTimeout:
+    def _make(self, timeout: float):
+        from uipath_langchain.chat.vertex import UiPathChatVertex
+
+        with patch.dict(os.environ, BASE_ENV, clear=False):
+            return UiPathChatVertex(timeout=timeout)
+
+    def test_default_timeout(self):
+        llm = self._make(300.0)
+        assert llm.client._api_client._httpx_client.timeout.read == 300.0
+
+    def test_custom_timeout_propagates(self):
+        llm = self._make(600.0)
+        assert llm.client._api_client._httpx_client.timeout.read == 600.0
+
+
+class TestAwsBedrockPassthroughClientTimeout:
+    def _make(self, timeout: float):
+        from uipath_langchain.chat.bedrock import AwsBedrockCompletionsPassthroughClient
+
+        return AwsBedrockCompletionsPassthroughClient(
+            model="anthropic.claude-haiku-4-5",
+            token="test-token",
+            api_flavor="converse",
+            timeout=timeout,
+        )
+
+    def test_default_timeout(self):
+        client = self._make(300.0)
+        boto_client = client.get_client()
+        assert boto_client.meta.config.read_timeout == 300.0
+
+    def test_custom_timeout_propagates(self):
+        client = self._make(600.0)
+        boto_client = client.get_client()
+        assert boto_client.meta.config.read_timeout == 600.0

--- a/uv.lock
+++ b/uv.lock
@@ -3437,7 +3437,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.9.31"
+version = "0.9.32"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- add `timeout: float | None = None` to `UiPathChatOpenAI`, `UiPathChatVertex`, `UiPathChatBedrockConverse`, `UiPathChatBedrock`
- add `get_default_timeout()` helper reading `UIPATH_TIMEOUT_SECONDS`, defaulting to 300s (up from 120s)
- fix openai: pass timeout to `super().__init__()` so the openai sdk enforces it per-request (httpx client-level alone was silently ignored)
- fix vertex: set `HttpOptions.timeout` (ms) so google-genai sdk enforces it per-request (same override pattern)
- add `test-llm-models` sample for comparing models side-by-side with timeout testing
- add `tests/chat/test_timeout.py` covering all three providers
