### PR TITLE
feat: rename template input field to question with description

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -6,7 +6,7 @@ A quickstart UiPath LangGraph agent. It answers user queries using live tools an
 
 ## What it does
 
-1. **Prepares** the conversation — injects a system prompt and the user query into state
+1. **Prepares** the conversation — injects a system prompt and the user question into state
 2. **Runs a ReAct agent node** that autonomously decides which tools to call and in what order
 3. **Postprocesses** — validates and truncates the response if it exceeds the configured max length
 
@@ -19,13 +19,12 @@ A quickstart UiPath LangGraph agent. It answers user queries using live tools an
 
 ### LLM Providers
 
-The template defaults to **GPT-4.1 Mini** via `UiPathChat`. To switch providers, edit `main.py`:
+The template defaults to **Claude Haiku 4.5** via `UiPathChatAnthropicBedrock`. To switch providers, edit `main.py`:
 
 ```python
 # Choose your LLM provider by uncommenting one of the following:
-llm = UiPathChat(model="gpt-4.1-mini-2025-04-14")
+llm = UiPathChatAnthropicBedrock(model="anthropic.claude-haiku-4-5-20251001-v1:0")
 # llm = UiPathAzureChatOpenAI(model="gpt-4.1-mini-2025-04-14")
-# llm = UiPathChatAnthropicBedrock(model="anthropic.claude-haiku-4-5-20251001-v1:0")
 # llm = UiPathChatGoogleGenerativeAI(model="gemini-2.5-flash")
 ```
 
@@ -44,7 +43,7 @@ flowchart TD
 ```json
 // Input
 {
-  "query": "What's the weather like in London?"
+  "question": "What's the weather like in London?"
 }
 
 // Output
@@ -57,10 +56,10 @@ flowchart TD
 
 ```bash
 # Run
-uv run uipath run agent --file input.json
+uv run uipath run agent --input-file input.json --output-file output.json
 
 # Debug with dynamic node breakpoints
-uv run uipath debug agent --file input.json
+uv run uipath debug agent --input-file input.json --output-file output.json
 ```
 
 ## Evaluation

--- a/template/entry-points.json
+++ b/template/entry-points.json
@@ -4,18 +4,19 @@
     "entryPoints": [
         {
             "filePath": "agent",
-            "uniqueId": "ed2b77c0-1fab-478a-abe4-41b3a6f573c2",
+            "uniqueId": "dd6b5e6a-fa02-4220-b78e-e99c2f112e34",
             "type": "agent",
             "input": {
                 "type": "object",
                 "properties": {
-                    "query": {
-                        "title": "Query",
+                    "question": {
+                        "description": "Question for the assistant, e.g. 'What's the weather in Paris?'",
+                        "title": "Question",
                         "type": "string"
                     }
                 },
                 "required": [
-                    "query"
+                    "question"
                 ]
             },
             "output": {
@@ -65,7 +66,8 @@
                                     "type": "model",
                                     "subgraph": null,
                                     "metadata": {
-                                        "model_name": "anthropic.claude-haiku-4-5-20251001-v1:0"
+                                        "model_name": "anthropic.claude-haiku-4-5-20251001-v1:0",
+                                        "max_tokens": 4096
                                     }
                                 },
                                 {
@@ -76,7 +78,7 @@
                                     "metadata": {
                                         "tool_names": [
                                             "get_current_time",
-                                            "web_search"
+                                            "get_weather"
                                         ],
                                         "tool_count": 2
                                     }

--- a/template/evaluations/eval-sets/evaluation-set-default.json
+++ b/template/evaluations/eval-sets/evaluation-set-default.json
@@ -13,7 +13,7 @@
       "id": "ada5a2c1-976c-470b-964f-eb70a5e61eb4",
       "name": "Weather in Paris",
       "inputs": {
-        "query": "Is it good weather for a walk in Paris?"
+        "question": "Is it good weather for a walk in Paris?"
       },
       "evaluationCriterias": {
         "evaluator-llm-judge-output": {

--- a/template/input.json
+++ b/template/input.json
@@ -1,3 +1,3 @@
 {
-  "query": "What's the weather like in London?"
+  "question": "What's the weather like in London?"
 }

--- a/template/main.py
+++ b/template/main.py
@@ -6,19 +6,17 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import tool
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from uipath_langchain.chat import (
     UiPathAzureChatOpenAI,
-    UiPathChat,
     UiPathChatAnthropicBedrock,
     UiPathChatGoogleGenerativeAI,
 )
 
 # Choose your LLM provider by uncommenting one of the following:
-llm = UiPathChat(model="gpt-4.1-mini-2025-04-14")
+llm = UiPathChatAnthropicBedrock(model="anthropic.claude-haiku-4-5-20251001-v1:0")
 # llm = UiPathAzureChatOpenAI(model="gpt-4.1-mini-2025-04-14")
-# llm = UiPathChatAnthropicBedrock(model="anthropic.claude-haiku-4-5-20251001-v1:0")
 # llm = UiPathChatGoogleGenerativeAI(model="gemini-2.5-flash")
 
 SYSTEM_PROMPT = (
@@ -31,7 +29,9 @@ MAX_RESPONSE_LENGTH = 5000
 
 
 class InputModel(BaseModel):
-    query: str
+    question: str = Field(
+        description="Question for the assistant, e.g. 'What's the weather in Paris?'"
+    )
 
 
 class AgentResponse(TypedDict):
@@ -76,7 +76,7 @@ async def prepare(input: InputModel) -> dict[str, Any]:
     return {
         "messages": [
             SystemMessage(SYSTEM_PROMPT),
-            HumanMessage(input.query),
+            HumanMessage(input.question),
         ],
     }
 


### PR DESCRIPTION
## Summary
- rename template input field `query` -> `question` with a pydantic `Field(description=...)` 
- default template LLM to `UiPathChatAnthropicBedrock` (claude haiku 4.5) and drop `UiPathChat` in favor of passthrough providers
- readme now uses `--input-file` and `--output-file` flags