### PR TITLE
fix: make MemoryConfig.field_weights optional

### DIFF
--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -81,18 +81,14 @@ class MemoryConfig(BaseModel):
     # Defaults match FE episodic memory settings (agentEditor.ts:324-328)
     result_count: int = Field(default=3, ge=1, le=10)
     threshold: float = Field(default=0.0, ge=0.0, le=1.0)
-    field_weights: dict[str, float] = Field(
+    field_weights: dict[str, float] | None = Field(
+        default=None,
         description=(
             "Per-field search weights. Keys are input field names, values are "
-            "weights between 0.0 and 1.0. At least one field must be specified."
+            "weights between 0.0 and 1.0. When None, all input fields are "
+            "searched with default weights."
         ),
     )
-
-    @model_validator(mode="after")
-    def _validate_field_weights(self) -> "MemoryConfig":
-        if not self.field_weights:
-            raise ValueError("field_weights must contain at least one field")
-        return self
 
 
 class AgentGraphConfig(BaseModel):


### PR DESCRIPTION
## Summary

- Make `field_weights` optional (`dict[str, float] | None`, default `None`) instead of required with a strict validator
- Remove the `_validate_field_weights` model validator that raised `ValueError` for empty dicts

### Why

When no `fieldSettings` are configured in the agent definition's `dynamicFewShotSettings`, the runtime passes `field_weights={}` which fails validation. In practice, memory spaces may not have field weights configured — in that case, all input fields should be searched with default weights.

This was causing `AGENT_STARTUP.UNEXPECTED_ERROR` in production:
```
1 validation error for MemoryConfig
  Value error, field_weights must contain at least one field
```

## Test plan

- [x] Agents with no fieldSettings configured can start without error
- [x] Agents with fieldSettings still work as before (weights are passed through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)