### PR TITLE
fix: set License-RefId header in legacy bedrock client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.10.24"
+version = "0.11.0"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/chat/_legacy/bedrock.py
+++ b/src/uipath_langchain/chat/_legacy/bedrock.py
@@ -129,6 +129,9 @@ class AwsBedrockCompletionsPassthroughClient:
             "before-send.bedrock-runtime.*", self._modify_request
         )
         client.meta.events.register(
+            "before-send.bedrock-runtime.*", self._inject_license_ref_id
+        )
+        client.meta.events.register(
             "after-call.bedrock-runtime.*", self._capture_response_headers
         )
         return client
@@ -141,6 +144,24 @@ class AwsBedrockCompletionsPassthroughClient:
             verify=ca_bundle if ca_bundle is not None else False,
             config=self._unsigned_config(),
         )
+
+    def _inject_license_ref_id(self, request, **kwargs):
+        """boto3 before-send handler that injects X-UiPath-License-RefId.
+
+        Boto3 analog of UiPathURLRewriteTransport._inject_license_ref_id.
+        Reads the legacy module global populated by
+        uipath_agents._observability.license_ref_id.apply_legacy_license_ref_id
+        when a model_run span starts.
+        """
+        from uipath_langchain.chat._legacy.openai import _get_license_ref_id
+
+        license_ref_id = _get_license_ref_id()
+        if license_ref_id:
+            request.headers["X-UiPath-License-RefId"] = license_ref_id
+        else:
+            logger.warning(
+                "Expected license_ref_id to be set, but it was %s", license_ref_id
+            )
 
     def _modify_request(self, request, **kwargs):
         """Intercept boto3 request and redirect to LLM Gateway."""

--- a/src/uipath_langchain/chat/_legacy/bedrock.py
+++ b/src/uipath_langchain/chat/_legacy/bedrock.py
@@ -18,6 +18,7 @@ from uipath_langchain._utils._environment import get_default_timeout
 from .http_client import build_uipath_headers, resolve_gateway_url
 from .http_client.header_capture import HeaderCapture
 from .http_client.retryers.bedrock import AsyncBedrockRetryer, BedrockRetryer
+from .license_ref_id import get_license_ref_id
 from .supported_models import BedrockModels
 from .types import APIFlavor, LLMProvider
 
@@ -149,13 +150,11 @@ class AwsBedrockCompletionsPassthroughClient:
         """boto3 before-send handler that injects X-UiPath-License-RefId.
 
         Boto3 analog of UiPathURLRewriteTransport._inject_license_ref_id.
-        Reads the legacy module global populated by
+        Reads the vendor-independent module global populated by
         uipath_agents._observability.license_ref_id.apply_legacy_license_ref_id
         when a model_run span starts.
         """
-        from uipath_langchain.chat._legacy.openai import _get_license_ref_id
-
-        license_ref_id = _get_license_ref_id()
+        license_ref_id = get_license_ref_id()
         if license_ref_id:
             request.headers["X-UiPath-License-RefId"] = license_ref_id
         else:

--- a/src/uipath_langchain/chat/_legacy/license_ref_id.py
+++ b/src/uipath_langchain/chat/_legacy/license_ref_id.py
@@ -1,0 +1,25 @@
+"""Process-wide storage for the active LLM-call license ref ID.
+
+The value is set by uipath-agents when a model_run span starts, and read by
+each vendor's transport-level injector to attach the
+``X-UiPath-License-RefId`` header to outgoing LLM gateway requests. It lives
+here rather than next to any one vendor because the same global is shared
+across all legacy chat clients (OpenAI, Bedrock, ...).
+
+A plain module global is used because the LangChain callback (which sets the
+value) and the transport (which reads it) run on different threads, so
+neither ContextVar nor threading.local work.
+"""
+
+_current_license_ref_id: str | None = None
+
+
+def set_license_ref_id(value: str | None) -> None:
+    """Set the license ref ID for injection on LLM requests."""
+    global _current_license_ref_id
+    _current_license_ref_id = value
+
+
+def get_license_ref_id() -> str | None:
+    """Read the current license ref ID."""
+    return _current_license_ref_id

--- a/src/uipath_langchain/chat/_legacy/openai.py
+++ b/src/uipath_langchain/chat/_legacy/openai.py
@@ -12,29 +12,11 @@ from uipath.platform.common import (
 )
 
 from .http_client import build_uipath_headers, resolve_gateway_url
+from .license_ref_id import get_license_ref_id
 from .supported_models import OpenAIModels
 from .types import APIFlavor, LLMProvider
 
 logger = logging.getLogger(__name__)
