### PR TITLE
feat: remove file type restriction for analyze files tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.21"
+version = "0.10.22"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/multimodal/invoke.py
+++ b/src/uipath_langchain/agent/multimodal/invoke.py
@@ -16,7 +16,6 @@ from .types import MAX_FILE_SIZE_BYTES, FileInfo
 from .utils import (
     download_file_base64,
     is_image,
-    is_pdf,
     is_tiff,
     sanitize_filename,
     stream_tiff_to_content_blocks,
@@ -32,8 +31,10 @@ async def build_file_content_blocks_for(
 ) -> list[DataContentBlock]:
     """Build LangChain content blocks for a single file attachment.
 
-    Handles all supported MIME types in one place: images, PDFs, and
-    TIFFs (multi-page, converted to individual PNG blocks).
+    Images become image blocks, TIFFs are split into per-page PNG blocks,
+    and every other MIME type — PDF, text, office documents, and any
+    arbitrary binary — is wrapped in a generic file block. Provider
+    compatibility for non-image formats is delegated to the LLM.
 
     Args:
         file_info: File URL, name, and MIME type.
@@ -44,8 +45,7 @@ async def build_file_content_blocks_for(
         A list of DataContentBlock instances for the file.
 
     Raises:
-        ValueError: If the MIME type is not supported or the file exceeds
-            the size limit for LLM payloads.
+        ValueError: If the file exceeds the size limit for LLM payloads.
     """
     if is_tiff(file_info.mime_type):
         try:
@@ -60,16 +60,15 @@ async def build_file_content_blocks_for(
 
     if is_image(file_info.mime_type):
         return [create_image_block(base64=base64_file, mime_type=file_info.mime_type)]
-    if is_pdf(file_info.mime_type):
-        return [
-            create_file_block(
-                base64=base64_file,
-                mime_type=file_info.mime_type,
-                filename=sanitize_filename(file_info.name),
-            )
-        ]
 
-    raise ValueError(f"Unsupported mime_type={file_info.mime_type}")
+    mime_type = file_info.mime_type or "application/octet-stream"
+    return [
+        create_file_block(
+            base64=base64_file,
+            mime_type=mime_type,
+            filename=sanitize_filename(file_info.name),
+        )
+    ]
 
 
 async def build_file_content_blocks(files: list[FileInfo]) -> list[DataContentBlock]:

--- a/tests/agent/multimodal/test_utils.py
+++ b/tests/agent/multimodal/test_utils.py
@@ -218,13 +218,31 @@ class TestBuildFileContentBlocksFor:
         assert len(blocks) == 1
         assert blocks[0]["type"] == "image"
 
-    async def test_unsupported_mime_type_raises(self, httpx_mock: HTTPXMock) -> None:
-        content = b"some data"
+    async def test_arbitrary_mime_type_returns_file_block(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        content = b"col1,col2\n1,2\n"
         httpx_mock.add_response(url=FILE_URL, content=content)
         file_info = FileInfo(url=FILE_URL, name="data.csv", mime_type="text/csv")
 
-        with pytest.raises(ValueError, match="Unsupported"):
-            await build_file_content_blocks_for(file_info)
+        blocks = await build_file_content_blocks_for(file_info)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "file"
+        assert blocks[0]["mime_type"] == "text/csv"
+
+    async def test_empty_mime_type_defaults_to_octet_stream(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        content = b"raw bytes"
+        httpx_mock.add_response(url=FILE_URL, content=content)
+        file_info = FileInfo(url=FILE_URL, name="blob.bin", mime_type="")
+
+        blocks = await build_file_content_blocks_for(file_info)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "file"
+        assert blocks[0]["mime_type"] == "application/octet-stream"
 
     async def test_error_includes_filename(self, httpx_mock: HTTPXMock) -> None:
         """ValueError from download includes the filename for debuggability."""

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.21"
+version = "0.10.22"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
- Remove file type restrictions and let the LLM handle unsupported file types.