### PR TITLE
feat: per-vendor model_name defaults on new chat clients (parity with legacy)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.5"
+version = "0.10.6"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/chat/__init__.py
+++ b/src/uipath_langchain/chat/__init__.py
@@ -9,6 +9,13 @@ Do NOT add eager imports like:
     from .models import UiPathChat  # BAD - loads langchain_openai immediately
 
 Instead, all exports are loaded on-demand when first accessed.
+
+Per-vendor classes are re-exported from ``uipath_langchain.chat.openai`` /
+``.bedrock`` / ``.vertex``. Those submodules are where the upstream
+``uipath_langchain_client`` classes are first imported — and where the
+legacy ``model_name`` defaults are attached to them — so each vendor-family
+default only fires (and loads its heavy deps) when a caller actually asks
+for that family.
 """
 
 from .hitl import (
@@ -24,71 +31,58 @@ def __getattr__(name):
 
         return get_chat_model
     if name == "UiPathChat":
-        from uipath_langchain_client.clients.normalized.chat_models import (
-            UiPathChat,
-        )
+        from .openai import UiPathChat
 
         return UiPathChat
     if name == "UiPathAzureChatOpenAI":
-        from uipath_langchain_client.clients.openai.chat_models import (
-            UiPathAzureChatOpenAI,
-        )
+        from .openai import UiPathAzureChatOpenAI
 
         return UiPathAzureChatOpenAI
     if name == "UiPathChatOpenAI":
-        from uipath_langchain_client.clients.openai.chat_models import (
-            UiPathChatOpenAI,
-        )
+        from .openai import UiPathChatOpenAI
 
         return UiPathChatOpenAI
     if name == "UiPathChatGoogleGenerativeAI":
-        from uipath_langchain_client.clients.google.chat_models import (
-            UiPathChatGoogleGenerativeAI,
-        )
+        from .vertex import UiPathChatGoogleGenerativeAI
 
         return UiPathChatGoogleGenerativeAI
+    if name == "UiPathChatVertex":
+        from .vertex import UiPathChatVertex
+
+        return UiPathChatVertex
     if name == "UiPathChatBedrock":
-        from uipath_langchain_client.clients.bedrock.chat_models import (
-            UiPathChatBedrock,
-        )
+        from .bedrock import UiPathChatBedrock
 
         return UiPathChatBedrock
     if name == "UiPathChatBedrockConverse":
-        from uipath_langchain_client.clients.bedrock.chat_models import (
-            UiPathChatBedrockConverse,
-        )
+        from .bedrock import UiPathChatBedrockConverse
 
         return UiPathChatBedrockConverse
     if name == "UiPathChatAnthropicBedrock":
-        from uipath_langchain_client.clients.bedrock.chat_models import (
-            UiPathChatAnthropicBedrock,
-        )
+        from .bedrock import UiPathChatAnthropicBedrock
 
         return UiPathChatAnthropicBedrock
     if name == "UiPathChatAnthropic":
+        # No legacy equivalent — model= stays required.
         from uipath_langchain_client.clients.anthropic.chat_models import (
             UiPathChatAnthropic,
         )
 
         return UiPathChatAnthropic
     if name == "UiPathChatAnthropicVertex":
+        # No legacy equivalent — model= stays required.
         from uipath_langchain_client.clients.vertexai.chat_models import (
             UiPathChatAnthropicVertex,
         )
 
         return UiPathChatAnthropicVertex
     if name == "UiPathChatFireworks":
+        # No legacy equivalent — model= stays required.
         from uipath_langchain_client.clients.fireworks.chat_models import (
             UiPathChatFireworks,
         )
 
         return UiPathChatFireworks
-    if name == "UiPathChatVertex":
-        from uipath_langchain_client.clients.google.chat_models import (
-            UiPathChatGoogleGenerativeAI,
-        )
-
-        return UiPathChatGoogleGenerativeAI
     if name in ("OpenAIModels", "BedrockModels", "GeminiModels"):
         from uipath_langchain.chat._legacy import supported_models
 

--- a/src/uipath_langchain/chat/__init__.py
+++ b/src/uipath_langchain/chat/__init__.py
@@ -24,45 +24,35 @@ def __getattr__(name):
 
         return get_chat_model
     if name == "UiPathChat":
-        from uipath_langchain_client.clients.normalized.chat_models import (
-            UiPathChat,
-        )
+        from .models import UiPathChat
 
         return UiPathChat
     if name == "UiPathAzureChatOpenAI":
-        from uipath_langchain_client.clients.openai.chat_models import (
-            UiPathAzureChatOpenAI,
-        )
+        from .openai import UiPathAzureChatOpenAI
 
         return UiPathAzureChatOpenAI
     if name == "UiPathChatOpenAI":
-        from uipath_langchain_client.clients.openai.chat_models import (
-            UiPathChatOpenAI,
-        )
+        from .openai import UiPathChatOpenAI
 
         return UiPathChatOpenAI
     if name == "UiPathChatGoogleGenerativeAI":
-        from uipath_langchain_client.clients.google.chat_models import (
-            UiPathChatGoogleGenerativeAI,
-        )
+        from .vertex import UiPathChatGoogleGenerativeAI
 
         return UiPathChatGoogleGenerativeAI
+    if name == "UiPathChatVertex":
+        from .vertex import UiPathChatVertex
+
+        return UiPathChatVertex
     if name == "UiPathChatBedrock":
-        from uipath_langchain_client.clients.bedrock.chat_models import (
-            UiPathChatBedrock,
-        )
+        from .bedrock import UiPathChatBedrock
 
         return UiPathChatBedrock
     if name == "UiPathChatBedrockConverse":
-        from uipath_langchain_client.clients.bedrock.chat_models import (
-            UiPathChatBedrockConverse,
-        )
+        from .bedrock import UiPathChatBedrockConverse
 
         return UiPathChatBedrockConverse
     if name == "UiPathChatAnthropicBedrock":
-        from uipath_langchain_client.clients.bedrock.chat_models import (
-            UiPathChatAnthropicBedrock,
-        )
+        from .bedrock import UiPathChatAnthropicBedrock
 
         return UiPathChatAnthropicBedrock
     if name == "UiPathChatAnthropic":
@@ -83,12 +73,6 @@ def __getattr__(name):
         )
 
         return UiPathChatFireworks
-    if name == "UiPathChatVertex":
-        from uipath_langchain_client.clients.google.chat_models import (
-            UiPathChatGoogleGenerativeAI,
-        )
-
-        return UiPathChatGoogleGenerativeAI
     if name in ("OpenAIModels", "BedrockModels", "GeminiModels"):
         from uipath_langchain.chat._legacy import supported_models
 

--- a/src/uipath_langchain/chat/bedrock.py
+++ b/src/uipath_langchain/chat/bedrock.py
@@ -1,8 +1,37 @@
+import os
+from typing import Any
+
+from pydantic import model_validator
 from uipath_langchain_client.clients.bedrock.chat_models import (
     UiPathChatAnthropicBedrock,
     UiPathChatBedrock,
-    UiPathChatBedrockConverse,
 )
+from uipath_langchain_client.clients.bedrock.chat_models import (
+    UiPathChatBedrockConverse as _UpstreamUiPathChatBedrockConverse,
+)
+
+DEFAULT_MODEL_NAME = "anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+def _default_factory() -> str:
+    return os.getenv("UIPATH_MODEL_NAME", DEFAULT_MODEL_NAME)
+
+
+for _cls in (UiPathChatBedrock, UiPathChatAnthropicBedrock):
+    _cls.model_fields["model_name"].default_factory = _default_factory
+    _cls.model_rebuild(force=True)
+
+
+class UiPathChatBedrockConverse(_UpstreamUiPathChatBedrockConverse):
+    @model_validator(mode="before")
+    @classmethod
+    def _inject_default_model(cls, values: Any) -> Any:
+        if isinstance(values, dict) and not any(
+            k in values for k in ("model", "model_id", "model_name")
+        ):
+            values = {**values, "model": _default_factory()}
+        return values
+
 
 __all__ = [
     "UiPathChatBedrock",

--- a/src/uipath_langchain/chat/bedrock.py
+++ b/src/uipath_langchain/chat/bedrock.py
@@ -1,8 +1,56 @@
+"""Bedrock-backed chat classes.
+
+Ports the legacy ``BedrockModels.anthropic_claude_haiku_4_5`` ``model_name``
+default to the upstream ``uipath_langchain_client`` classes so
+``UiPathChatBedrock()`` (no args) works.
+
+``UiPathChatBedrock`` and ``UiPathChatAnthropicBedrock`` take the default via
+a pydantic ``default_factory`` on the upstream ``model_name`` field — their
+upstream before-validators tolerate a missing ``model_id``.
+
+``UiPathChatBedrockConverse`` is the odd one out: its upstream
+``ChatBedrockConverse.set_disable_streaming`` before-validator reads ``model``
+/ ``model_id`` from the raw input dict and fires BEFORE pydantic applies the
+field ``default_factory``. We wrap it in a thin subclass with our own
+before-validator that injects the default into the raw input when the caller
+passed no model kwarg.
+"""
+
+from typing import Any
+
+from pydantic import model_validator
 from uipath_langchain_client.clients.bedrock.chat_models import (
     UiPathChatAnthropicBedrock,
     UiPathChatBedrock,
-    UiPathChatBedrockConverse,
 )
+from uipath_langchain_client.clients.bedrock.chat_models import (
+    UiPathChatBedrockConverse as _UpstreamUiPathChatBedrockConverse,
+)
+
+DEFAULT_MODEL_NAME = "anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+def _default_factory() -> str:
+    return DEFAULT_MODEL_NAME
+
+
+for _cls in (UiPathChatBedrock, UiPathChatAnthropicBedrock):
+    _cls.model_fields["model_name"].default_factory = _default_factory
+    _cls.model_rebuild(force=True)
+
+
+class UiPathChatBedrockConverse(_UpstreamUiPathChatBedrockConverse):
+    """Subclass that injects the Bedrock default when no model is passed."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _inject_default_model(cls, values: Any) -> Any:
+        if isinstance(values, dict) and not any(
+            k in values for k in ("model", "model_id", "model_name")
+        ):
+            values = {**values, "model": _default_factory()}
+        return values
+
 
 __all__ = [
     "UiPathChatBedrock",

--- a/src/uipath_langchain/chat/models.py
+++ b/src/uipath_langchain/chat/models.py
@@ -1,11 +1,18 @@
+import os
+
 from uipath_langchain_client.clients.normalized.chat_models import UiPathChat
-from uipath_langchain_client.clients.openai.chat_models import (
-    UiPathAzureChatOpenAI,
-    UiPathChatOpenAI,
-)
+
+DEFAULT_MODEL_NAME = "gpt-4.1-mini-2025-04-14"
+
+
+def _default_factory() -> str:
+    return os.getenv("UIPATH_MODEL_NAME", DEFAULT_MODEL_NAME)
+
+
+UiPathChat.model_fields["model_name"].default_factory = _default_factory
+UiPathChat.model_rebuild(force=True)
+
 
 __all__ = [
     "UiPathChat",
-    "UiPathAzureChatOpenAI",
-    "UiPathChatOpenAI",
 ]

--- a/src/uipath_langchain/chat/models.py
+++ b/src/uipath_langchain/chat/models.py
@@ -1,8 +1,10 @@
-from uipath_langchain_client.clients.normalized.chat_models import UiPathChat
-from uipath_langchain_client.clients.openai.chat_models import (
-    UiPathAzureChatOpenAI,
-    UiPathChatOpenAI,
-)
+"""Aggregate re-export of the OpenAI-family chat classes.
+
+Re-exports from :mod:`uipath_langchain.chat.openai` so the ``model_name``
+default applied there is also seen by callers using this module.
+"""
+
+from .openai import UiPathAzureChatOpenAI, UiPathChat, UiPathChatOpenAI
 
 __all__ = [
     "UiPathChat",

--- a/src/uipath_langchain/chat/openai.py
+++ b/src/uipath_langchain/chat/openai.py
@@ -1,7 +1,21 @@
+import os
+
 from uipath_langchain_client.clients.openai.chat_models import (
     UiPathAzureChatOpenAI,
     UiPathChatOpenAI,
 )
+
+DEFAULT_MODEL_NAME = "gpt-4.1-mini-2025-04-14"
+
+
+def _default_factory() -> str:
+    return os.getenv("UIPATH_MODEL_NAME", DEFAULT_MODEL_NAME)
+
+
+for _cls in (UiPathAzureChatOpenAI, UiPathChatOpenAI):
+    _cls.model_fields["model_name"].default_factory = _default_factory
+    _cls.model_rebuild(force=True)
+
 
 __all__ = [
     "UiPathAzureChatOpenAI",

--- a/src/uipath_langchain/chat/openai.py
+++ b/src/uipath_langchain/chat/openai.py
@@ -1,9 +1,34 @@
+"""OpenAI / Azure-backed chat classes.
+
+Ports the legacy ``UiPathRequestMixin`` ``model_name`` default to the upstream
+``uipath_langchain_client`` classes so ``UiPathChat()`` (no args) works:
+reads ``UIPATH_MODEL_NAME`` env var with a hardcoded fallback. The mutation
+runs at module import and is scoped per-class (pydantic stores ``FieldInfo``
+per class, so it does not leak to siblings or parents).
+"""
+
+import os
+
+from uipath_langchain_client.clients.normalized.chat_models import UiPathChat
 from uipath_langchain_client.clients.openai.chat_models import (
     UiPathAzureChatOpenAI,
     UiPathChatOpenAI,
 )
 
+DEFAULT_MODEL_NAME = "gpt-4.1-mini-2025-04-14"
+
+
+def _default_factory() -> str:
+    return os.getenv("UIPATH_MODEL_NAME", DEFAULT_MODEL_NAME)
+
+
+for _cls in (UiPathChat, UiPathAzureChatOpenAI, UiPathChatOpenAI):
+    _cls.model_fields["model_name"].default_factory = _default_factory
+    _cls.model_rebuild(force=True)
+
+
 __all__ = [
+    "UiPathChat",
     "UiPathAzureChatOpenAI",
     "UiPathChatOpenAI",
 ]

--- a/src/uipath_langchain/chat/vertex.py
+++ b/src/uipath_langchain/chat/vertex.py
@@ -1,8 +1,30 @@
+"""Vertex-backed chat classes.
+
+Ports the legacy ``GeminiModels.gemini_2_5_flash`` ``model_name`` default to
+``UiPathChatGoogleGenerativeAI`` so ``UiPathChatVertex()`` (no args) works.
+
+``UiPathChatAnthropicVertex`` has no legacy equivalent — its ``model=`` stays
+required.
+"""
+
 from uipath_langchain_client.clients.google.chat_models import (
     UiPathChatGoogleGenerativeAI,
 )
 
+DEFAULT_MODEL_NAME = "gemini-2.5-flash"
+
+
+def _default_factory() -> str:
+    return DEFAULT_MODEL_NAME
+
+
+UiPathChatGoogleGenerativeAI.model_fields[
+    "model_name"
+].default_factory = _default_factory
+UiPathChatGoogleGenerativeAI.model_rebuild(force=True)
+
 UiPathChatVertex = UiPathChatGoogleGenerativeAI
+
 
 __all__ = [
     "UiPathChatGoogleGenerativeAI",

--- a/src/uipath_langchain/chat/vertex.py
+++ b/src/uipath_langchain/chat/vertex.py
@@ -1,8 +1,23 @@
+import os
+
 from uipath_langchain_client.clients.google.chat_models import (
     UiPathChatGoogleGenerativeAI,
 )
 
+DEFAULT_MODEL_NAME = "gemini-2.5-flash"
+
+
+def _default_factory() -> str:
+    return os.getenv("UIPATH_MODEL_NAME", DEFAULT_MODEL_NAME)
+
+
+UiPathChatGoogleGenerativeAI.model_fields[
+    "model_name"
+].default_factory = _default_factory
+UiPathChatGoogleGenerativeAI.model_rebuild(force=True)
+
 UiPathChatVertex = UiPathChatGoogleGenerativeAI
+
 
 __all__ = [
     "UiPathChatGoogleGenerativeAI",

--- a/tests/chat/test_default_model_name.py
+++ b/tests/chat/test_default_model_name.py
@@ -1,0 +1,164 @@
+"""Tests for per-vendor ``model_name`` defaults on re-exported client classes.
+
+Exercises the public ``uipath_langchain.chat`` API only. Behavior is verified
+by instantiating the public classes and checking the resulting ``model_name``
+(or ``model_id`` for Bedrock), rather than introspecting pydantic fields.
+"""
+
+import pytest
+
+from tests.settings import agent_hub_dummy_settings
+
+# Expected per-vendor defaults — duplicated intentionally so these tests fail
+# loudly if someone "silently" changes the defaults without updating the test.
+_DEFAULT_OPENAI = "gpt-4.1-mini-2025-04-14"
+_DEFAULT_BEDROCK = "anthropic.claude-haiku-4-5-20251001-v1:0"
+_DEFAULT_VERTEX = "gemini-2.5-flash"
+
+
+def _get_exported(class_name: str):
+    import uipath_langchain.chat as chat_pkg
+
+    return getattr(chat_pkg, class_name)
+
+
+# (exported class name, expected default model_name)
+# Classes that had a legacy equivalent — ``UiPathChat()`` (no args) must
+# produce a usable instance with the vendor-appropriate default model.
+_CASES = [
+    ("UiPathChat", _DEFAULT_OPENAI),
+    ("UiPathAzureChatOpenAI", _DEFAULT_OPENAI),
+    ("UiPathChatOpenAI", _DEFAULT_OPENAI),
+    ("UiPathChatGoogleGenerativeAI", _DEFAULT_VERTEX),
+    ("UiPathChatVertex", _DEFAULT_VERTEX),
+    ("UiPathChatBedrock", _DEFAULT_BEDROCK),
+    ("UiPathChatBedrockConverse", _DEFAULT_BEDROCK),
+    ("UiPathChatAnthropicBedrock", _DEFAULT_BEDROCK),
+]
+
+
+@pytest.mark.parametrize("class_name, expected", _CASES)
+class TestInstantiationWithoutModelKwarg:
+    """``UiPathChat()`` (no ``model=``) must produce an instance with the
+    vendor-appropriate default ``model_name``."""
+
+    def test_no_args_uses_default(self, class_name, expected):
+        cls = _get_exported(class_name)
+        instance = cls(settings=agent_hub_dummy_settings, model_details={})
+        assert instance.model_name == expected
+
+    def test_explicit_model_kwarg_overrides_default(self, class_name, expected):
+        cls = _get_exported(class_name)
+        instance = cls(
+            model="custom-model-id",
+            settings=agent_hub_dummy_settings,
+            model_details={},
+        )
+        assert instance.model_name == "custom-model-id"
+
+
+class TestOpenAIEnvVarOverride:
+    """``UIPATH_MODEL_NAME`` overrides only the OpenAI/Azure-backed classes."""
+
+    def test_env_var_overrides_openai_default(self, monkeypatch):
+        monkeypatch.setenv("UIPATH_MODEL_NAME", "gpt-5-preview")
+        from uipath_langchain.chat import UiPathChat
+
+        instance = UiPathChat(settings=agent_hub_dummy_settings, model_details={})
+        assert instance.model_name == "gpt-5-preview"
+
+    def test_env_var_overrides_azure(self, monkeypatch):
+        monkeypatch.setenv("UIPATH_MODEL_NAME", "gpt-5-preview")
+        from uipath_langchain.chat import UiPathAzureChatOpenAI
+
+        instance = UiPathAzureChatOpenAI(
+            settings=agent_hub_dummy_settings, model_details={}
+        )
+        assert instance.model_name == "gpt-5-preview"
+
+    def test_env_var_does_not_leak_into_bedrock(self, monkeypatch):
+        """Bedrock classes stay at their vendor-specific default even when
+        ``UIPATH_MODEL_NAME`` is set."""
+        monkeypatch.setenv("UIPATH_MODEL_NAME", "gpt-5-preview")
+        from uipath_langchain.chat import UiPathChatBedrock
+
+        instance = UiPathChatBedrock(
+            settings=agent_hub_dummy_settings, model_details={}
+        )
+        assert instance.model_name == _DEFAULT_BEDROCK
+
+    def test_env_var_does_not_leak_into_vertex(self, monkeypatch):
+        """Vertex classes stay at their vendor-specific default even when
+        ``UIPATH_MODEL_NAME`` is set."""
+        monkeypatch.setenv("UIPATH_MODEL_NAME", "gpt-5-preview")
+        from uipath_langchain.chat import UiPathChatGoogleGenerativeAI
+
+        instance = UiPathChatGoogleGenerativeAI(
+            settings=agent_hub_dummy_settings, model_details={}
+        )
+        assert instance.model_name == _DEFAULT_VERTEX
+
+
+class TestExportsWithoutDefaults:
+    """Classes without a legacy equivalent keep ``model=`` required."""
+
+    def test_anthropic_raises_without_model(self):
+        from pydantic import ValidationError
+
+        from uipath_langchain.chat import UiPathChatAnthropic
+
+        with pytest.raises(ValidationError, match="model"):
+            UiPathChatAnthropic(settings=agent_hub_dummy_settings, model_details={})
+
+    def test_anthropic_vertex_raises_without_model(self):
+        """``UiPathChatAnthropicVertex`` has no legacy equivalent."""
+        from pydantic import ValidationError
+
+        from uipath_langchain.chat import UiPathChatAnthropicVertex
+
+        with pytest.raises(ValidationError, match="model"):
+            UiPathChatAnthropicVertex(
+                settings=agent_hub_dummy_settings, model_details={}
+            )
+
+    def test_fireworks_raises_without_model(self):
+        from pydantic import ValidationError
+
+        from uipath_langchain.chat import UiPathChatFireworks
+
+        with pytest.raises(ValidationError, match="model"):
+            UiPathChatFireworks(settings=agent_hub_dummy_settings, model_details={})
+
+
+class TestReExportedClassIdentity:
+    def test_uipath_chat_is_upstream_class(self):
+        """Non-wrapped re-exports share identity with the upstream class."""
+        from uipath_langchain_client.clients.normalized.chat_models import (
+            UiPathChat as _Upstream,
+        )
+
+        from uipath_langchain.chat import UiPathChat
+
+        assert UiPathChat is _Upstream
+
+    def test_uipath_chat_vertex_alias_matches_google(self):
+        """``UiPathChatVertex`` is a legacy alias for
+        ``UiPathChatGoogleGenerativeAI``."""
+        from uipath_langchain.chat import (
+            UiPathChatGoogleGenerativeAI,
+            UiPathChatVertex,
+        )
+
+        assert UiPathChatVertex is UiPathChatGoogleGenerativeAI
+
+    def test_bedrock_converse_is_subclass_of_upstream(self):
+        """``UiPathChatBedrockConverse`` is wrapped in a subclass with an
+        injecting before-validator — it is NOT identical to upstream, but
+        ``issubclass`` still holds for langchain interop."""
+        from uipath_langchain_client.clients.bedrock.chat_models import (
+            UiPathChatBedrockConverse as _Upstream,
+        )
+
+        from uipath_langchain.chat import UiPathChatBedrockConverse
+
+        assert issubclass(UiPathChatBedrockConverse, _Upstream)

--- a/tests/chat/test_default_model_name.py
+++ b/tests/chat/test_default_model_name.py
@@ -1,0 +1,131 @@
+import pytest
+from pydantic import ValidationError
+from uipath_langchain_client.clients.bedrock.chat_models import (
+    UiPathChatBedrockConverse as _UpstreamBedrockConverse,
+)
+from uipath_langchain_client.clients.normalized.chat_models import (
+    UiPathChat as _UpstreamUiPathChat,
+)
+
+from uipath_langchain.chat import (
+    UiPathAzureChatOpenAI,
+    UiPathChat,
+    UiPathChatAnthropic,
+    UiPathChatAnthropicBedrock,
+    UiPathChatAnthropicVertex,
+    UiPathChatBedrock,
+    UiPathChatBedrockConverse,
+    UiPathChatFireworks,
+    UiPathChatGoogleGenerativeAI,
+    UiPathChatOpenAI,
+    UiPathChatVertex,
+)
+
+_DEFAULT_OPENAI = "gpt-4.1-mini-2025-04-14"
+_DEFAULT_BEDROCK = "anthropic.claude-haiku-4-5-20251001-v1:0"
+_DEFAULT_VERTEX = "gemini-2.5-flash"
+
+_FAKE_JWT = (
+    "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9."
+    "eyJzdWIiOiAidGVzdCIsICJpc3MiOiAidGVzdCJ9."
+    "signature"
+)
+
+
+@pytest.fixture(autouse=True)
+def _platform_env(monkeypatch):
+    monkeypatch.setenv("UIPATH_ACCESS_TOKEN", _FAKE_JWT)
+    monkeypatch.setenv("UIPATH_URL", "https://example.com/org/tenant/orchestrator_/")
+    monkeypatch.setenv("UIPATH_TENANT_ID", "tenant")
+    monkeypatch.setenv("UIPATH_ORGANIZATION_ID", "org")
+    monkeypatch.delenv("UIPATH_MODEL_NAME", raising=False)
+
+
+_CASES = [
+    (UiPathChat, _DEFAULT_OPENAI),
+    (UiPathAzureChatOpenAI, _DEFAULT_OPENAI),
+    (UiPathChatOpenAI, _DEFAULT_OPENAI),
+    (UiPathChatGoogleGenerativeAI, _DEFAULT_VERTEX),
+    (UiPathChatVertex, _DEFAULT_VERTEX),
+    (UiPathChatBedrock, _DEFAULT_BEDROCK),
+    (UiPathChatBedrockConverse, _DEFAULT_BEDROCK),
+    (UiPathChatAnthropicBedrock, _DEFAULT_BEDROCK),
+]
+
+
+@pytest.mark.parametrize("cls, expected", _CASES)
+class TestInstantiationWithoutModelKwarg:
+    def test_no_args_uses_default(self, cls, expected):
+        llm = cls()
+        assert llm.model_name == expected
+
+    def test_explicit_model_kwarg_overrides_default(self, cls, expected):
+        llm = cls(model="custom-model-id")
+        assert llm.model_name == "custom-model-id"
+
+
+def test_uipath_chat_no_args():
+    llm = UiPathChat()
+    assert llm.model_name == _DEFAULT_OPENAI
+
+
+def test_uipath_chat_bedrock_no_args():
+    llm = UiPathChatBedrock()
+    assert llm.model_name == _DEFAULT_BEDROCK
+
+
+def test_uipath_chat_bedrock_converse_no_args():
+    llm = UiPathChatBedrockConverse()
+    assert llm.model_name == _DEFAULT_BEDROCK
+
+
+def test_uipath_chat_vertex_no_args():
+    llm = UiPathChatVertex()
+    assert llm.model_name == _DEFAULT_VERTEX
+
+
+class TestUipathModelNameEnvVarOverride:
+    def test_env_var_overrides_openai_default(self, monkeypatch):
+        monkeypatch.setenv("UIPATH_MODEL_NAME", "custom-override")
+        llm = UiPathChat()
+        assert llm.model_name == "custom-override"
+
+    def test_env_var_overrides_bedrock_default(self, monkeypatch):
+        monkeypatch.setenv("UIPATH_MODEL_NAME", "custom-override")
+        llm = UiPathChatBedrock()
+        assert llm.model_name == "custom-override"
+
+    def test_env_var_overrides_bedrock_converse_default(self, monkeypatch):
+        monkeypatch.setenv("UIPATH_MODEL_NAME", "custom-override")
+        llm = UiPathChatBedrockConverse()
+        assert llm.model_name == "custom-override"
+
+    def test_env_var_overrides_vertex_default(self, monkeypatch):
+        monkeypatch.setenv("UIPATH_MODEL_NAME", "custom-override")
+        llm = UiPathChatGoogleGenerativeAI()
+        assert llm.model_name == "custom-override"
+
+
+class TestExportsWithoutDefaults:
+    def test_anthropic_raises_without_model(self):
+        with pytest.raises(ValidationError, match="model"):
+            UiPathChatAnthropic()
+
+    def test_anthropic_vertex_raises_without_model(self):
+        with pytest.raises(ValidationError, match="model"):
+            UiPathChatAnthropicVertex()
+
+    def test_fireworks_raises_without_model(self):
+        with pytest.raises(ValidationError, match="model"):
+            UiPathChatFireworks()
+
+
+class TestReExportedClassIdentity:
+    def test_uipath_chat_is_upstream_class(self):
+        assert UiPathChat is _UpstreamUiPathChat
+
+    def test_uipath_chat_vertex_alias_matches_google(self):
+        assert UiPathChatVertex is UiPathChatGoogleGenerativeAI
+
+    def test_bedrock_converse_is_subclass_of_upstream(self):
+        assert issubclass(UiPathChatBedrockConverse, _UpstreamBedrockConverse)

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.5"
+version = "0.10.6"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

The legacy chat classes had per-vendor ``model_name`` defaults so callers could instantiate ``UiPathChat()`` or ``UiPathChatBedrock()`` with no args. The new classes re-exported from ``uipath_langchain.chat`` (backed by ``uipath_langchain_client``) don't — ``model=`` is a required pydantic field. This PR restores parity **where a legacy default existed**.

### Per-vendor defaults (verified against the git history of the legacy classes)

| Class | Default | Mechanism |
|---|---|---|
| ``UiPathChat``, ``UiPathAzureChatOpenAI``, ``UiPathChatOpenAI`` | ``UIPATH_MODEL_NAME`` → ``gpt-4.1-mini-2025-04-14`` | field ``default_factory`` |
| ``UiPathChatGoogleGenerativeAI``, ``UiPathChatVertex`` | ``gemini-2.5-flash`` | field ``default_factory`` |
| ``UiPathChatBedrock``, ``UiPathChatAnthropicBedrock`` | ``anthropic.claude-haiku-4-5-20251001-v1:0`` | field ``default_factory`` |
| ``UiPathChatBedrockConverse`` | ``anthropic.claude-haiku-4-5-20251001-v1:0`` | thin subclass with a ``model_validator(mode="before")`` |

### Classes with NO default (``model=`` stays required)

| Class | Reason |
|---|---|
| ``UiPathChatAnthropic`` | No legacy equivalent |
| ``UiPathChatAnthropicVertex`` | No legacy equivalent |
| ``UiPathChatFireworks`` | No legacy equivalent |

Only Azure-backed classes ever honored ``UIPATH_MODEL_NAME``; Bedrock and Vertex legacy defaults were hardcoded. Verified in commit ``634d9fe feat: add chat models``.

## Approach

Each existing vendor re-export file is where:
1. The upstream ``uipath_langchain_client`` class is first imported
2. The legacy ``model_name`` default is attached inline

```
src/uipath_langchain/chat/
    __init__.py       # lazy __getattr__ delegates to the vendor files
    openai.py         # sets default on UiPathChat, UiPathAzureChatOpenAI, UiPathChatOpenAI
    bedrock.py        # sets default on UiPathChatBedrock + UiPathChatAnthropicBedrock; wraps UiPathChatBedrockConverse with a before-validator subclass
    vertex.py         # sets default on UiPathChatGoogleGenerativeAI (+ UiPathChatVertex alias)
    models.py         # re-exports the OpenAI family from openai.py
```

For classes where it works, the default is attached via pydantic ``FieldInfo`` mutation directly on the upstream class: ``cls.model_fields["model_name"].default_factory = factory; cls.model_rebuild(force=True)``. Pydantic V2 gives each class its own ``FieldInfo`` instance at class creation, so the mutation is scoped to exactly that class and doesn't leak to siblings or parents in ``uipath_langchain_client``.

``UiPathChatBedrockConverse`` gets a thin subclass with a ``@model_validator(mode="before")`` because its upstream ``ChatBedrockConverse.set_disable_streaming`` reads ``model`` / ``model_id`` from the raw input dict before field defaults fire.

### Properties preserved

- ``model=...`` kwarg still wins over the default.
- For non-wrapped classes, the re-exported class IS the upstream class (identity preserved).
- For ``UiPathChatBedrockConverse``, the re-export is a subclass — ``issubclass`` check still holds.
- Tracing span names unchanged.
- Lazy imports preserved: asking for ``UiPathChat`` doesn't load Bedrock/Vertex code.

## Bookkeeping

- ``pyproject.toml``: ``0.10.5`` → ``0.10.6``
- ``uv.lock`` refreshed

## Test plan

- [x] [tests/chat/test_default_model_name.py](tests/chat/test_default_model_name.py) — **26 tests** exercising the public ``uipath_langchain.chat`` API only. For each of the 8 defaulted classes: construct ``cls()`` with no model kwarg and assert ``.model_name``. For the 3 non-defaulted classes: assert ``ValidationError`` is raised. Plus env-var behavior, identity/alias, and subclass-relationship assertions. **All pass.**
- [x] ``uv run pytest tests/chat/`` — 192 passed
- [x] ``uv run mypy src/`` — clean
- [x] ``just lint`` — clean

Generated with [Claude Code](https://claude.com/claude-code)