### PR TITLE
fix: use origin identity check for types.UnionType in _unwrap_optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.3"
+version = "0.10.4"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/json_utils.py
+++ b/src/uipath_langchain/agent/react/json_utils.py
@@ -184,7 +184,7 @@ def _unwrap_optional(annotation: Any) -> Any:
         The unwrapped type, or the original if not Optional/Union
     """
     origin = get_origin(annotation)
-    if origin is Union or isinstance(annotation, types.UnionType):
+    if origin is Union or origin is types.UnionType:
         args = get_args(annotation)
         non_none_args = [arg for arg in args if arg is not type(None)]
         if non_none_args:

--- a/tests/agent/react/test_json_utils.py
+++ b/tests/agent/react/test_json_utils.py
@@ -27,6 +27,10 @@ class WithOptional(BaseModel):
     target: Optional[Target] = None
 
 
+class WithPipeUnion(BaseModel):
+    target: Target | None = None
+
+
 class WithNestedList(BaseModel):
     matrix: list[list[Target]]
 
@@ -52,6 +56,10 @@ class TestGetJsonPathsByType:
 
     def test_optional_field(self):
         paths = get_json_paths_by_type(WithOptional, "Target")
+        assert paths == ["$.target"]
+
+    def test_pipe_union_field(self):
+        paths = get_json_paths_by_type(WithPipeUnion, "Target")
         assert paths == ["$.target"]
 
     def test_nested_list_of_lists(self):

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- replace `isinstance(annotation, types.UnionType)` with `origin is types.UnionType` in `_unwrap_optional`
- add regression test for `X | None` (PEP 604) field annotations

## Why

the previous fix used `isinstance` on the annotation object directly, which runs on every non-generic annotation (when `get_origin` returns `None`) and could raise on pathological annotations. checking `origin is types.UnionType` is equivalent, safer, and consistent with how the `typing.Union` case is already handled.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.10.4.dev1008014385",

  # Any version from PR
  "uipath-langchain>=0.10.4.dev1008010000,<0.10.4.dev1008020000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath-langchain>=0.10.4.dev1008010000,<0.10.4.dev1008020000",
]
```
<!-- DEV_PACKAGE_END -->