### PR TITLE
ci: add coverage report on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,4 @@ jobs:
       UIPATH_URL: ${{ secrets.UIPATH_URL }}
       UIPATH_CLIENT_ID: ${{ secrets.UIPATH_CLIENT_ID }}
       UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,14 @@ name: Test
 on:
   workflow_call:
     secrets:
-        UIPATH_URL:
-          required: true
-        UIPATH_CLIENT_ID:
-          required: true
-        UIPATH_CLIENT_SECRET:
-          required: true
+      UIPATH_URL:
+        required: true
+      UIPATH_CLIENT_ID:
+        required: true
+      UIPATH_CLIENT_SECRET:
+        required: true
+      SONAR_TOKEN:
+        required: false
 
 jobs:
   test:
@@ -41,19 +43,66 @@ jobs:
         if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')"
         uses: actions/setup-python@v5
         with:
-          python-version-file: ".python-version"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')"
-        run: uv sync --all-extras
+        run: uv sync --all-extras --python ${{ matrix.python-version }}
 
       - name: Run tests
-        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')"
-        run: uv run pytest
+        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13')"
+        run: uv run --python ${{ matrix.python-version }} pytest
         env:
           UIPATH_URL: ${{ secrets.UIPATH_URL }}
           UIPATH_CLIENT_ID: ${{ secrets.UIPATH_CLIENT_ID }}
           UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
 
+      - name: Run tests with coverage
+        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'"
+        run: uv run --python ${{ matrix.python-version }} pytest --cov-report=xml --cov-report=html --tb=short
+        env:
+          UIPATH_URL: ${{ secrets.UIPATH_URL }}
+          UIPATH_CLIENT_ID: ${{ secrets.UIPATH_CLIENT_ID }}
+          UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
+
+      - name: Upload coverage HTML report
+        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-report
+          path: htmlcov/
+          retention-days: 30
+
+      - name: Upload coverage XML report
+        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml-report
+          path: coverage.xml
+          retention-days: 30
+
     continue-on-error: true
 
+  sonarcloud:
+    name: SonarCloud
+    needs: test
+    runs-on: ubuntu-latest
+    if: always() && needs.test.result != 'failure'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: coverage-xml-report
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,9 +127,30 @@ disallow_untyped_defs = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
-addopts = "-ra -q"
+addopts = "-ra -q --cov=src/uipath_langchain --cov-report=term-missing"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["src/uipath_langchain"]
+relative_files = true
+omit = [
+  "*/tests/*",
+  "*/__pycache__/*",
+  "*/site-packages/*",
+  "*/conftest.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+precision = 2
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "raise NotImplementedError",
+  "if TYPE_CHECKING:",
+  "@(abc\\.)?abstractmethod",
+]
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=UiPath_uipath-langchain-python
+sonar.organization=ui
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=src/uipath_langchain
+sonar.tests=tests
+
+sonar.python.version=3.11,3.12,3.13
+sonar.python.coverage.reportPaths=coverage.xml
+
+sonar.exclusions=**/samples/**,**/testcases/**,**/template/**
+
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- coverage xml/html artifacts on PRs, 30-day retention
- sonarcloud scan imports coverage.xml and evaluates the quality gate on new code
- coverage runs only on the ubuntu/3.13 matrix cell, no duplicate test runs
- also runs on push to main so sonarcloud has a baseline for new-code comparisons
- fixes the matrix `python-version` being silently ignored: `setup-python` read `python-version-file: .python-version` (3.11) on every cell, and `uv run` rebuilt the venv from `.python-version` losing the synced extras. now both `uv sync` and `uv run` explicitly use `${{ matrix.python-version }}` so 3.11/3.12/3.13 actually get exercised.