### PR TITLE
fix: forward agenthub_config to upstream factory on new-clients path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.18"
+version = "0.10.19"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -23,7 +23,7 @@ dependencies = [
     "langchain-mcp-adapters==0.2.1",
     "pillow>=12.1.1",
     "a2a-sdk>=0.2.0,<1.0.0",
-    "uipath-langchain-client[openai]>=1.10.0,<1.11.0",
+    "uipath-langchain-client[openai]>=1.10.1,<1.11.0",
 ]
 
 classifiers = [
@@ -40,21 +40,21 @@ maintainers = [
 
 [project.optional-dependencies]
 anthropic = [
-    "uipath-langchain-client[anthropic]>=1.10.0,<1.11.0",
+    "uipath-langchain-client[anthropic]>=1.10.1,<1.11.0",
 ]
 vertex = [
-    "uipath-langchain-client[google]>=1.10.0,<1.11.0",
-    "uipath-langchain-client[vertexai]>=1.10.0,<1.11.0",
+    "uipath-langchain-client[google]>=1.10.1,<1.11.0",
+    "uipath-langchain-client[vertexai]>=1.10.1,<1.11.0",
 ]
 bedrock = [
-    "uipath-langchain-client[bedrock]>=1.10.0,<1.11.0",
+    "uipath-langchain-client[bedrock]>=1.10.1,<1.11.0",
     "boto3-stubs>=1.41.4",
 ]
 fireworks = [
-    "uipath-langchain-client[fireworks]>=1.10.0,<1.11.0",
+    "uipath-langchain-client[fireworks]>=1.10.1,<1.11.0",
 ]
 all = [
-    "uipath-langchain-client[all]>=1.10.0,<1.11.0",
+    "uipath-langchain-client[all]>=1.10.1,<1.11.0",
 ]
 
 [project.entry-points."uipath.middlewares"]

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -44,7 +44,6 @@ def get_chat_model(
     timeout: float | None = DEFAULT_TIMEOUT_SECONDS,
     max_retries: int | None = DEFAULT_MAX_RETRIES,
     callbacks: Callbacks = _UNSET,
-    # Legacy-only arguments
     agenthub_config: str | None = None,
     use_new_llm_clients: bool = True,
     **kwargs: Any,
@@ -74,7 +73,7 @@ def get_chat_model(
             ``BaseCallbackManager``. Forwarded only when explicitly set.
             Ignored by the legacy factory.
         agenthub_config: AgentHub config header value. Required by the legacy
-            factory; ignored by the new factory.
+            factory; forwarded to the new factory.
         use_new_llm_clients: Routes to the new ``uipath_langchain_client``
             factory when True (default). When False, routes to the legacy
             in-repo clients.
@@ -115,6 +114,7 @@ def get_chat_model(
         vendor_type=vendor_type,
         api_flavor=api_flavor,
         custom_class=custom_class,
+        agenthub_config=agenthub_config,
         **optional_kwargs,
         **kwargs,
     )

--- a/tests/chat/test_chat_model_factory_agenthub.py
+++ b/tests/chat/test_chat_model_factory_agenthub.py
@@ -1,0 +1,43 @@
+"""Tests that ``chat_model_factory.get_chat_model`` forwards ``agenthub_config``
+to the upstream ``uipath_langchain_client`` factory on the new-clients path."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from uipath_langchain.chat.chat_model_factory import get_chat_model
+
+
+class TestForwardAgentHubConfig:
+    def test_agenthub_config_forwarded_on_new_path(self, mocker):
+        """The kwarg the caller passes must reach the upstream factory verbatim."""
+        upstream = mocker.patch(
+            "uipath_langchain.chat.chat_model_factory.get_chat_model_factory",
+            return_value=MagicMock(),
+        )
+
+        get_chat_model(
+            "gpt-4o",
+            agenthub_config="agentsplayground",
+            use_new_llm_clients=True,
+        )
+
+        _, kwargs = upstream.call_args
+        assert kwargs.get("agenthub_config") == "agentsplayground"
+
+    def test_agenthub_config_none_forwarded_on_new_path(self, mocker):
+        """Pass-through preserves None so upstream applies its own default."""
+        upstream = mocker.patch(
+            "uipath_langchain.chat.chat_model_factory.get_chat_model_factory",
+            return_value=MagicMock(),
+        )
+
+        get_chat_model("gpt-4o", use_new_llm_clients=True)
+
+        _, kwargs = upstream.call_args
+        assert kwargs.get("agenthub_config") is None
+
+    def test_legacy_path_still_requires_agenthub_config(self, mocker):
+        """Legacy factory contract is unchanged: missing agenthub_config raises."""
+        with pytest.raises(ValueError, match="agenthub_config is required"):
+            get_chat_model("gpt-4o", use_new_llm_clients=False)

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.18"
+version = "0.10.19"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4452,13 +4452,13 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "uipath", specifier = ">=2.10.61,<2.11.0" },
     { name = "uipath-core", specifier = ">=0.5.15,<0.6.0" },
-    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.10.0,<1.11.0" },
-    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.10.0,<1.11.0" },
-    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.10.0,<1.11.0" },
-    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.10.0,<1.11.0" },
-    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.10.0,<1.11.0" },
-    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.10.0,<1.11.0" },
-    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.10.0,<1.11.0" },
+    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.10.1,<1.11.0" },
+    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.10.1,<1.11.0" },
+    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.10.1,<1.11.0" },
+    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.10.1,<1.11.0" },
+    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.10.1,<1.11.0" },
+    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.10.1,<1.11.0" },
+    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.10.1,<1.11.0" },
     { name = "uipath-platform", specifier = ">=0.1.45,<0.2.0" },
     { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
 ]
@@ -4482,15 +4482,15 @@ dev = [
 
 [[package]]
 name = "uipath-langchain-client"
-version = "1.10.0"
+version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
     { name = "uipath-llm-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2d/6a683f7635fd2daab21ad3c451f168ac9893011fb05e3c976634ce6e5642/uipath_langchain_client-1.10.0.tar.gz", hash = "sha256:a50feb02d612dd18ee97d036f61125dbc875888da248995963dffa1428e2b3f3", size = 35833, upload-time = "2026-04-23T18:18:15.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/b8/5034d1a12a24e34138b2f3e0bba389d9ff870daf3511dbe71bee121e5e03/uipath_langchain_client-1.10.1.tar.gz", hash = "sha256:151ab00cd10c173df575ba64e3a81a9ba2ced268eaec9e4b822a8109e4863c8b", size = 36113, upload-time = "2026-05-08T11:39:49.538Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/e1/4e17ef24c644962b7a2120d4ad6a9903cc5a3154cf3f17b6012a31b5867c/uipath_langchain_client-1.10.0-py3-none-any.whl", hash = "sha256:4afb08843f65ec96a9ef0dbc8fde5e087a5357dd761b3f84da2389a06a11a084", size = 46015, upload-time = "2026-04-23T18:18:14.119Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/03/73aed19e0271f5cb2c62d15b7bba3274e110c9a738815ad975fb8348d8dc/uipath_langchain_client-1.10.1-py3-none-any.whl", hash = "sha256:73a72ffb3c0b992d295650d331f5b4c58f4d18709bfffe1e2f699525d951da10", size = 46184, upload-time = "2026-05-08T11:39:50.607Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- forward `agenthub_config` from `chat_model_factory.get_chat_model` to the upstream `uipath_langchain_client.factory.get_chat_model` (was silently dropped on the `use_new_llm_clients=True` path)
- bump upstream pin to `uipath-langchain-client>=1.10.1` so the new kwarg is available

## Why

callers that pass `agenthub_config` to `get_chat_model` had it silently dropped on the new-clients path. every gateway request shipped the upstream default regardless of the caller's intent.

depends on https://github.com/UiPath/uipath-llm-client-python/pull/75