### PR TITLE
fix: clear agenthub_config via field_validator so headers are correct (#825)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.17"
+version = "0.10.18"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/chat/_settings.py
+++ b/src/uipath_langchain/chat/_settings.py
@@ -1,15 +1,16 @@
 import os
 
-from pydantic import model_validator
+from pydantic import field_validator
 
 
 class _AgentHubConfigDefaultMixin:
-    @model_validator(mode="after")
-    def _clear_agenthub_config_default(self):
-        if os.getenv("UIPATH_AGENTHUB_CONFIG") is None:
-            client_settings = getattr(self, "client_settings", None)
-            if client_settings is not None and hasattr(
-                client_settings, "agenthub_config"
-            ):
-                client_settings.agenthub_config = None
-        return self
+    @field_validator("client_settings", mode="after")
+    @classmethod
+    def _clear_agenthub_config_default(cls, client_settings):
+        if (
+            client_settings is not None
+            and os.getenv("UIPATH_AGENTHUB_CONFIG") is None
+            and hasattr(client_settings, "agenthub_config")
+        ):
+            client_settings.agenthub_config = None
+        return client_settings

--- a/tests/chat/test_agenthub_config_default.py
+++ b/tests/chat/test_agenthub_config_default.py
@@ -63,6 +63,22 @@ class TestDirectConstructorAgentHubConfig:
         llm = cls()
         assert llm.client_settings.agenthub_config == "agentsplayground"
 
+    def test_no_agenthub_header_on_inner_http_client(self, cls):
+        llm = cls()
+        client = getattr(llm, "uipath_sync_client", None)
+        if client is None:
+            pytest.skip(f"{cls.__name__} has no uipath_sync_client to inspect")
+        assert "x-uipath-agenthub-config" not in {key.lower() for key in client.headers}
+
+    def test_env_var_is_honored_on_inner_http_client(self, cls, monkeypatch):
+        monkeypatch.setenv("UIPATH_AGENTHUB_CONFIG", "agentsplayground")
+        llm = cls()
+        client = getattr(llm, "uipath_sync_client", None)
+        if client is None:
+            pytest.skip(f"{cls.__name__} has no uipath_sync_client to inspect")
+        normalized = {key.lower(): value for key, value in client.headers.items()}
+        assert normalized.get("x-uipath-agenthub-config") == "agentsplayground"
+
 
 _UPSTREAM_CASES = [
     "uipath_langchain_client.clients.normalized.chat_models:UiPathChat",

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- re-exported chat models no longer leak `X-UiPath-AgentHub-Config: agentsruntime` on direct construction

## Why

Fixes #825

the previous [fix](https://github.com/UiPath/uipath-langchain-python/pull/826) used a `model_validator(mode="after")` to null `client_settings.agenthub_config` which runs after upstream validators which materialize the inner httpx client during ctor and cache its headers from the still-default `agenthub_config="agentsruntime"`. 

moving to `field_validator("client_settings", mode="after")` clears the field before any model validator accesses the cached client.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.10.18.dev1008304470",

  # Any version from PR
  "uipath-langchain>=0.10.18.dev1008300000,<0.10.18.dev1008310000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath-langchain>=0.10.18.dev1008300000,<0.10.18.dev1008310000",
]
```
<!-- DEV_PACKAGE_END -->