### PR TITLE
fix: thread agenthub_config through chat_model_factory new path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.18"
+version = "0.10.19"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -73,8 +73,10 @@ def get_chat_model(
             returned chat model. Accepts ``list[BaseCallbackHandler]`` or a
             ``BaseCallbackManager``. Forwarded only when explicitly set.
             Ignored by the legacy factory.
-        agenthub_config: AgentHub config header value. Required by the legacy
-            factory; ignored by the new factory.
+        agenthub_config: AgentHub config header value. Threaded onto
+            ``client_settings.agenthub_config`` on the new path (PlatformSettings
+            otherwise defaults to ``"agentsruntime"``); required by the legacy
+            factory.
         use_new_llm_clients: Routes to the new ``uipath_langchain_client``
             factory when True (default). When False, routes to the legacy
             in-repo clients.
@@ -94,6 +96,14 @@ def get_chat_model(
             byo_connection_id=byo_connection_id,
             **kwargs,
         )
+
+    if agenthub_config is not None:
+        if client_settings is None:
+            from uipath_langchain_client.settings import get_default_client_settings
+
+            client_settings = get_default_client_settings()
+        if hasattr(client_settings, "agenthub_config"):
+            client_settings.agenthub_config = agenthub_config
 
     optional_kwargs = {
         k: v

--- a/tests/chat/test_chat_model_factory_agenthub.py
+++ b/tests/chat/test_chat_model_factory_agenthub.py
@@ -1,0 +1,123 @@
+"""Tests for chat_model_factory.get_chat_model agenthub_config plumbing.
+
+The new-LLM-clients path must thread agenthub_config onto client_settings
+before delegating to the upstream factory. PlatformSettings.agenthub_config
+defaults to "agentsruntime", so without explicit threading, the carefully
+computed value at the call site never reaches the wire.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from uipath_langchain.chat import chat_model_factory
+
+_FAKE_JWT = (
+    "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9."
+    "eyJzdWIiOiAidGVzdCIsICJpc3MiOiAidGVzdCJ9."
+    "signature"
+)
+
+
+@pytest.fixture(autouse=True)
+def _platform_env(monkeypatch):
+    monkeypatch.setenv("UIPATH_ACCESS_TOKEN", _FAKE_JWT)
+    monkeypatch.setenv("UIPATH_URL", "https://example.com/org/tenant/orchestrator_/")
+    monkeypatch.setenv("UIPATH_TENANT_ID", "tenant")
+    monkeypatch.setenv("UIPATH_ORGANIZATION_ID", "org")
+    monkeypatch.delenv("UIPATH_AGENTHUB_CONFIG", raising=False)
+
+
+class _Sentinel:
+    """Lightweight stand-in for the chat model returned by the upstream factory."""
+
+
+def _stub_factory(monkeypatch):
+    """Replace the upstream factory with a capturing stub.
+
+    Returns a dict that will receive the kwargs the factory was called with.
+    """
+    captured: dict = {}
+
+    def fake_factory(model, **kwargs):
+        captured["model"] = model
+        captured.update(kwargs)
+        return _Sentinel()
+
+    monkeypatch.setattr(chat_model_factory, "get_chat_model_factory", fake_factory)
+    return captured
+
+
+def test_new_path_threads_agenthub_config_into_client_settings(monkeypatch):
+    captured = _stub_factory(monkeypatch)
+
+    chat_model_factory.get_chat_model(
+        "gpt-4.1-mini-2025-04-14",
+        agenthub_config="agentsplayground",
+        use_new_llm_clients=True,
+    )
+
+    settings = captured["client_settings"]
+    assert settings is not None, "factory must receive a non-None client_settings"
+    assert settings.agenthub_config == "agentsplayground"
+
+
+def test_new_path_passes_through_when_agenthub_config_is_none(monkeypatch):
+    captured = _stub_factory(monkeypatch)
+
+    chat_model_factory.get_chat_model(
+        "gpt-4.1-mini-2025-04-14",
+        agenthub_config=None,
+        use_new_llm_clients=True,
+    )
+
+    # Without explicit agenthub_config, the factory must not synthesize a
+    # client_settings — leave it for the upstream factory to default and let
+    # the existing env-var / mixin paths govern.
+    assert captured["client_settings"] is None
+
+
+def test_new_path_mutates_caller_supplied_client_settings(monkeypatch):
+    captured = _stub_factory(monkeypatch)
+
+    caller_settings = SimpleNamespace(
+        agenthub_config="agentsruntime",
+        other_field="preserved",
+    )
+
+    chat_model_factory.get_chat_model(
+        "gpt-4.1-mini-2025-04-14",
+        client_settings=caller_settings,  # type: ignore[arg-type]
+        agenthub_config="agentsplayground",
+        use_new_llm_clients=True,
+    )
+
+    forwarded = captured["client_settings"]
+    assert forwarded is caller_settings, (
+        "caller's settings instance must be preserved, not replaced"
+    )
+    assert forwarded.agenthub_config == "agentsplayground"
+    assert forwarded.other_field == "preserved"
+
+
+def test_legacy_path_forwards_agenthub_config(monkeypatch):
+    import uipath_langchain.chat._legacy.chat_model_factory as legacy_module
+
+    captured: dict = {}
+
+    def fake_legacy_factory(
+        model, temperature, max_tokens, agenthub_config, byo_connection_id, **kwargs
+    ):
+        captured["model"] = model
+        captured["agenthub_config"] = agenthub_config
+        return _Sentinel()
+
+    monkeypatch.setattr(legacy_module, "get_chat_model", fake_legacy_factory)
+
+    chat_model_factory.get_chat_model(
+        "gpt-4.1-mini-2025-04-14",
+        agenthub_config="agentsplayground",
+        use_new_llm_clients=False,
+    )
+
+    assert captured["agenthub_config"] == "agentsplayground"

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.18"
+version = "0.10.19"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

When agents run with `command=\"debug\"` (or any non-runtime context), the LLM gateway calls were shipping `X-UiPath-AgentHub-Config: agentsruntime` instead of the computed `agentsplayground`. Every debug session was billed against the runtime quota.

## The bug

`chat_model_factory.get_chat_model` accepted an `agenthub_config` parameter whose docstring said it was \"ignored by the new factory\" — and it was. On the `use_new_llm_clients=True` path, the value was dropped before delegating to `uipath_langchain_client.factory.get_chat_model`, which built a fresh `PlatformSettings` whose `agenthub_config` defaults to `\"agentsruntime\"` upstream.

The local `_AgentHubConfigDefaultMixin` (added in #825/#830) clears that default for direct-construction users — `from uipath_langchain.chat import UiPathChat` etc. — but the factory path bypassed it entirely, so `uipath-agents` callers in `agent_graph_builder/llm_utils.py:create_llm` had their carefully computed value silently discarded.

Trace for `uipath debug agent.json`:
```
get_execution_type(ctx) → AgentExecutionType.PLAYGROUND
get_agenthub_config(PLAYGROUND) → \"agentsplayground\"  ✓
get_chat_model(model, agenthub_config=\"agentsplayground\")  → dropped on floor
get_chat_model_factory(client_settings=None)
  └─ PlatformSettings()  → agenthub_config=\"agentsruntime\"  ✗
```

## The fix

In `chat_model_factory.get_chat_model`, when `agenthub_config` is provided on the new path:
- Build `client_settings` via `get_default_client_settings()` if the caller didn't supply one.
- Set `client_settings.agenthub_config = agenthub_config` before delegating.
- Caller-supplied `client_settings` instances are **mutated**, not replaced, so other fields survive.
- `agenthub_config=None` is a pass-through — preserves existing env-var / direct-construction paths governed by the mixin.

`hasattr` guard mirrors the pattern in `_AgentHubConfigDefaultMixin._clear_agenthub_config_default`, since the `UiPathBaseSettings` ABC doesn't expose `agenthub_config` (only the concrete `PlatformBaseSettings` does).

## What changed

| File | Change |
|------|--------|
| `src/uipath_langchain/chat/chat_model_factory.py` | +12/-2 — fix + docstring update |
| `tests/chat/test_chat_model_factory_agenthub.py` | +123 — 4 new tests |
| `pyproject.toml` | 0.10.18 → 0.10.19 |
| `uv.lock` | regenerated |

## Tests added (4)

1. **Tracer** — `get_chat_model(agenthub_config=\"agentsplayground\", use_new_llm_clients=True)` results in `client_settings.agenthub_config == \"agentsplayground\"` reaching the upstream factory. *Was failing before the fix; proves the bug.*
2. **Pass-through** — `agenthub_config=None` does not synthesize a `client_settings`; preserves env-var / mixin paths.
3. **Caller settings preserved** — explicit `client_settings` is mutated, not replaced; non-`agenthub_config` fields survive.
4. **Legacy path regression guard** — `use_new_llm_clients=False` still threads `agenthub_config` to the legacy factory.

Existing `tests/chat/test_agenthub_config_default.py` (39 tests for direct-construction mixin behavior) still passes — the fix is additive, the mixin is still load-bearing for direct constructors.

Full chat suite: 239 passed.

## Out of scope / follow-ups

- **`ClaudeSDKRuntime` and `GatewayProxy` defaults** in `uipath-agents-python/src/uipath_agents/claude_sdk/{runtime.py:90,gateway_proxy.py:168}` — same `agenthub_config: str = \"agentsruntime\"` anti-pattern. Currently masked by `AgentsClaudeSDKRuntime` overriding both. Worth fixing but lives in a different repo/package.
- **Upstream `PlatformSettings.agenthub_config = \"agentsruntime\"` default** in `uipath_langchain_client` — would be a cleaner fix to set `default=None` upstream, but cross-package coordination. This PR neutralizes the symptom for the agents path without needing it.

## Test plan

- [x] New tests pass: `uv run pytest tests/chat/test_chat_model_factory_agenthub.py`
- [x] Existing mixin tests still pass: `uv run pytest tests/chat/test_agenthub_config_default.py`
- [x] Full chat suite passes: `uv run pytest tests/chat/` (239 passed)
- [x] mypy clean on changed source: `uv run mypy src/uipath_langchain/chat/chat_model_factory.py`
- [x] ruff clean on changed files
- [ ] Manual verification: run `uv run uipath debug agent.json '{}'` against a real tenant; confirm LLM gateway requests carry `X-UiPath-AgentHub-Config: agentsplayground`

🤖 Generated with [Claude Code](https://claude.com/claude-code)