-
-# Module-level storage for the current license ref ID.
-# Set by uipath-agents when a model_run span starts, read by the
-# transport to inject X-UiPath-License-RefId on LLM calls.
-# A plain global is used because the LangChain callback (which sets the
-# value) and the httpx transport (which reads it) run on different
-# threads, so neither ContextVar nor threading.local work.
-_current_license_ref_id: str | None = None
-
-
-def set_license_ref_id(value: str | None) -> None:
-    """Set the license ref ID for injection on LLM requests."""
-    global _current_license_ref_id
-    _current_license_ref_id = value
-
-
-def _get_license_ref_id() -> str | None:
-    """Read the current license ref ID."""
-    return _current_license_ref_id
 
 
 def _rewrite_openai_url(
@@ -66,7 +48,7 @@ def _rewrite_openai_url(
 
 def _inject_license_ref_id(request: httpx.Request) -> None:
     """Inject X-UiPath-License-RefId header if a model_run span is active."""
-    license_ref_id = _get_license_ref_id()
+    license_ref_id = get_license_ref_id()
     if license_ref_id:
         request.headers["X-UiPath-License-RefId"] = license_ref_id
 

--- a/tests/chat/test_bedrock.py
+++ b/tests/chat/test_bedrock.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Any
 from unittest.mock import patch
 
 import botocore
@@ -95,6 +96,58 @@ class TestGetClientSkipsImds:
         assert not credential_log_records, (
             f"Unexpected credential resolution: {[r.getMessage() for r in credential_log_records]}"
         )
+
+
+class TestInjectLicenseRefId:
+    """Boto3 before-send chain stamps X-UiPath-License-RefId on the request."""
+
+    def _make_passthrough(self) -> AwsBedrockCompletionsPassthroughClient:
+        return AwsBedrockCompletionsPassthroughClient(
+            model="anthropic.claude-haiku-4-5-20251001",
+            token="test-token",
+            api_flavor="converse",
+        )
+
+    def _emit_before_send(
+        self, passthrough: AwsBedrockCompletionsPassthroughClient
+    ) -> Any:
+        client = passthrough.get_client()
+
+        class _Req:
+            url = "https://bedrock.example/foo/converse"
+            headers: dict[str, str] = {}
+
+        request = _Req()
+        with patch.object(
+            passthrough, "_resolve_url", return_value=("https://gateway/x", False)
+        ):
+            client.meta.events.emit(
+                "before-send.bedrock-runtime.Converse", request=request
+            )
+        return request
+
+    def test_emits_header_when_global_is_set(self):
+        from uipath_langchain.chat._legacy.openai import set_license_ref_id
+
+        passthrough = self._make_passthrough()
+        set_license_ref_id("registered-order-uuid")
+        try:
+            request = self._emit_before_send(passthrough)
+        finally:
+            set_license_ref_id(None)
+
+        assert request.headers.get("Authorization") == "Bearer test-token"
+        assert request.headers.get("X-UiPath-License-RefId") == "registered-order-uuid"
+
+    def test_omits_header_when_global_is_unset(self):
+        from uipath_langchain.chat._legacy.openai import set_license_ref_id
+
+        passthrough = self._make_passthrough()
+        set_license_ref_id(None)
+        request = self._emit_before_send(passthrough)
+
+        assert request.headers.get("Authorization") == "Bearer test-token"
+        assert "X-UiPath-License-RefId" not in request.headers
 
 
 class TestConvertFileBlocksToAnthropicDocuments:

--- a/tests/chat/test_bedrock.py
+++ b/tests/chat/test_bedrock.py
@@ -127,7 +127,7 @@ class TestInjectLicenseRefId:
         return request
 
     def test_emits_header_when_global_is_set(self):
-        from uipath_langchain.chat._legacy.openai import set_license_ref_id
+        from uipath_langchain.chat._legacy.license_ref_id import set_license_ref_id
 
         passthrough = self._make_passthrough()
         set_license_ref_id("registered-order-uuid")
@@ -140,7 +140,7 @@ class TestInjectLicenseRefId:
         assert request.headers.get("X-UiPath-License-RefId") == "registered-order-uuid"
 
     def test_omits_header_when_global_is_unset(self):
-        from uipath_langchain.chat._legacy.openai import set_license_ref_id
+        from uipath_langchain.chat._legacy.license_ref_id import set_license_ref_id
 
         passthrough = self._make_passthrough()
         set_license_ref_id(None)

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.10.24"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
- Extract the license_ref_id global out of the legacy openai chat client module
  - This is a breaking change for consumers of the global; bump to 0.11.0
- The current flow that sets the header for the legacy clients only works with httpx; but the legacy bedrock client uses botocore instead
  - The fix: read the global in a botocore callback and set the header on the request
- In the new LLM clients, this isn't a problem because the bedrock client is modified to also use an httpx transport, so the header callback is applied