### PR TITLE
chore: update pyproject template version to current minor interval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.9"
+version = "0.10.10"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/_cli/cli_new.py
+++ b/src/uipath_langchain/_cli/cli_new.py
@@ -31,7 +31,7 @@ version = "0.0.1"
 description = "{project_name}"
 authors = [{{ name = "John Doe", email = "john.doe@myemail.com" }}]
 dependencies = [
-    "uipath-langchain>=0.8.0, <0.9.0",
+    "uipath-langchain>=0.10.0, <0.11.0",
 ]
 requires-python = ">=3.11"
 """

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.9"
+version = "0.10.10"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Bump uipath-langchain package version to 0.10.10 and update the cli new template to generate projects pinned to the current minor interval (>=0.10.0, <0.11.0).