### PR TITLE
fix: unwrap PEP 604 union types (X | None) in _unwrap_optional

### DIFF
--- a/src/uipath_langchain/agent/react/json_utils.py
+++ b/src/uipath_langchain/agent/react/json_utils.py
@@ -1,6 +1,7 @@
 import ast
 import json
 import sys
+import types
 from typing import Any, ForwardRef, Union, get_args, get_origin
 
 from jsonpath_ng import parse  # type: ignore[import-untyped]
@@ -183,7 +184,7 @@ def _unwrap_optional(annotation: Any) -> Any:
         The unwrapped type, or the original if not Optional/Union
     """
     origin = get_origin(annotation)
-    if origin is Union:
+    if origin is Union or isinstance(annotation, types.UnionType):
         args = get_args(annotation)
         non_none_args = [arg for arg in args if arg is not type(None)]
         if non_none_args:


### PR DESCRIPTION
## Summary
- fix job attachment detection failing on Python 3.10-3.13 when agent input fields use `X | None` syntax
- `_unwrap_optional` now handles both `typing.Union` (Optional[X]) and `types.UnionType` (X | None)

## Why

on Python 3.10-3.13, `get_origin(X | None)` returns `types.UnionType` instead of `typing.Union`. the `_unwrap_optional` check was only testing for `typing.Union`, so `Attachment | None` field annotations were never unwrapped to `Attachment`, causing `get_job_attachment_paths` to return no paths and `job_attachments` to stay empty. Python 3.14 changed `get_origin` to return `typing.Union` for both forms, masking the bug locally.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.10.1.dev1008004366",

  # Any version from PR
  "uipath-langchain>=0.10.1.dev1008000000,<0.10.1.dev1008010000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath-langchain>=0.10.1.dev1008000000,<0.10.1.dev1008010000",
]
```
<!-- DEV_PACKAGE_END -->