### PR TITLE
feat: chat model factory defaults + omit strict_mode=False from payload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.4"
+version = "0.10.5"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/chat/_legacy/chat_model_factory.py
+++ b/src/uipath_langchain/chat/_legacy/chat_model_factory.py
@@ -40,7 +40,7 @@ def _create_openai_llm(
     model: str,
     api_flavor: APIFlavor,
     temperature: float | None,
-    max_tokens: int,
+    max_tokens: int | None,
     agenthub_config: str,
     byo_connection_id: str | None = None,
     **kwargs: Any,
@@ -87,7 +87,7 @@ def _create_bedrock_llm(
     model: str,
     api_flavor: APIFlavor,
     temperature: float | None,
-    max_tokens: int,
+    max_tokens: int | None,
     agenthub_config: str,
     byo_connection_id: str | None = None,
     **kwargs: Any,
@@ -244,8 +244,8 @@ def _get_model_info(
 
 def get_chat_model(
     model: str,
-    temperature: float,
-    max_tokens: int,
+    temperature: float | None,
+    max_tokens: int | None,
     agenthub_config: str,
     byo_connection_id: str | None = None,
     **kwargs: Any,

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -25,6 +25,7 @@ from uipath_langchain_client.settings import (
 
 _UNSET: Final[Any] = object()
 DEFAULT_TIMEOUT_SECONDS: Final[float] = 300.0
+DEFAULT_MAX_TOKENS: Final[int] = 1000
 DEFAULT_TEMPERATURE: Final[float] = 0.0
 DEFAULT_MAX_RETRIES: Final[int] = 3
 
@@ -39,7 +40,7 @@ def get_chat_model(
     api_flavor: ApiFlavor | str | None = None,
     custom_class: type[UiPathBaseChatModel] | None = None,
     temperature: float | None = DEFAULT_TEMPERATURE,
-    max_tokens: int | None = None,
+    max_tokens: int | None = DEFAULT_MAX_TOKENS,
     timeout: float | None = DEFAULT_TIMEOUT_SECONDS,
     max_retries: int | None = DEFAULT_MAX_RETRIES,
     callbacks: Callbacks = _UNSET,
@@ -62,8 +63,10 @@ def get_chat_model(
             instead of the auto-detected one.
         temperature: Sampling temperature. Defaults to 0.0. Pass ``None`` to
             omit the parameter when the underlying client supports it.
-        max_tokens: Maximum output tokens. Defaults to ``None`` (unset), which
-            lets the underlying client apply its own default.
+        max_tokens: Maximum output tokens. Defaults to 1000 to match the
+            historical default from ``UiPathRequestMixin``. Pass ``None`` to
+            forward an explicit unset value (lets the underlying client apply
+            its own default or use no limit).
         timeout: Request timeout in seconds. Defaults to 300 seconds.
         max_retries: Max retry count. Defaults to 3.
         callbacks: LangChain callbacks (handlers or a manager) attached to the
@@ -136,7 +139,7 @@ def _legacy_chat_model(
     return _legacy_get_chat_model(
         model,
         temperature if temperature is not _UNSET and temperature is not None else 0.0,
-        max_tokens if max_tokens is not _UNSET and max_tokens is not None else 0,
+        max_tokens,
         agenthub_config,
         byo_connection_id,
         **kwargs,

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -138,7 +138,7 @@ def _legacy_chat_model(
 
     return _legacy_get_chat_model(
         model,
-        temperature if temperature is not _UNSET and temperature is not None else 0.0,
+        temperature,
         max_tokens,
         agenthub_config,
         byo_connection_id,

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -25,7 +25,6 @@ from uipath_langchain_client.settings import (
 
 _UNSET: Final[Any] = object()
 DEFAULT_TIMEOUT_SECONDS: Final[float] = 300.0
-DEFAULT_MAX_TOKENS: Final[int] = 1000
 DEFAULT_TEMPERATURE: Final[float] = 0.0
 DEFAULT_MAX_RETRIES: Final[int] = 3
 
@@ -40,7 +39,7 @@ def get_chat_model(
     api_flavor: ApiFlavor | str | None = None,
     custom_class: type[UiPathBaseChatModel] | None = None,
     temperature: float | None = DEFAULT_TEMPERATURE,
-    max_tokens: int | None = DEFAULT_MAX_TOKENS,
+    max_tokens: int | None = None,
     timeout: float | None = DEFAULT_TIMEOUT_SECONDS,
     max_retries: int | None = DEFAULT_MAX_RETRIES,
     callbacks: Callbacks = _UNSET,
@@ -63,9 +62,8 @@ def get_chat_model(
             instead of the auto-detected one.
         temperature: Sampling temperature. Defaults to 0.0. Pass ``None`` to
             omit the parameter when the underlying client supports it.
-        max_tokens: Maximum output tokens. Defaults to 1000 to match the
-            historical default from ``UiPathRequestMixin``. Pass ``None`` to
-            omit the limit when the underlying client supports it.
+        max_tokens: Maximum output tokens. Defaults to ``None`` (unset), which
+            lets the underlying client apply its own default.
         timeout: Request timeout in seconds. Defaults to 300 seconds.
         max_retries: Max retry count. Defaults to 3.
         callbacks: LangChain callbacks (handlers or a manager) attached to the
@@ -138,7 +136,7 @@ def _legacy_chat_model(
     return _legacy_get_chat_model(
         model,
         temperature if temperature is not _UNSET and temperature is not None else 0.0,
-        max_tokens if max_tokens is not _UNSET and max_tokens is not None else DEFAULT_MAX_TOKENS,
+        max_tokens if max_tokens is not _UNSET and max_tokens is not None else 0,
         agenthub_config,
         byo_connection_id,
         **kwargs,

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -25,6 +25,9 @@ from uipath_langchain_client.settings import (
 
 _UNSET: Final[Any] = object()
 DEFAULT_TIMEOUT_SECONDS: Final[float] = 300.0
+DEFAULT_MAX_TOKENS: Final[int] = 1000
+DEFAULT_TEMPERATURE: Final[float] = 0.0
+DEFAULT_MAX_RETRIES: Final[int] = 3
 
 
 def get_chat_model(
@@ -36,10 +39,10 @@ def get_chat_model(
     vendor_type: VendorType | str | None = None,
     api_flavor: ApiFlavor | str | None = None,
     custom_class: type[UiPathBaseChatModel] | None = None,
-    temperature: float | None = _UNSET,
-    max_tokens: int | None = _UNSET,
+    temperature: float | None = DEFAULT_TEMPERATURE,
+    max_tokens: int | None = DEFAULT_MAX_TOKENS,
     timeout: float | None = DEFAULT_TIMEOUT_SECONDS,
-    max_retries: int | None = _UNSET,
+    max_retries: int | None = DEFAULT_MAX_RETRIES,
     callbacks: Callbacks = _UNSET,
     # Legacy-only arguments
     agenthub_config: str | None = None,
@@ -58,10 +61,13 @@ def get_chat_model(
             Converse). Auto-detected when omitted.
         custom_class: Custom ``UiPathBaseChatModel`` subclass to instantiate
             instead of the auto-detected one.
-        temperature: Sampling temperature. Forwarded only when explicitly set.
-        max_tokens: Maximum output tokens. Forwarded only when explicitly set.
+        temperature: Sampling temperature. Defaults to 0.0. Pass ``None`` to
+            omit the parameter when the underlying client supports it.
+        max_tokens: Maximum output tokens. Defaults to 1000 to match the
+            historical default from ``UiPathRequestMixin``. Pass ``None`` to
+            omit the limit when the underlying client supports it.
         timeout: Request timeout in seconds. Defaults to 300 seconds.
-        max_retries: Max retry count. Forwarded only when explicitly set.
+        max_retries: Max retry count. Defaults to 3.
         callbacks: LangChain callbacks (handlers or a manager) attached to the
             returned chat model. Accepts ``list[BaseCallbackHandler]`` or a
             ``BaseCallbackManager``. Forwarded only when explicitly set.
@@ -132,7 +138,7 @@ def _legacy_chat_model(
     return _legacy_get_chat_model(
         model,
         temperature if temperature is not _UNSET and temperature is not None else 0.0,
-        max_tokens if max_tokens is not _UNSET and max_tokens is not None else 0,
+        max_tokens if max_tokens is not _UNSET and max_tokens is not None else DEFAULT_MAX_TOKENS,
         agenthub_config,
         byo_connection_id,
         **kwargs,

--- a/src/uipath_langchain/chat/handlers/anthropic.py
+++ b/src/uipath_langchain/chat/handlers/anthropic.py
@@ -48,8 +48,8 @@ class AnthropicPayloadHandler(ModelPayloadHandler):
         kwargs: dict[str, Any] = {"tool_choice": tool_choice}
         if parallel_tool_calls is not None:
             kwargs["parallel_tool_calls"] = parallel_tool_calls
-        if strict_mode is not None:
-            kwargs["strict"] = strict_mode
+        if strict_mode is True:
+            kwargs["strict"] = True
         return kwargs
 
     def check_stop_reason(self, response: AIMessage) -> None:

--- a/src/uipath_langchain/chat/handlers/fireworks.py
+++ b/src/uipath_langchain/chat/handlers/fireworks.py
@@ -18,8 +18,8 @@ class FireworksPayloadHandler(ModelPayloadHandler):
         strict_mode: bool | None = None,
     ) -> dict[str, Any]:
         kwargs: dict[str, Any] = {"tool_choice": tool_choice}
-        if strict_mode is not None:
-            kwargs["strict"] = strict_mode
+        if strict_mode is True:
+            kwargs["strict"] = True
         return kwargs
 
     def check_stop_reason(self, response: Any) -> None:

--- a/src/uipath_langchain/chat/handlers/openai.py
+++ b/src/uipath_langchain/chat/handlers/openai.py
@@ -73,8 +73,8 @@ class OpenAIPayloadHandler(ModelPayloadHandler):
         kwargs: dict[str, Any] = {"tool_choice": tool_choice}
         if parallel_tool_calls is not None:
             kwargs["parallel_tool_calls"] = parallel_tool_calls
-        if strict_mode is not None:
-            kwargs["strict"] = strict_mode
+        if strict_mode is True:
+            kwargs["strict"] = True
         return kwargs
 
     def check_stop_reason(self, response: AIMessage) -> None:

--- a/tests/chat/handlers/test_tool_binding_kwargs.py
+++ b/tests/chat/handlers/test_tool_binding_kwargs.py
@@ -103,10 +103,11 @@ class TestOpenAIGetToolBindingKwargs:
         assert result["strict"] is True
 
     def test_strict_mode_false(self):
+        """strict_mode=False must be omitted from the request payload."""
         result = self.handler.get_tool_binding_kwargs(
             tools=self.tools, tool_choice="auto", strict_mode=False
         )
-        assert result["strict"] is False
+        assert "strict" not in result
 
     def test_all_keys_present(self):
         result = self.handler.get_tool_binding_kwargs(
@@ -161,17 +162,18 @@ class TestAnthropicGetToolBindingKwargs:
         assert result["strict"] is True
 
     def test_strict_mode_false(self):
+        """strict_mode=False must be omitted from the request payload."""
         result = self.handler.get_tool_binding_kwargs(
             tools=self.tools, tool_choice="auto", strict_mode=False
         )
-        assert result["strict"] is False
+        assert "strict" not in result
 
     def test_all_keys_present(self):
         result = self.handler.get_tool_binding_kwargs(
             tools=self.tools,
             tool_choice="any",
             parallel_tool_calls=True,
-            strict_mode=False,
+            strict_mode=True,
         )
         assert set(result.keys()) == {"tool_choice", "parallel_tool_calls", "strict"}
 

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Two related fixes to keep the request payload sent to the LLM gateway predictable and free of accidental defaults.

### 1. Explicit defaults in `get_chat_model`

Stop falling through to whatever the vendor library happens to default to (which varies wildly — Gemini ran out of reasoning tokens on a 3-word prompt because `max_tokens` wasn't forwarded). Restore the historical knobs from `UiPathRequestMixin`:

| param | old | new | escape hatch |
|---|---|---|---|
| `max_tokens` | `_UNSET` (not forwarded) | `1000` (historical default from `634d9fe feat: add chat models`) | pass `None` to forward an explicit unset |
| `temperature` | `_UNSET` (not forwarded) | `0.0` | pass `None` to omit |
| `max_retries` | `_UNSET` (not forwarded) | `3` | — |

Also cleaned up a dead-code fallback in the legacy dispatch path that mapped `None`/`_UNSET` back to `0` for `max_tokens` and `0.0` for `temperature` — these silently overrode an explicit "unset" caller intent. Now `None` is forwarded straight through to the legacy leaf clients (which already handle it correctly via `if temperature is not None: ...` guards).

### 2. Don't send `strict_mode=False` to the API

Three handlers (OpenAI, Anthropic, Fireworks) used `if strict_mode is not None` to gate the `strict` kwarg. Since `AgentConfig.strict_mode` defaults to `False`, every request was being sent with `strict=False` — leaking an opt-in flag as if it were always set. Switched to `if strict_mode is True` so only an explicit opt-in reaches the wire. Matches the existing behavior of BedrockConverse and Gemini.

### Bookkeeping

- `pyproject.toml`: `0.10.4` → `0.10.5`
- `uv.lock` refreshed

## Test plan

- [x] `uv run pytest tests/chat/test_chat_model_factory.py` — 25 pass, 4 skipped (vertex/bedrock extras not installed locally)
- [x] `uv run pytest tests/chat/handlers/test_tool_binding_kwargs.py tests/chat/test_bedrock_payload_handler.py` — 70 pass
- [x] `just lint` — clean
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)