### PR TITLE
ci: drop redundant test job from cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,20 +12,12 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
-  test:
-    uses: ./.github/workflows/test.yml
-    secrets:
-      UIPATH_URL: ${{ secrets.UIPATH_URL }}
-      UIPATH_CLIENT_ID: ${{ secrets.UIPATH_CLIENT_ID }}
-      UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
-
   build:
     name: Build
     runs-on: ubuntu-latest
 
     needs:
       - lint
-      - test
 
     if: ${{ github.repository == 'UiPath/uipath-langchain-python' }}
     permissions:


### PR DESCRIPTION
## Summary
- remove the `test` job from `cd.yml` so publishing on `main` no longer depends on a second tests + sonarcloud run
- tests and sonarcloud continue to run via `ci.yml` on prs and on push to `main`

## Why

the version-bump push that triggers `cd.yml` was just merged through `ci.yml`, which already ran tests and sonarcloud on the same commit. the cd-side run added no signal and was blocking releases because `SONAR_TOKEN` was not forwarded to the reusable workflow.