### PR TITLE
fix: reinsert citation tags on chat history replay [JAR-9909]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.24"
+version = "0.10.25"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/runtime/_citations.py
+++ b/src/uipath_langchain/runtime/_citations.py
@@ -5,7 +5,7 @@ import logging
 import mimetypes
 import re
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Sequence
 from uuid import uuid4
 
 from langchain_core.messages.tool import ToolCall
@@ -265,6 +265,48 @@ def extract_citations_from_text(
         offset += length
 
     return ("".join(cleaned_parts), citations)
+
+
+def reconstruct_text_with_citations(
+    cleaned_text: str,
+    citations: Sequence[UiPathConversationCitationData] | None,
+) -> str:
+    """Inverse of extract_citations_from_text: reinsert <uip:cite/> tags into cleaned text.
+
+    Used when replaying assistant messages so the LLM sees its own prior citation markup
+    and doesn't over- or under-cite on the next turn.
+    """
+    if not citations:
+        return cleaned_text
+
+    parts: list[str] = []
+    cursor = 0
+    for citation in citations:
+        insert_pos = citation.offset + citation.length
+        parts.append(cleaned_text[cursor:insert_pos])
+        for source in citation.sources:
+            parts.append(_source_to_cite_tag(source))
+        cursor = insert_pos
+
+    parts.append(cleaned_text[cursor:])
+    return "".join(parts)
+
+
+def _source_to_cite_tag(
+    source: UiPathConversationCitationSourceUrl | UiPathConversationCitationSourceMedia,
+) -> str:
+    if isinstance(source, UiPathConversationCitationSourceUrl):
+        return (
+            f'<uip:cite title="{_escape_attr(source.title)}" '
+            f'url="{_escape_attr(source.url)}" />'
+        )
+    if isinstance(source, UiPathConversationCitationSourceMedia):
+        return (
+            f'<uip:cite title="{_escape_attr(source.title)}" '
+            f'reference="{_escape_attr(source.download_url or "")}" '
+            f'page_number="{_escape_attr(source.page_number or "")}" />'
+        )
+    return ""
 
 
 def _escape_attr(value: str) -> str:

--- a/src/uipath_langchain/runtime/_citations.py
+++ b/src/uipath_langchain/runtime/_citations.py
@@ -155,30 +155,6 @@ class CitationStreamProcessor:
         self._source_numbers: dict[_ParsedCitation, int] = {}
         self._next_number: int = 1
 
-    def _build_content_part_citation(
-        self,
-        text: str,
-        citation: _ParsedCitation | None = None,
-    ) -> UiPathConversationContentPartChunkEvent:
-        if citation is None:
-            return UiPathConversationContentPartChunkEvent(data=text)
-
-        source, self._next_number = _make_source(
-            citation, self._source_numbers, self._next_number
-        )
-
-        if not source:
-            return UiPathConversationContentPartChunkEvent(data=text)
-
-        return UiPathConversationContentPartChunkEvent(
-            data=text,
-            citation=UiPathConversationCitationEvent(
-                citation_id=str(uuid4()),
-                start=UiPathConversationCitationStartEvent(),
-                end=UiPathConversationCitationEndEvent(sources=[source]),
-            ),
-        )
-
     def _process_segments(
         self, text: str
     ) -> list[UiPathConversationContentPartChunkEvent]:
@@ -186,16 +162,32 @@ class CitationStreamProcessor:
         if not segments:
             return []
 
+        # Emit each segment as up to two chunk events: a plain text chunk for the
+        # preceding text (if any), then a citation-only chunk with no data. CAS's
+        # content-part-event-helper records offset on start and length on end; with
+        # no data between them, length resolves to 0 (a point citation).
         content_parts: list[UiPathConversationContentPartChunkEvent] = []
         for segment_text, citation in segments:
-            if citation is not None:
-                content_part_with_citation = self._build_content_part_citation(
-                    segment_text, citation
+            if segment_text:
+                content_parts.append(
+                    UiPathConversationContentPartChunkEvent(data=segment_text)
                 )
-                content_parts.append(content_part_with_citation)
-            elif segment_text:
-                content_part_plain = self._build_content_part_citation(segment_text)
-                content_parts.append(content_part_plain)
+            if citation is None:
+                continue
+            source, self._next_number = _make_source(
+                citation, self._source_numbers, self._next_number
+            )
+            if source is None:
+                continue
+            content_parts.append(
+                UiPathConversationContentPartChunkEvent(
+                    citation=UiPathConversationCitationEvent(
+                        citation_id=str(uuid4()),
+                        start=UiPathConversationCitationStartEvent(),
+                        end=UiPathConversationCitationEndEvent(sources=[source]),
+                    ),
+                )
+            )
 
         return content_parts
 
@@ -229,7 +221,12 @@ class CitationStreamProcessor:
 def extract_citations_from_text(
     text: str,
 ) -> tuple[str, list[UiPathConversationCitationData]]:
-    """Parse inline <uip:cite .../> tags from text and return cleaned text with structured citations."""
+    """Parse inline <uip:cite .../> tags from text and return cleaned text with structured point citations.
+
+    Each tag becomes a length=0 citation anchored at the offset where the tag appeared
+    (i.e., immediately after its preceding text). This mirrors what the streaming emitter
+    produces on the wire, where start/end fire around an empty data slice.
+    """
     segments = _parse_citations(text)
     if not segments:
         return (text, [])
@@ -242,27 +239,20 @@ def extract_citations_from_text(
 
     for segment_text, citation in segments:
         cleaned_parts.append(segment_text)
-        length = len(segment_text)
+        offset += len(segment_text)
 
-        if citation is not None:
-            source, next_number = _make_source(citation, source_numbers, next_number)
-            if not source:
-                offset += length
-                continue
-            if length > 0:
-                citations.append(
-                    UiPathConversationCitationData(
-                        offset=offset,
-                        length=length,
-                        sources=[source],
-                    )
-                )
-            elif citations:
-                # Back-to-back citation with no preceding text:
-                # merge into the previous citation's sources (one citation data with two sources)
-                citations[-1].sources.append(source)
-
-        offset += length
+        if citation is None:
+            continue
+        source, next_number = _make_source(citation, source_numbers, next_number)
+        if source is None:
+            continue
+        citations.append(
+            UiPathConversationCitationData(
+                offset=offset,
+                length=0,
+                sources=[source],
+            )
+        )
 
     return ("".join(cleaned_parts), citations)
 
@@ -274,19 +264,23 @@ def reconstruct_text_with_citations(
     """Inverse of extract_citations_from_text: reinsert <uip:cite/> tags into cleaned text.
 
     Used when replaying assistant messages so the LLM sees its own prior citation markup
-    and doesn't over- or under-cite on the next turn.
+    and doesn't over- or under-cite on the next turn. Citations are point anchors
+    (length=0), so tags are inserted at the offset directly.
     """
     if not citations:
         return cleaned_text
 
+    # Sort by offset so we never walk the cursor backwards — out-of-order
+    # citations would otherwise re-emit text already added to `parts`.
+    ordered = sorted(citations, key=lambda c: c.offset)
+
     parts: list[str] = []
     cursor = 0
-    for citation in citations:
-        insert_pos = citation.offset + citation.length
-        parts.append(cleaned_text[cursor:insert_pos])
+    for citation in ordered:
+        parts.append(cleaned_text[cursor : citation.offset])
         for source in citation.sources:
             parts.append(_source_to_cite_tag(source))
-        cursor = insert_pos
+        cursor = citation.offset
 
     parts.append(cleaned_text[cursor:])
     return "".join(parts)

--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -39,7 +39,11 @@ from uipath.core.chat import (
 )
 from uipath.runtime import UiPathRuntimeStorageProtocol
 
-from ._citations import CitationStreamProcessor, extract_citations_from_text
+from ._citations import (
+    CitationStreamProcessor,
+    extract_citations_from_text,
+    reconstruct_text_with_citations,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +144,9 @@ class UiPathChatMessagesMapper:
                     ):
                         text = str(data.inline)
                         if text:
+                            text = reconstruct_text_with_citations(
+                                text, uipath_content_part.citations
+                            )
                             content_blocks.append(
                                 create_text_block(
                                     text, id=uipath_content_part.content_part_id

--- a/tests/runtime/test_chat_message_mapper.py
+++ b/tests/runtime/test_chat_message_mapper.py
@@ -12,6 +12,7 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from uipath.core.chat import (
+    UiPathConversationCitation,
     UiPathConversationCitationSourceMedia,
     UiPathConversationCitationSourceUrl,
     UiPathConversationContentPart,
@@ -798,6 +799,70 @@ class TestMapMessages:
         assert isinstance(msg, AIMessage)
         assert msg.content == "I can help with that"
         assert msg.additional_kwargs["message_id"] == "msg-1"
+
+    def test_map_messages_reinserts_uip_cite_tags_for_assistant(self):
+        """Assistant messages with stored citations have <uip:cite/> tags reinserted on replay."""
+        mapper = UiPathChatMessagesMapper("test-runtime", None)
+        uipath_msg = UiPathConversationMessage(
+            message_id="msg-1",
+            role="assistant",
+            created_at=TEST_TIMESTAMP,
+            updated_at=TEST_TIMESTAMP,
+            content_parts=[
+                UiPathConversationContentPart(
+                    content_part_id="part-1",
+                    mime_type="text/markdown",
+                    data=UiPathInlineValue(inline="First and second."),
+                    citations=[
+                        UiPathConversationCitation(
+                            citation_id="cit-1",
+                            created_at=TEST_TIMESTAMP,
+                            updated_at=TEST_TIMESTAMP,
+                            offset=0,
+                            length=5,
+                            sources=[
+                                UiPathConversationCitationSourceUrl(
+                                    title="A",
+                                    number=1,
+                                    url="https://a.com",
+                                )
+                            ],
+                        ),
+                        UiPathConversationCitation(
+                            citation_id="cit-2",
+                            created_at=TEST_TIMESTAMP,
+                            updated_at=TEST_TIMESTAMP,
+                            offset=5,
+                            length=11,
+                            sources=[
+                                UiPathConversationCitationSourceMedia(
+                                    title="Report.pdf",
+                                    number=2,
+                                    mime_type="application/pdf",
+                                    download_url="https://r.com",
+                                    page_number="5",
+                                )
+                            ],
+                        ),
+                    ],
+                    created_at=TEST_TIMESTAMP,
+                    updated_at=TEST_TIMESTAMP,
+                )
+            ],
+            tool_calls=[],
+            interrupts=[],
+        )
+
+        result = mapper.map_messages([uipath_msg])
+
+        assert len(result) == 1
+        msg = result[0]
+        assert isinstance(msg, AIMessage)
+        assert msg.content == (
+            'First<uip:cite title="A" url="https://a.com" />'
+            ' and second<uip:cite title="Report.pdf" reference="https://r.com" '
+            'page_number="5" />.'
+        )
 
     def test_map_messages_external_value_produces_attachment_content(self):
         """Should include attachment metadata in content for external value content parts."""

--- a/tests/runtime/test_chat_message_mapper.py
+++ b/tests/runtime/test_chat_message_mapper.py
@@ -818,8 +818,8 @@ class TestMapMessages:
                             citation_id="cit-1",
                             created_at=TEST_TIMESTAMP,
                             updated_at=TEST_TIMESTAMP,
-                            offset=0,
-                            length=5,
+                            offset=5,
+                            length=0,
                             sources=[
                                 UiPathConversationCitationSourceUrl(
                                     title="A",
@@ -832,8 +832,8 @@ class TestMapMessages:
                             citation_id="cit-2",
                             created_at=TEST_TIMESTAMP,
                             updated_at=TEST_TIMESTAMP,
-                            offset=5,
-                            length=11,
+                            offset=16,
+                            length=0,
                             sources=[
                                 UiPathConversationCitationSourceMedia(
                                     title="Report.pdf",
@@ -1741,8 +1741,9 @@ class TestMapLangChainAIMessageCitations:
         assert isinstance(part.data, UiPathInlineValue)
         assert part.data.inline == "Some fact and more."
         assert len(part.citations) == 1
-        assert part.citations[0].offset == 0
-        assert part.citations[0].length == 9  # "Some fact"
+        # Point citation anchored right after "Some fact".
+        assert part.citations[0].offset == 9
+        assert part.citations[0].length == 0
         source = part.citations[0].sources[0]
         assert isinstance(source, UiPathConversationCitationSourceUrl)
         assert source.url == "https://doc.com"
@@ -1988,7 +1989,7 @@ class TestMapAiMessageToEvents:
 
     @pytest.mark.asyncio
     async def test_processes_citations_in_content(self):
-        """Should strip citation tags, emit cleaned text, and attach citation to chunk."""
+        """Should strip citation tags, emit cleaned text, and emit a citation-only chunk."""
         mapper = UiPathChatMessagesMapper("test-runtime", None)
         msg = AIMessage(
             content='Some fact<uip:cite title="Doc" url="https://doc.com" /> and more.',
@@ -2007,13 +2008,13 @@ class TestMapAiMessageToEvents:
         for e in chunk_events:
             assert e.content_part is not None
             assert e.content_part.chunk is not None
-            assert e.content_part.chunk.data is not None
-            texts.append(e.content_part.chunk.data)
+            if e.content_part.chunk.data is not None:
+                texts.append(e.content_part.chunk.data)
         full_text = "".join(texts)
         assert "uip:cite" not in full_text
         assert "Some fact" in full_text
 
-        # The "Some fact" chunk should carry an attached citation
+        # The citation is emitted as its own chunk with no data (point citation).
         citation_chunk = next(
             e
             for e in chunk_events
@@ -2023,6 +2024,7 @@ class TestMapAiMessageToEvents:
         )
         assert citation_chunk.content_part is not None
         assert citation_chunk.content_part.chunk is not None
+        assert citation_chunk.content_part.chunk.data is None
         citation_event = citation_chunk.content_part.chunk.citation
         assert citation_event is not None
         assert citation_event.end is not None

--- a/tests/runtime/test_citations.py
+++ b/tests/runtime/test_citations.py
@@ -17,6 +17,7 @@ from uipath_langchain.runtime._citations import (
     cas_deep_rag_citation_wrapper,
     convert_citations_to_inline_tags,
     extract_citations_from_text,
+    reconstruct_text_with_citations,
 )
 
 
@@ -755,6 +756,59 @@ class TestExtractCitationsFromText:
         cleaned, citations = extract_citations_from_text(text)
         assert citations[0].sources[0].number == 1
         assert citations[1].sources[0].number == 2
+
+
+class TestReconstructTextWithCitations:
+    """Test cases for reconstruct_text_with_citations - the inverse of extract_citations_from_text."""
+
+    def test_no_citations_returns_text_unchanged(self):
+        assert reconstruct_text_with_citations("hello world", []) == "hello world"
+        assert reconstruct_text_with_citations("hello world", None) == "hello world"
+
+    def test_url_citation_roundtrip(self):
+        original = 'Some fact<uip:cite title="Doc" url="https://doc.com" />'
+        cleaned, citations = extract_citations_from_text(original)
+        assert reconstruct_text_with_citations(cleaned, citations) == original
+
+    def test_media_citation_roundtrip(self):
+        original = (
+            'A finding<uip:cite title="Report.pdf" reference="https://r.com" '
+            'page_number="5" />'
+        )
+        cleaned, citations = extract_citations_from_text(original)
+        assert reconstruct_text_with_citations(cleaned, citations) == original
+
+    def test_multiple_citations_roundtrip(self):
+        original = (
+            'First<uip:cite title="A" url="https://a.com" />'
+            ' and second<uip:cite title="B" url="https://b.com" />.'
+        )
+        cleaned, citations = extract_citations_from_text(original)
+        assert reconstruct_text_with_citations(cleaned, citations) == original
+
+    def test_back_to_back_citations_roundtrip(self):
+        original = (
+            'Text<uip:cite title="A" url="https://a.com" />'
+            '<uip:cite title="B" url="https://b.com" />'
+        )
+        cleaned, citations = extract_citations_from_text(original)
+        # Both sources merged into a single citation; reconstruction should
+        # re-emit them back-to-back after the shared text span.
+        assert reconstruct_text_with_citations(cleaned, citations) == original
+
+    def test_citation_with_trailing_text_roundtrip(self):
+        original = 'A fact<uip:cite title="S" url="https://s.com" /> and more text.'
+        cleaned, citations = extract_citations_from_text(original)
+        assert reconstruct_text_with_citations(cleaned, citations) == original
+
+    def test_quotes_in_title_are_escaped(self):
+        cleaned, citations = extract_citations_from_text(
+            r'A fact<uip:cite title="The \"Real\" Story" url="https://example.com" />'
+        )
+        reconstructed = reconstruct_text_with_citations(cleaned, citations)
+        assert 'title="The "Real" Story"' not in reconstructed
+        assert "&quot;Real&quot;" in reconstructed
+        assert 'url="https://example.com"' in reconstructed
 
 
 class TestConvertCitationsToInlineTags:

--- a/tests/runtime/test_citations.py
+++ b/tests/runtime/test_citations.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 from langchain_core.messages.tool import ToolCall, ToolMessage
 from uipath.core.chat import (
+    UiPathConversationCitationData,
     UiPathConversationCitationSourceMedia,
     UiPathConversationCitationSourceUrl,
 )
@@ -77,11 +78,15 @@ class TestCitationStreamProcessor:
         proc = CitationStreamProcessor()
         text = 'A fact<uip:cite title="Doc" url="https://doc.com" />'
         events = proc.add_chunk(text)
-        assert len(events) == 1
+        # Preceding text and citation are emitted as two separate chunks so CAS
+        # resolves the citation to a point (offset=N, length=0).
+        assert len(events) == 2
         assert events[0].data == "A fact"
-        assert events[0].citation is not None
-        assert events[0].citation.end is not None
-        source = events[0].citation.end.sources[0]
+        assert events[0].citation is None
+        assert events[1].data is None
+        assert events[1].citation is not None
+        assert events[1].citation.end is not None
+        source = events[1].citation.end.sources[0]
         assert isinstance(source, UiPathConversationCitationSourceUrl)
         assert source.url == "https://doc.com"
 
@@ -89,10 +94,13 @@ class TestCitationStreamProcessor:
         proc = CitationStreamProcessor()
         text = 'A fact<uip:cite title="Report.pdf" reference="https://doc.com" page_number="3" />'
         events = proc.add_chunk(text)
-        assert len(events) == 1
-        assert events[0].citation is not None
-        assert events[0].citation.end is not None
-        source = events[0].citation.end.sources[0]
+        assert len(events) == 2
+        assert events[0].data == "A fact"
+        assert events[0].citation is None
+        assert events[1].data is None
+        assert events[1].citation is not None
+        assert events[1].citation.end is not None
+        source = events[1].citation.end.sources[0]
         assert isinstance(source, UiPathConversationCitationSourceMedia)
         assert source.download_url == "https://doc.com"
         assert source.page_number == "3"
@@ -154,12 +162,14 @@ class TestCitationStreamProcessor:
         events = proc.add_chunk(text)
         events.extend(proc.finalize())
 
+        # One plain text event for "First", followed by two citation-only events.
+        plain = [e for e in events if e.data]
+        assert len(plain) == 1
+        assert plain[0].data == "First"
         cited_events = [e for e in events if e.citation is not None]
         assert len(cited_events) == 2
-        assert cited_events[0].data == "First"
+        assert all(e.data is None for e in cited_events)
         assert cited_events[0].citation.end.sources[0].url == "https://doc1.com"
-        # Second citation has empty text (back-to-back)
-        assert cited_events[1].data == ""
         assert cited_events[1].citation.end.sources[0].url == "https://doc2.com"
 
     def test_citation_at_beginning_of_text(self):
@@ -168,8 +178,10 @@ class TestCitationStreamProcessor:
         text = '<uip:cite title="Doc" url="https://doc.com" />Some text after.'
         events = proc.add_chunk(text)
         events.extend(proc.finalize())
+        # No leading text event (empty preceding text is skipped), then citation,
+        # then plain text event for trailing content.
         assert len(events) == 2
-        assert events[0].data == ""
+        assert events[0].data is None
         assert events[0].citation is not None
         assert events[0].citation.end.sources[0].url == "https://doc.com"
         assert events[1].data == "Some text after."
@@ -219,9 +231,9 @@ class TestCitationStreamProcessor:
         assert combined == "Fact more"
         cited = [e for e in all_events if e.citation is not None]
         assert len(cited) == 1
-        # "Fact" was emitted as plain text before the '<' started buffering,
-        # so the citation event has empty data (back-to-back with preceding text)
-        assert cited[0].data == ""
+        # Citation events carry no data; the cited span text was emitted in
+        # preceding plain-text events.
+        assert cited[0].data is None
         assert cited[0].citation.end.sources[0].url == "https://s.com"
 
     def test_multiple_citations_streamed_across_chunks(self):
@@ -426,7 +438,7 @@ class TestCitationStreamProcessor:
         events.extend(proc.finalize())
         cited = [e for e in events if e.citation is not None]
         assert len(cited) == 3
-        assert all(e.data == "" for e in cited)
+        assert all(e.data is None for e in cited)
         assert cited[0].citation.end.sources[0].url == "https://a.com"
         assert cited[1].citation.end.sources[0].url == "https://b.com"
         assert cited[2].citation.end.sources[0].url == "https://c.com"
@@ -467,10 +479,13 @@ class TestCitationStreamProcessor:
         events.extend(proc.finalize())
         cited = [e for e in events if e.citation is not None]
         assert len(cited) == 2
-        assert cited[0].data == ""
+        assert all(e.data is None for e in cited)
         assert cited[0].citation.end.sources[0].url == "https://a.com"
-        assert cited[1].data == "   "
         assert cited[1].citation.end.sources[0].url == "https://b.com"
+        # The whitespace between citations is emitted in its own plain text event.
+        plain = [e for e in events if e.data]
+        assert len(plain) == 1
+        assert plain[0].data == "   "
 
     def test_unclosed_tag_with_valid_content_before(self):
         """Valid citation followed by an unclosed partial tag at end of stream."""
@@ -546,15 +561,18 @@ class TestCitationStreamProcessor:
         assert all(e.citation is None for e in events)
 
     def test_uip_prefix_followed_by_citation_single_chunk(self):
-        """'<uip ' followed by valid citation in a single chunk emits '<uip ' with the citation."""
+        """'<uip ' followed by valid citation in a single chunk emits '<uip ' then the citation."""
         proc = CitationStreamProcessor()
         events = proc.add_chunk(
             '<uip <uip:cite title="Source" url="https://example.com" />'
         )
         events.extend(proc.finalize())
+        plain = [e for e in events if e.data]
+        assert len(plain) == 1
+        assert plain[0].data == "<uip "
         cited = [e for e in events if e.citation is not None]
         assert len(cited) == 1
-        assert cited[0].data == "<uip "
+        assert cited[0].data is None
         assert cited[0].citation.end.sources[0].url == "https://example.com"
 
     def test_escaped_quotes_in_title(self):
@@ -563,9 +581,12 @@ class TestCitationStreamProcessor:
         text = r'Some text.<uip:cite title="The Peculiar Journey of \"Orange\"" url="https://example.com" />'
         events = proc.add_chunk(text)
         events.extend(proc.finalize())
+        plain = [e for e in events if e.data]
+        assert len(plain) == 1
+        assert plain[0].data == "Some text."
         cited = [e for e in events if e.citation is not None]
         assert len(cited) == 1
-        assert cited[0].data == "Some text."
+        assert cited[0].data is None
         source = cited[0].citation.end.sources[0]
         assert isinstance(source, UiPathConversationCitationSourceUrl)
         assert source.url == "https://example.com"
@@ -597,13 +618,14 @@ class TestExtractCitationsFromText:
         assert citations == []
 
     def test_url_citation(self):
-        """Text with a URL citation returns cleaned text and CitationData with URL source."""
+        """Text with a URL citation returns cleaned text and a point CitationData with URL source."""
         text = 'Some fact<uip:cite title="Doc" url="https://doc.com" />'
         cleaned, citations = extract_citations_from_text(text)
         assert cleaned == "Some fact"
         assert len(citations) == 1
-        assert citations[0].offset == 0
-        assert citations[0].length == 9  # len("Some fact")
+        # Point citation anchored right after the cited span.
+        assert citations[0].offset == 9  # len("Some fact")
+        assert citations[0].length == 0
         source = citations[0].sources[0]
         assert isinstance(source, UiPathConversationCitationSourceUrl)
         assert source.url == "https://doc.com"
@@ -623,7 +645,7 @@ class TestExtractCitationsFromText:
         assert source.title == "Report.pdf"
 
     def test_multiple_citations_correct_offsets(self):
-        """Multiple citations on different spans get correct offsets and lengths."""
+        """Multiple point citations are anchored right after their cited spans."""
         text = (
             'First<uip:cite title="A" url="https://a.com" />'
             ' and second<uip:cite title="B" url="https://b.com" />'
@@ -631,13 +653,13 @@ class TestExtractCitationsFromText:
         cleaned, citations = extract_citations_from_text(text)
         assert cleaned == "First and second"
         assert len(citations) == 2
-        # First citation: "First" at offset 0, length 5
-        assert citations[0].offset == 0
-        assert citations[0].length == 5
+        # First citation anchored after "First" (offset 5, length 0).
+        assert citations[0].offset == 5
+        assert citations[0].length == 0
         assert citations[0].sources[0].url == "https://a.com"
-        # Second citation: " and second" at offset 5, length 11
-        assert citations[1].offset == 5
-        assert citations[1].length == 11
+        # Second citation anchored after " and second" (offset 16, length 0).
+        assert citations[1].offset == 16
+        assert citations[1].length == 0
         assert citations[1].sources[0].url == "https://b.com"
 
     def test_duplicate_sources_same_number(self):
@@ -651,21 +673,21 @@ class TestExtractCitationsFromText:
         assert len(citations) == 2
         assert citations[0].sources[0].number == citations[1].sources[0].number
 
-    def test_back_to_back_citations_merged_into_previous(self):
-        """Back-to-back citations merge the second source into the previous citation."""
+    def test_back_to_back_citations_become_separate_point_citations(self):
+        """Back-to-back citations emit as separate point citations at the same offset."""
         text = (
             'Text<uip:cite title="A" url="https://a.com" />'
             '<uip:cite title="B" url="https://b.com" />'
         )
         cleaned, citations = extract_citations_from_text(text)
         assert cleaned == "Text"
-        assert len(citations) == 1
-        assert len(citations[0].sources) == 2
+        assert len(citations) == 2
+        assert all(c.offset == 4 and c.length == 0 for c in citations)
         assert citations[0].sources[0].url == "https://a.com"
-        assert citations[0].sources[1].url == "https://b.com"
+        assert citations[1].sources[0].url == "https://b.com"
 
     def test_three_back_to_back_citations(self):
-        """Three back-to-back citations all merge into one citation with three sources."""
+        """Three back-to-back citations emit as three separate point citations."""
         text = (
             'Answer<uip:cite title="A" reference="https://a.com" page_number="1" />'
             '<uip:cite title="B" reference="https://b.com" page_number="2" />'
@@ -673,24 +695,24 @@ class TestExtractCitationsFromText:
         )
         cleaned, citations = extract_citations_from_text(text)
         assert cleaned == "Answer"
-        assert len(citations) == 1
-        assert len(citations[0].sources) == 3
+        assert len(citations) == 3
+        assert all(c.offset == 6 and c.length == 0 for c in citations)
         assert citations[0].sources[0].title == "A"
-        assert citations[0].sources[1].title == "B"
-        assert citations[0].sources[2].title == "C"
+        assert citations[1].sources[0].title == "B"
+        assert citations[2].sources[0].title == "C"
 
     def test_back_to_back_citations_at_start_with_no_preceding_text(self):
-        """Back-to-back citations at the very start (no preceding text) are all dropped."""
+        """Back-to-back citations at the very start emit as point citations at offset 0."""
         text = (
             '<uip:cite title="A" url="https://a.com" />'
             '<uip:cite title="B" url="https://b.com" />'
         )
         cleaned, citations = extract_citations_from_text(text)
         assert cleaned == ""
-        # First citation has no preceding text and no previous citation to merge into
-        # Second citation also has no preceding text but merges into the first
-        # Both end up dropped since neither has a text span
-        assert len(citations) == 0
+        assert len(citations) == 2
+        assert all(c.offset == 0 and c.length == 0 for c in citations)
+        assert citations[0].sources[0].url == "https://a.com"
+        assert citations[1].sources[0].url == "https://b.com"
 
     def test_empty_text(self):
         """Empty string returns empty text and no citations."""
@@ -704,8 +726,8 @@ class TestExtractCitationsFromText:
         cleaned, citations = extract_citations_from_text(text)
         assert cleaned == "A fact and more text."
         assert len(citations) == 1
-        assert citations[0].offset == 0
-        assert citations[0].length == 6  # len("A fact")
+        assert citations[0].offset == 6  # right after "A fact"
+        assert citations[0].length == 0
 
     def test_reference_without_page_number_skipped(self):
         """Web URL misclassified as reference (no page_number) must not emit a citation."""
@@ -792,14 +814,55 @@ class TestReconstructTextWithCitations:
             '<uip:cite title="B" url="https://b.com" />'
         )
         cleaned, citations = extract_citations_from_text(original)
-        # Both sources merged into a single citation; reconstruction should
-        # re-emit them back-to-back after the shared text span.
+        # Two separate point citations at the same offset; reconstruction
+        # re-emits them back-to-back at that anchor.
         assert reconstruct_text_with_citations(cleaned, citations) == original
 
     def test_citation_with_trailing_text_roundtrip(self):
         original = 'A fact<uip:cite title="S" url="https://s.com" /> and more text.'
         cleaned, citations = extract_citations_from_text(original)
         assert reconstruct_text_with_citations(cleaned, citations) == original
+
+    def test_out_of_order_citations_sorted_by_offset(self):
+        """Reconstruct must not duplicate text when citations arrive out of offset order."""
+        cleaned = "First and second and third."
+        # Same sources, but presented in reverse offset order to reconstruct.
+        out_of_order = [
+            UiPathConversationCitationData(
+                offset=26,
+                length=0,
+                sources=[
+                    UiPathConversationCitationSourceUrl(
+                        title="C", number=3, url="https://c.com"
+                    )
+                ],
+            ),
+            UiPathConversationCitationData(
+                offset=16,
+                length=0,
+                sources=[
+                    UiPathConversationCitationSourceUrl(
+                        title="B", number=2, url="https://b.com"
+                    )
+                ],
+            ),
+            UiPathConversationCitationData(
+                offset=5,
+                length=0,
+                sources=[
+                    UiPathConversationCitationSourceUrl(
+                        title="A", number=1, url="https://a.com"
+                    )
+                ],
+            ),
+        ]
+        result = reconstruct_text_with_citations(cleaned, out_of_order)
+        expected = (
+            'First<uip:cite title="A" url="https://a.com" />'
+            ' and second<uip:cite title="B" url="https://b.com" />'
+            ' and third<uip:cite title="C" url="https://c.com" />.'
+        )
+        assert result == expected
 
     def test_quotes_in_title_are_escaped(self):
         cleaned, citations = extract_citations_from_text(
@@ -980,7 +1043,7 @@ class TestConvertCitationsToInlineTags:
         assert '<uip:cite title="B.pdf"' in result
 
     def test_back_to_back_ordinals_roundtrip_with_extract(self):
-        """End-to-end: [1][2] converted to inline tags then extracted as merged sources."""
+        """End-to-end: [1][2] converted to inline tags then extracted as separate point citations."""
         content = {
             "text": "Answer [1][2]",
             "citations": [
@@ -1003,10 +1066,10 @@ class TestConvertCitationsToInlineTags:
         cleaned, citations = extract_citations_from_text(inline_text)
 
         assert cleaned == "Answer "
-        assert len(citations) == 1
-        assert len(citations[0].sources) == 2
+        assert len(citations) == 2
+        assert all(c.offset == 7 and c.length == 0 for c in citations)
         assert citations[0].sources[0].title == "A.pdf"
-        assert citations[0].sources[1].title == "B.pdf"
+        assert citations[1].sources[0].title == "B.pdf"
 
 
 class TestDeepRagCitationWrapper:

--- a/uv.lock
+++ b/uv.lock
@@ -4375,7 +4375,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.24"
+version = "0.10.25"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- When assistant messages are replayed through the chat history, the cleaned text was sent to the LLM without its prior `<uip:cite/>` markup. The LLM then "forgot" that it had cited sources and would over- or under-cite on the next turn.
- Add `reconstruct_text_with_citations` (inverse of `extract_citations_from_text`) and call it from the chat message mapper before emitting text content blocks.
- Bump version 0.10.24 → 0.10.25.


<img width="1076" height="651" alt="Screenshot 2026-05-18 at 7 11 21 PM" src="https://github.com/user-attachments/assets/5e5c54be-7809-4a29-b9c0-a379fc644a93" />

https://uipath.atlassian.net/browse/JAR-9909