### PR TITLE
fix: close content part before tool calls to prevent no-start-event error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.9.32"
+version = "0.9.33"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -585,7 +585,6 @@ class UiPathChatMessagesMapper:
     def map_to_content_part_end_event(
         self, message_id: str
     ) -> UiPathConversationMessageEvent:
-        """Emit ContentPartEndEvent without MessageEnd."""
         return UiPathConversationMessageEvent(
             message_id=message_id,
             content_part=UiPathConversationContentPartEvent(

--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -355,6 +355,7 @@ class UiPathChatMessagesMapper:
                 events.append(self._chunk_to_message_event(message.id, chunk))
             self._citation_stream_processor = CitationStreamProcessor()
 
+            events.append(self.map_to_content_part_end_event(message.id))
             if (
                 self.current_message.tool_calls is not None
                 and len(self.current_message.tool_calls) > 0
@@ -389,6 +390,7 @@ class UiPathChatMessagesMapper:
                 events.append(self._chunk_to_message_event(message.id, chunk))
             self._citation_stream_processor = CitationStreamProcessor()
 
+        events.append(self.map_to_content_part_end_event(message.id))
         if message.tool_calls:
             events.extend(await self.map_current_message_to_start_tool_call_events())
         else:
@@ -578,6 +580,14 @@ class UiPathChatMessagesMapper:
         return UiPathConversationMessageEvent(
             message_id=message_id,
             end=UiPathConversationMessageEndEvent(),
+        )
+
+    def map_to_content_part_end_event(
+        self, message_id: str
+    ) -> UiPathConversationMessageEvent:
+        """Emit ContentPartEndEvent without MessageEnd."""
+        return UiPathConversationMessageEvent(
+            message_id=message_id,
             content_part=UiPathConversationContentPartEvent(
                 content_part_id=self.get_content_part_id(message_id),
                 end=UiPathConversationContentPartEndEvent(),

--- a/tests/runtime/test_chat_message_mapper.py
+++ b/tests/runtime/test_chat_message_mapper.py
@@ -1136,11 +1136,15 @@ class TestMapEvent:
         result = await mapper.map_event(last_chunk)
 
         assert result is not None
-        # Should have the end event
+        # Should have content part end event followed by message end event
+        content_part_end_event = result[-2]
+        assert content_part_end_event.content_part is not None
+        assert content_part_end_event.content_part.end is not None
+        assert content_part_end_event.end is None
+
         end_event = result[-1]
         assert end_event.end is not None
-        assert end_event.content_part is not None
-        assert end_event.content_part.end is not None
+        assert end_event.content_part is None
 
     @pytest.mark.asyncio
     async def test_map_event_emits_tool_call_start_events_on_last_chunk(self):
@@ -1771,10 +1775,14 @@ class TestMapAiMessageToEvents:
         assert start_event.content_part is not None
         assert start_event.content_part.start is not None
 
+        content_part_end_event = result[-2]
+        assert content_part_end_event.content_part is not None
+        assert content_part_end_event.content_part.end is not None
+        assert content_part_end_event.end is None
+
         end_event = result[-1]
         assert end_event.end is not None
-        assert end_event.content_part is not None
-        assert end_event.content_part.end is not None
+        assert end_event.content_part is None
 
     @pytest.mark.asyncio
     async def test_emits_content_chunk_for_string_content(self):

--- a/uv.lock
+++ b/uv.lock
@@ -3437,7 +3437,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.9.32"
+version = "0.9.33"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION

# Summary:
Fixes `"Content part chunk-... has no start event"` error on CAS when agents use tools that cause graph suspension (escalation, process, HITL confirmation, etc.)

The content part lifecycle (Start → Chunks → End) now completes before tool execution begins. Before, the ContentPartEnd event would be sent with the MessageEnd, at the end of the tool-call execution. 
Thus I believe that before, what was happening was:
- Websocket session 1 sends ContentPartStart + chunks
- A langgraph tool that suspends the execution before (and thus ends the websocket session) would run
- The next websocket session 2 is initialized and would then send the ContentPartEnd
- On CAS-side, this would not be correlated to the original websocket session's ContentPartStart event, causing the `"Content part chunk-... has no start event"` error

Now, ContentPartEnd is emitted as a separate event **before** tool-calls, and MessageEnd no longer bundles the two together. This matches old Temporal behavior.

Demo working end-to-end, and notice independent `endContentPart` event.

https://github.com/user-attachments/assets/8600804b-77a4-4e25-9137-0ef91cca8efc

Don't mind the missing chat-history in above video, that's just my local setup being wrong.


# Test plan:

 All 1556 existing tests pass
 Updated 2 tests to match new event structure (ContentPartEnd and MessageEnd are now separate events)