### PR TITLE
feat: use ToolsConfiguration in MCP tool factory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.2"
+version = "0.11.3"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.10.61, <2.11.0",
+    "uipath>=2.10.68, <2.11.0",
     "uipath-core>=0.5.15, <0.6.0",
     "uipath-platform>=0.1.45, <0.2.0",
     "uipath-runtime>=0.10.0, <0.11.0",

--- a/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
+++ b/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
@@ -6,7 +6,8 @@ from langchain_core.tools import BaseTool
 from uipath.agent.models.agent import (
     AgentMcpResourceConfig,
     AgentMcpTool,
-    DynamicToolsMode,
+    CachedToolsConfig,
+    DynamicToolsConfig,
 )
 from uipath.eval.mocks import mockable
 
@@ -56,26 +57,34 @@ async def create_mcp_tools(
         List of BaseTool instances, one for each tool in the config.
         Returns empty list if config.is_enabled is False.
 
-    Behavior depends on config.dynamic_tools:
-        - none: Uses tool schemas from config.available_tools (default).
-        - schema: Lists tools from the MCP server via mcpClient, but only
-          includes tools whose names appear in config.available_tools.
-        - all: Lists all tools from the MCP server via mcpClient, ignoring
-          config.available_tools entirely.
+    Behavior depends on config.tools_configuration.discovery_mode:
+        - Cached (default when unset): Uses the tools and schemas saved in
+          config.available_tools.
+        - Dynamic with allow_all=True: Lists all tools from the MCP
+          server via mcpClient, ignoring config.available_tools as a source
+          of truth.
+        - Dynamic with allow_all=False: Lists tools from the MCP server,
+          then filters by names present in config.available_tools (live
+          schemas, curated tool set).
+        Argument properties from the snapshot are carried over by matching tool name.
     """
 
     if config.is_enabled is False:
         return []
 
-    dynamic_tools = config.dynamic_tools
+    discovery_mode = (
+        config.tools_configuration.discovery_mode
+        if config.tools_configuration is not None
+        else CachedToolsConfig()
+    )
     logger.info(
         f"Loading MCP tools for server '{config.slug}' "
-        f"(dynamic_tools={dynamic_tools.value})"
+        f"(discovery_mode={discovery_mode.type})"
     )
 
     config_tools_by_name = {t.name: t for t in config.available_tools}
 
-    if dynamic_tools in (DynamicToolsMode.SCHEMA, DynamicToolsMode.ALL):
+    if isinstance(discovery_mode, DynamicToolsConfig):
         logger.info(f"Fetching tools from MCP server '{config.slug}' via list_tools")
         result = await mcpClient.list_tools()
         server_tools = result.tools
@@ -84,7 +93,7 @@ async def create_mcp_tools(
             f"{[t.name for t in server_tools]}"
         )
 
-        if dynamic_tools == DynamicToolsMode.SCHEMA:
+        if not discovery_mode.allow_all:
             allowed_names = {t.name for t in config.available_tools}
             server_tool_names = {t.name for t in server_tools}
             missing = allowed_names - server_tool_names

--- a/tests/agent/tools/test_mcp/test_mcp_tool.py
+++ b/tests/agent/tools/test_mcp/test_mcp_tool.py
@@ -12,7 +12,8 @@ from uipath.agent.models.agent import (
     AgentMcpResourceConfig,
     AgentMcpTool,
     AgentResourceType,
-    DynamicToolsMode,
+    DynamicToolsConfig,
+    ToolsConfiguration,
 )
 
 from uipath_langchain.agent.tools.mcp import McpClient
@@ -718,8 +719,8 @@ class TestMcpToolNameSanitization:
         assert len(tools[0].name) > 0
 
 
-class TestDynamicToolsMode:
-    """Test dynamic_tools mode behavior in create_mcp_tools."""
+class TestToolsConfiguration:
+    """Test tools_configuration behaviour (Cached vs Dynamic) in create_mcp_tools."""
 
     @pytest.fixture
     def server_tools(self):
@@ -751,14 +752,16 @@ class TestDynamicToolsMode:
         ]
 
     @pytest.fixture
-    def mcp_resource_schema(self):
-        """Resource config with dynamic_tools=schema."""
+    def mcp_resource_curated_dynamic(self):
+        """Resource config with Dynamic discovery_mode + allow_all=False (curated subset)."""
         return AgentMcpResourceConfig(
             name="schema_server",
-            description="Schema mode server",
+            description="Curated dynamic server",
             folder_path="/Shared",
             slug="schema-server",
-            dynamic_tools=DynamicToolsMode.SCHEMA,
+            tools_configuration=ToolsConfiguration(
+                discovery_mode=DynamicToolsConfig(allow_all=False)
+            ),
             available_tools=[
                 AgentMcpTool(
                     name="tool_a",
@@ -774,14 +777,16 @@ class TestDynamicToolsMode:
         )
 
     @pytest.fixture
-    def mcp_resource_all(self):
-        """Resource config with dynamic_tools=all."""
+    def mcp_resource_dynamic(self):
+        """Resource config with Dynamic discovery_mode + allow_all=True."""
         return AgentMcpResourceConfig(
-            name="all_server",
-            description="All mode server",
+            name="dynamic_server",
+            description="Dynamic mode server",
             folder_path="/Shared",
-            slug="all-server",
-            dynamic_tools=DynamicToolsMode.ALL,
+            slug="dynamic-server",
+            tools_configuration=ToolsConfiguration(
+                discovery_mode=DynamicToolsConfig(allow_all=True)
+            ),
             available_tools=[
                 AgentMcpTool(
                     name="tool_a",
@@ -799,20 +804,20 @@ class TestDynamicToolsMode:
         return client
 
     @pytest.mark.asyncio
-    async def test_schema_mode_calls_list_tools(
-        self, mcp_resource_schema, mock_mcp_client
+    async def test_curated_dynamic_calls_list_tools(
+        self, mcp_resource_curated_dynamic, mock_mcp_client
     ):
-        """Test that schema mode calls mcpClient.list_tools()."""
-        await create_mcp_tools(mcp_resource_schema, mock_mcp_client)
+        """Dynamic with allow_all=False still calls mcpClient.list_tools()."""
+        await create_mcp_tools(mcp_resource_curated_dynamic, mock_mcp_client)
 
         mock_mcp_client.list_tools.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_schema_mode_filters_to_available_tools(
-        self, mcp_resource_schema, mock_mcp_client
+    async def test_curated_dynamic_filters_to_available_tools(
+        self, mcp_resource_curated_dynamic, mock_mcp_client
     ):
-        """Test that schema mode only includes tools listed in available_tools."""
-        tools = await create_mcp_tools(mcp_resource_schema, mock_mcp_client)
+        """Dynamic with allow_all=False only includes tools listed in available_tools."""
+        tools = await create_mcp_tools(mcp_resource_curated_dynamic, mock_mcp_client)
 
         tool_names = [t.name for t in tools]
         assert "tool_a" in tool_names
@@ -821,40 +826,71 @@ class TestDynamicToolsMode:
         assert len(tools) == 2
 
     @pytest.mark.asyncio
-    async def test_schema_mode_uses_server_schemas(
-        self, mcp_resource_schema, mock_mcp_client
+    async def test_curated_dynamic_uses_server_schemas_and_descriptions(
+        self, mcp_resource_curated_dynamic, mock_mcp_client
     ):
-        """Test that schema mode uses input/output schemas from the server, not the resource."""
-        tools = await create_mcp_tools(mcp_resource_schema, mock_mcp_client)
+        """Dynamic with allow_all=False uses input/output schemas and descriptions from the server."""
+        tools = await create_mcp_tools(mcp_resource_curated_dynamic, mock_mcp_client)
 
         tool_a = next(t for t in tools if t.name == "tool_a")
-        # Should have the server's schema (with "x" property), not the stale empty one
+        assert tool_a.description == "Tool A from server"
         assert isinstance(tool_a.args_schema, dict)
         assert "x" in tool_a.args_schema["properties"]
 
     @pytest.mark.asyncio
-    async def test_schema_mode_uses_server_descriptions(
-        self, mcp_resource_schema, mock_mcp_client
+    async def test_curated_dynamic_warns_about_missing_allowed_tool(
+        self, mock_mcp_client, caplog
     ):
-        """Test that schema mode uses descriptions from the server."""
-        tools = await create_mcp_tools(mcp_resource_schema, mock_mcp_client)
+        """Dynamic with allow_all=False logs a warning for allowlisted tools the server no longer has."""
+        resource = AgentMcpResourceConfig(
+            name="schema_server",
+            description="Server with phantom in allowlist",
+            folder_path="/Shared",
+            slug="schema-server",
+            tools_configuration=ToolsConfiguration(
+                discovery_mode=DynamicToolsConfig(allow_all=False)
+            ),
+            available_tools=[
+                AgentMcpTool(
+                    name="tool_a",
+                    description="Tool A (stale)",
+                    input_schema={"type": "object", "properties": {}},
+                ),
+                AgentMcpTool(
+                    name="phantom",
+                    description="Tool that no longer exists on the server",
+                    input_schema={"type": "object", "properties": {}},
+                ),
+            ],
+        )
 
-        tool_a = next(t for t in tools if t.name == "tool_a")
-        assert tool_a.description == "Tool A from server"
+        with caplog.at_level(logging.WARNING):
+            tools = await create_mcp_tools(resource, mock_mcp_client)
+
+        tool_names = [t.name for t in tools]
+        assert "tool_a" in tool_names
+        assert "phantom" not in tool_names
+        assert any(
+            "'phantom' is in availableTools" in record.message
+            and "schema-server" in record.message
+            for record in caplog.records
+        )
 
     @pytest.mark.asyncio
-    async def test_all_mode_calls_list_tools(self, mcp_resource_all, mock_mcp_client):
-        """Test that all mode calls mcpClient.list_tools()."""
-        await create_mcp_tools(mcp_resource_all, mock_mcp_client)
+    async def test_dynamic_calls_list_tools(
+        self, mcp_resource_dynamic, mock_mcp_client
+    ):
+        """Test that Dynamic mode calls mcpClient.list_tools()."""
+        await create_mcp_tools(mcp_resource_dynamic, mock_mcp_client)
 
         mock_mcp_client.list_tools.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_all_mode_returns_all_server_tools(
-        self, mcp_resource_all, mock_mcp_client
+    async def test_dynamic_returns_all_server_tools(
+        self, mcp_resource_dynamic, mock_mcp_client
     ):
-        """Test that all mode returns every tool from the server."""
-        tools = await create_mcp_tools(mcp_resource_all, mock_mcp_client)
+        """Test that Dynamic mode returns every tool from the server."""
+        tools = await create_mcp_tools(mcp_resource_dynamic, mock_mcp_client)
 
         tool_names = [t.name for t in tools]
         assert "tool_a" in tool_names
@@ -863,32 +899,33 @@ class TestDynamicToolsMode:
         assert len(tools) == 3
 
     @pytest.mark.asyncio
-    async def test_all_mode_ignores_available_tools(
-        self, mcp_resource_all, mock_mcp_client
+    async def test_dynamic_ignores_available_tools(
+        self, mcp_resource_dynamic, mock_mcp_client
     ):
-        """Test that all mode ignores the available_tools list in the resource config."""
+        """Test that Dynamic mode ignores the available_tools list in the resource config."""
         # Resource only lists tool_a, but all 3 server tools should be returned
-        tools = await create_mcp_tools(mcp_resource_all, mock_mcp_client)
+        tools = await create_mcp_tools(mcp_resource_dynamic, mock_mcp_client)
 
         assert len(tools) == 3
 
     @pytest.mark.asyncio
-    async def test_all_mode_preserves_output_schema(
-        self, mcp_resource_all, mock_mcp_client
+    async def test_dynamic_uses_server_schemas_and_descriptions(
+        self, mcp_resource_dynamic, mock_mcp_client
     ):
-        """Test that all mode preserves output_schema from the server."""
-        tools = await create_mcp_tools(mcp_resource_all, mock_mcp_client)
+        """Test that Dynamic mode uses schemas and descriptions from the server."""
+        tools = await create_mcp_tools(mcp_resource_dynamic, mock_mcp_client)
 
-        # tool_a has outputSchema on the server
         tool_a = next(t for t in tools if t.name == "tool_a")
         assert tool_a.description == "Tool A from server"
+        assert isinstance(tool_a.args_schema, dict)
+        assert "x" in tool_a.args_schema["properties"]
 
     @pytest.mark.asyncio
-    async def test_none_mode_does_not_call_list_tools(self):
-        """Test that none mode (default) does not call mcpClient.list_tools()."""
+    async def test_cached_default_does_not_call_list_tools(self):
+        """Test that Cached mode (default when tools_configuration is unset) does not call list_tools()."""
         resource = AgentMcpResourceConfig(
             name="default_server",
-            description="Default mode",
+            description="Default (Cached) mode",
             folder_path="/Shared",
             slug="default",
             available_tools=[
@@ -910,11 +947,11 @@ class TestDynamicToolsMode:
         assert tools[0].name == "local_tool"
 
     @pytest.mark.asyncio
-    async def test_none_mode_uses_resource_schemas(self):
-        """Test that none mode uses schemas from available_tools, not the server."""
+    async def test_cached_uses_resource_schemas(self):
+        """Test that Cached mode uses schemas from available_tools, not the server."""
         resource = AgentMcpResourceConfig(
             name="default_server",
-            description="Default mode",
+            description="Default (Cached) mode",
             folder_path="/Shared",
             slug="default",
             available_tools=[
@@ -1088,7 +1125,9 @@ class TestMcpToolArgumentProperties:
             description="Test",
             folder_path="/Shared",
             slug="test",
-            dynamic_tools=DynamicToolsMode.ALL,
+            tools_configuration=ToolsConfiguration(
+                discovery_mode=DynamicToolsConfig(allow_all=True)
+            ),
             available_tools=[
                 AgentMcpTool(
                     name="divide",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-18T13:33:18.218624Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -4344,7 +4344,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.61"
+version = "2.10.68"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -4367,9 +4367,9 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/75/a6292d858cf8c751cd672a83d92cbc7e68d45a1cdf399f7c4de64e8dfc62/uipath-2.10.61.tar.gz", hash = "sha256:de1ed6496358ac86335747fec3661f6cb0a43f88c82881686aad88ec992ce398", size = 2935921, upload-time = "2026-05-02T00:15:00.216Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/d15796221896fb73c38835a4669043a59fb1a5b32c8637ea4f18897a28e4/uipath-2.10.68.tar.gz", hash = "sha256:a9dab84960133ff9d8fa618e98b187e5ae5a8874d0afe4648b094e4879d08d44", size = 2942178, upload-time = "2026-05-20T13:27:56.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/c7/6214987e0a4a0b6cc97f1df1306d5a87068c920cf7e8815add4c04eed524/uipath-2.10.61-py3-none-any.whl", hash = "sha256:922b0ad3efe85f77b64a56ae4520e0b7eab6abee02a1425adbd6adc635e1fcec", size = 389764, upload-time = "2026-05-02T00:14:57.776Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ae/9f8a77694dac09cc3dbe43b4e65ba33efcbbbf632ba860d57739b9a87eb3/uipath-2.10.68-py3-none-any.whl", hash = "sha256:5b9d9d727805791ad050945662b163d6da0cc760db0fc298eea2ce66653a5ab1", size = 390746, upload-time = "2026-05-20T13:27:54.291Z" },
 ]
 
 [[package]]
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4463,7 +4463,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.10.61,<2.11.0" },
+    { name = "uipath", specifier = ">=2.10.68,<2.11.0" },
     { name = "uipath-core", specifier = ">=0.5.15,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.11.0,<1.12.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.11.0,<1.12.0" },
@@ -4556,7 +4556,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.45"
+version = "0.1.54"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4566,9 +4566,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/6a/bc5624c31bebce2726724851796f40a99c48e8103cb4dd89306bf1e45b28/uipath_platform-0.1.45.tar.gz", hash = "sha256:7d7f2a178605dbf9841879317e8d399f9776a72728e3491a4f304104839bf747", size = 336368, upload-time = "2026-05-05T13:38:23.94Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/3f/d642609355d60618a71626e67475508aacd5c29ea295e0d23423619c1658/uipath_platform-0.1.54.tar.gz", hash = "sha256:5c49c4303a8a40dcc7df4e0ab14c8d64c307ce3555e5ab71545b3de7b59ab2fd", size = 339248, upload-time = "2026-05-19T16:57:37.753Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/16/a4270dd04995200e89991e56c697b2e19a99c30005c570b0b3256af323ca/uipath_platform-0.1.45-py3-none-any.whl", hash = "sha256:360a44a36bbb78b5cb5b3c96a63e51f2619081d7f062442205f14fe22baadbae", size = 220915, upload-time = "2026-05-05T13:38:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/03/2e32d0efabd3dded465ff27042f2af39cfd7ecab72b89cd9f1fddc04eb3e/uipath_platform-0.1.54-py3-none-any.whl", hash = "sha256:64e4c9f8848b4e0124747cb9049875f4ad534d01ac7672460d3ed1ccc305556e", size = 221582, upload-time = "2026-05-19T16:57:35.171Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Switches `create_mcp_tools` from `config.dynamic_tools` (legacy enum) to `config.tools_configuration.discovery_mode` (new discriminated union from `uipath.agent.models.agent`):

- **`CachedToolsConfig`** preserves the previous `none` behaviour — snapshot only, no `tools/list` call.
- **`DynamicToolsConfig`** drives the eager server-discovery path. The new `allow_all` boolean controls whether the live list is forwarded as-is (`True`) or filtered through the snapshot's `availableTools` (`False`, equivalent to the old `schema` behaviour).

Argument-properties carry-over from the snapshot to server-discovered tools is unchanged.

Bumps `uipath` floor to `2.10.68` (the version that ships `ToolsConfiguration`).

Patch version bumped: `0.11.1` → `0.11.2`.

## Related PRs (must land together)

- uipath-python model change (required dependency): https://github.com/UiPath/uipath-python/pull/1655
- uipath-agents-python dep bump: https://github.com/UiPath/uipath-agents-python/pull/499
- Agents frontend (UI rename + storage schema): https://github.com/UiPath/Agents/pull/5290

## Test plan

- [x] `tests/agent/tools/test_mcp/` — 56 tests passing against editable install of uipath-python PR #1655.
- [x] `TestToolsConfiguration` covers three paths: Cached default, Dynamic + `allow_all=True`, Dynamic + `allow_all=False` (curated).
- [x] `ruff format --check` / `ruff check` clean.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.11.3.dev1008614636",

  # Any version from PR
  "uipath-langchain>=0.11.3.dev1008610000,<0.11.3.dev1008620000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath-langchain>=0.11.3.dev1008610000,<0.11.3.dev1008620000",
]
```
<!-- DEV_PACKAGE_END -->