### PR TITLE
chore: enforce 2 day min age for third party packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,18 @@ exclude_lines = [
   "@(abc\\.)?abstractmethod",
 ]
 
+[tool.uv]
+exclude-newer = "2 days"
+
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [[tool.uv.index]]
 name = "testpypi"
 url = "https://test.pypi.org/simple/"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,19 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
+[options.exclude-newer-package]
+uipath = false
+uipath-platform = false
+uipath-runtime = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+uipath-langchain-client = false
+uipath-core = false
+
 [[package]]
 name = "a2a-sdk"
 version = "0.3.26"


### PR DESCRIPTION
To prevent potential supply chain attacks (like the recent npm ones), it would be prudent to enforce min age.
Packages managed by us are excluded, so there is no impact for development or hotfixing. 