### PR TITLE
refactor: re-export OpenAI-family chat classes from models.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.6"
+version = "0.10.7"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/chat/models.py
+++ b/src/uipath_langchain/chat/models.py
@@ -2,6 +2,8 @@ import os
 
 from uipath_langchain_client.clients.normalized.chat_models import UiPathChat
 
+from .openai import UiPathAzureChatOpenAI, UiPathChatOpenAI
+
 DEFAULT_MODEL_NAME = "gpt-4.1-mini-2025-04-14"
 
 
@@ -15,4 +17,6 @@ UiPathChat.model_rebuild(force=True)
 
 __all__ = [
     "UiPathChat",
+    "UiPathAzureChatOpenAI",
+    "UiPathChatOpenAI",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.6"
+version = "0.10.7"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Follow-up to #809. ``chat/models.py`` now re-exports ``UiPathAzureChatOpenAI`` and ``UiPathChatOpenAI`` from ``chat/openai.py`` alongside its existing ``UiPathChat`` — so all three OpenAI-family classes are reachable via ``uipath_langchain.chat.models``.

The implementation (per-class ``model_name`` default mutation) stays where it was in ``chat/openai.py``, so:
- existing imports of ``from uipath_langchain.chat.openai import UiPathChatOpenAI`` keep working
- the mock paths in [tests/cli/test_agent_with_guardrails.py](tests/cli/test_agent_with_guardrails.py) (e.g. ``"uipath_langchain.chat.openai.UiPathChatOpenAI.ainvoke"``) keep resolving

## Bookkeeping

- ``pyproject.toml``: ``0.10.6`` → ``0.10.7``
- ``uv.lock`` refreshed

## Test plan

- [x] ``uv run pytest tests/chat/`` — 196 passed
- [x] ``uv run mypy src/`` — clean across 160 source files
- [x] ``just lint`` — clean

Generated with [Claude Code](https://claude.com/claude-code)