### PR TITLE
chore: restrict a2a-sdk version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.9.33"
+version = "0.9.34"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -23,7 +23,7 @@ dependencies = [
     "mcp==1.26.0",
     "langchain-mcp-adapters==0.2.1",
     "pillow>=12.1.1",
-    "a2a-sdk>=0.2.0",
+    "a2a-sdk>=0.2.0,<1.0.0",
 ]
 
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -3437,7 +3437,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.9.33"
+version = "0.9.34"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -3489,7 +3489,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.2.0" },
+    { name = "a2a-sdk", specifier = ">=0.2.0,<1.0.0" },
     { name = "boto3-stubs", marker = "extra == 'bedrock'", specifier = ">=1.41.4" },
     { name = "google-generativeai", marker = "extra == 'vertex'", specifier = ">=0.8.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
A2A-SDK 1.0.0 was released yesterday, which introduces breaking changes.
pyproject.toml did not have an upper bound, causing potential invalid combinations.
Initial mitigation is to add an upper cap, with a proper migration to 1.0.0 to be done later.