### PR TITLE
Add spans for escalation memory lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.1"
+version = "0.11.2"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -169,4 +169,3 @@ name = "testpypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
 explicit = true
-

--- a/src/uipath_langchain/agent/tools/escalation_memory.py
+++ b/src/uipath_langchain/agent/tools/escalation_memory.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from contextlib import contextmanager
 from typing import Any
 from uuid import UUID
 
@@ -29,9 +30,16 @@ logger = logging.getLogger(__name__)
 
 MEMORY_CACHE_HIT_METRIC = "MemoryCacheHit"
 MEMORY_CACHE_MISS_METRIC = "MemoryCacheMiss"
+ESCALATION_MEMORY_STRATEGY = "EscalationMemoryCache"
 
 _metric_counters: dict[str, Any] = {}
 _MISSING_VALUE = object()
+
+
+@contextmanager
+def _noop_context():
+    """No-op context manager when OTel is unavailable."""
+    yield None
 
 
 class EscalationMemoryFieldSetting(BaseModel):
@@ -81,11 +89,13 @@ class EscalationMemoryRetriever:
         self,
         memory_space_id: str,
         *,
+        memory_space_name: str | None = None,
         folder_path: str | None = None,
         memory_settings: EscalationMemorySettings | None = None,
         uipath_sdk: UiPath | None = None,
     ) -> None:
         self.memory_space_id = memory_space_id
+        self.memory_space_name = memory_space_name or ""
         self.folder_path = folder_path
         self.memory_settings = memory_settings or EscalationMemorySettings()
         self._uipath_sdk = uipath_sdk
@@ -97,16 +107,116 @@ class EscalationMemoryRetriever:
         """Search escalation memory and return the first cached answer."""
         request = self._build_search_request(serialized_input)
         sdk = self._uipath_sdk if self._uipath_sdk is not None else UiPath()
-        try:
-            response = await sdk.memory.escalation_search_async(
-                memory_space_id=self.memory_space_id,
-                request=request,
-                folder_path=self.folder_path,
-            )
-        except ValidationError:
-            response = await self._raw_escalation_search(sdk, request)
 
-        return _cached_result_from_search_response(response)
+        results_count = 0
+        cached_result: EscalationMemoryCachedResult | None = None
+        try:
+            # Keep the OTel import local to match episodic memory and keep this
+            # module importable in runtimes where tracing is not installed.
+            from opentelemetry import trace as otel_trace
+
+            tracer = otel_trace.get_tracer("uipath_langchain.memory")
+        except ImportError:
+            tracer = None
+            otel_trace = None  # type: ignore[assignment]
+
+        # Span attribute keys matching what the LlmOpsHttpExporter and
+        # Studio UI expect. "openinference.span.kind" sets SpanType.
+        lookup_span_ctx = (
+            tracer.start_as_current_span(
+                "Find previous memories",
+                attributes={
+                    "openinference.span.kind": "agentMemoryLookup",
+                    "type": "agentMemoryLookup",
+                    "span_type": "agentMemoryLookup",
+                    "uipath.custom_instrumentation": True,
+                    "memorySpaceName": self.memory_space_name,
+                    "memorySpaceId": self.memory_space_id,
+                    "strategy": ESCALATION_MEMORY_STRATEGY,
+                },
+            )
+            if tracer
+            else _noop_context()
+        )
+
+        with lookup_span_ctx as lookup_span:
+            fewshot_span_ctx = (
+                tracer.start_as_current_span(
+                    "Apply escalation memory",
+                    attributes={
+                        # LlmOps/Studio still key memory rendering off this
+                        # exported span type; rename it when that contract changes.
+                        "openinference.span.kind": "applyDynamicFewShot",
+                        "type": "applyDynamicFewShot",
+                        "span_type": "applyDynamicFewShot",
+                        "uipath.custom_instrumentation": True,
+                        "memorySpaceName": self.memory_space_name,
+                        "memorySpaceId": self.memory_space_id,
+                        "strategy": ESCALATION_MEMORY_STRATEGY,
+                    },
+                )
+                if tracer
+                else _noop_context()
+            )
+
+            with fewshot_span_ctx as fewshot_span:
+                try:
+                    try:
+                        response = await sdk.memory.escalation_search_async(
+                            memory_space_id=self.memory_space_id,
+                            request=request,
+                            folder_path=self.folder_path,
+                        )
+                    except ValidationError:
+                        # Some existing escalation memories store `answer` as a
+                        # JSON string that the SDK response model rejects. The
+                        # raw API payload is still usable and parsed below.
+                        response = await self._raw_escalation_search(sdk, request)
+
+                    results = _read_value(response, "results") or []
+                    results_count = _safe_len(results)
+                    cached_result = _cached_result_from_search_response(response)
+                    # Set request/response on fewshot span as JSON strings.
+                    # The exporter parses JSON strings back to objects.
+                    # The UI reads "response" to display matched memory items.
+                    if fewshot_span and hasattr(fewshot_span, "set_attribute"):
+                        fewshot_span.set_attribute(
+                            "request",
+                            _json_dumps(
+                                request.model_dump(by_alias=True, exclude_none=True)
+                            ),
+                        )
+                        fewshot_span.set_attribute(
+                            "response",
+                            _serialize_search_response_for_trace(response),
+                        )
+                        fewshot_span.set_attribute(
+                            "fromMemory", cached_result is not None
+                        )
+                except Exception as error:
+                    error_detail = repr(error)
+                    if otel_trace:
+                        if fewshot_span and hasattr(fewshot_span, "set_status"):
+                            fewshot_span.set_status(
+                                otel_trace.StatusCode.ERROR, error_detail
+                            )
+                        if lookup_span and hasattr(lookup_span, "set_status"):
+                            lookup_span.set_status(
+                                otel_trace.StatusCode.ERROR, error_detail
+                            )
+                    raise
+
+            if lookup_span and hasattr(lookup_span, "set_attribute"):
+                lookup_span.set_attribute("memoryItemsMatched", results_count)
+                if cached_result is not None:
+                    lookup_span.set_attribute(
+                        "result",
+                        _json_dumps(
+                            cached_result.model_dump(by_alias=True, exclude_none=True)
+                        ),
+                    )
+
+        return cached_result
 
     def _build_search_request(
         self,
@@ -209,6 +319,32 @@ def _get_escalation_memory_folder_path(
     return _resolve_memory_folder_path(
         folder_path, str(memory_space_name) if memory_space_name else None
     )
+
+
+def _get_escalation_memory_space_name(
+    resource: AgentEscalationResourceConfig,
+    agent: Any | None = None,
+) -> str | None:
+    """Resolve memory space name from escalation resource or agent memory feature."""
+    if not _is_escalation_memory_enabled(resource):
+        return None
+
+    memory = _get_escalation_memory_properties(resource)
+    memory_space_name = _read_first_value(
+        (resource, memory),
+        "memorySpaceName",
+        "memory_space_name",
+    )
+    if memory_space_name:
+        return str(memory_space_name)
+
+    feature = _get_agent_memory_space_feature(agent)
+    memory_space_name = _read_value(
+        feature,
+        "memorySpaceName",
+        "memory_space_name",
+    )
+    return str(memory_space_name) if memory_space_name else None
 
 
 def _get_escalation_memory_settings(
@@ -390,10 +526,12 @@ async def _check_escalation_memory_cache(
     serialized_input: dict[str, Any],
     folder_path: str | None = None,
     memory_settings: EscalationMemorySettings | None = None,
+    memory_space_name: str | None = None,
 ) -> EscalationMemoryCachedResult | None:
     """Check escalation memory for a cached answer."""
     retriever = EscalationMemoryRetriever(
         memory_space_id,
+        memory_space_name=memory_space_name,
         folder_path=folder_path,
         memory_settings=memory_settings,
     )
@@ -535,6 +673,23 @@ def _record_custom_metric(metric_name: str, memory_space_id: str) -> None:
             )
     except Exception:
         logger.debug("Failed to record metric '%s'", metric_name, exc_info=True)
+
+
+def _serialize_search_response_for_trace(response: Any) -> str:
+    if isinstance(response, BaseModel):
+        response = response.model_dump(by_alias=True, exclude_none=True)
+    return _json_dumps(response)
+
+
+def _safe_len(value: Any) -> int:
+    try:
+        return len(value)
+    except Exception:
+        return 0
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, default=str)
 
 
 def _cached_result_from_search_response(

--- a/src/uipath_langchain/agent/tools/escalation_tool.py
+++ b/src/uipath_langchain/agent/tools/escalation_tool.py
@@ -45,6 +45,7 @@ from .escalation_memory import (
     _get_escalation_memory_folder_path,
     _get_escalation_memory_settings,
     _get_escalation_memory_space_id,
+    _get_escalation_memory_space_name,
     _ingest_escalation_memory,
     _resolve_user_id,
 )
@@ -272,6 +273,7 @@ def create_escalation_tool(
     _memory_folder_path: str | None = _get_escalation_memory_folder_path(
         resource, agent
     )
+    _memory_space_name: str | None = _get_escalation_memory_space_name(resource, agent)
     _memory_settings: EscalationMemorySettings | None = _get_escalation_memory_settings(
         resource
     )
@@ -302,6 +304,7 @@ def create_escalation_tool(
                 serialized_data,
                 folder_path=_memory_folder_path or folder_path,
                 memory_settings=_memory_settings,
+                memory_space_name=_memory_space_name,
             )
             if cached_result is not None:
                 return {

--- a/tests/agent/tools/test_escalation_memory.py
+++ b/tests/agent/tools/test_escalation_memory.py
@@ -1,6 +1,9 @@
 """Tests for escalation memory cache check and ingest."""
 
+import builtins
+import json
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,9 +13,10 @@ from uipath.platform.common._bindings import (
     GenericResourceOverwrite,
     _resource_overwrites,
 )
-from uipath.platform.memory import EscalationMemorySearchResponse
+from uipath.platform.memory import EscalationMemorySearchResponse, SearchMode
 
 from uipath_langchain.agent.tools.escalation_memory import (
+    ESCALATION_MEMORY_STRATEGY,
     MEMORY_CACHE_HIT_METRIC,
     MEMORY_CACHE_MISS_METRIC,
     EscalationMemoryFieldSetting,
@@ -26,6 +30,7 @@ from uipath_langchain.agent.tools.escalation_memory import (
     _get_escalation_memory_folder_path,
     _get_escalation_memory_settings,
     _get_escalation_memory_space_id,
+    _get_escalation_memory_space_name,
     _get_memory_space_folder_override,
     _get_user_email,
     _get_user_id,
@@ -34,10 +39,52 @@ from uipath_langchain.agent.tools.escalation_memory import (
     _record_custom_metric,
     _resolve_memory_space_id_by_name,
     _resolve_user_id,
+    _safe_len,
+    _serialize_search_response_for_trace,
     _stringify_search_value,
 )
 
 USER_GUID = "a543cbbd-f3f3-4868-bccf-f5142d2d3d7e"
+
+
+class _FakeSpan:
+    def __init__(self, name: str, attributes: dict[str, object]) -> None:
+        self.name = name
+        self.attributes = dict(attributes)
+        self.recorded_errors: list[BaseException] = []
+        self.statuses: list[tuple[object, ...]] = []
+
+    def set_attribute(self, name: str, value: object) -> None:
+        self.attributes[name] = value
+
+    def record_exception(self, error: BaseException) -> None:
+        self.recorded_errors.append(error)
+
+    def set_status(self, *status: object) -> None:
+        self.statuses.append(status)
+
+
+class _FakeSpanContext:
+    def __init__(self, span: _FakeSpan) -> None:
+        self.span = span
+
+    def __enter__(self) -> _FakeSpan:
+        return self.span
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class _FakeTracer:
+    def __init__(self) -> None:
+        self.spans: list[_FakeSpan] = []
+
+    def start_as_current_span(
+        self, name: str, attributes: dict[str, object] | None = None
+    ) -> _FakeSpanContext:
+        span = _FakeSpan(name, attributes or {})
+        self.spans.append(span)
+        return _FakeSpanContext(span)
 
 
 def _memory_resource(**overrides: object) -> AgentEscalationResourceConfig:
@@ -189,6 +236,54 @@ class TestGetEscalationMemorySpaceId:
 
         assert feature is not None
         assert _read_value(feature, "memorySpaceId") == "selected-space"
+
+    def test_returns_space_id_from_agent_memory_feature(self) -> None:
+        resource = _memory_resource(
+            is_agent_memory_enabled=False,
+            properties={"memory": {"isEnabled": True}},
+        )
+        agent = SimpleNamespace(
+            features=[
+                {
+                    "$featureType": "memorySpace",
+                    "isEnabled": True,
+                    "memorySpaceId": "feature-space-id",
+                }
+            ]
+        )
+
+        assert _get_escalation_memory_space_id(resource, agent) == "feature-space-id"
+
+    def test_returns_memory_space_name_from_properties(self) -> None:
+        resource = _memory_resource(
+            is_agent_memory_enabled=False,
+            properties={
+                "memory": {
+                    "isEnabled": True,
+                    "memorySpaceName": "MemorySpace",
+                }
+            },
+        )
+
+        assert _get_escalation_memory_space_name(resource) == "MemorySpace"
+
+    def test_returns_memory_space_name_from_agent_memory_feature(self) -> None:
+        resource = _memory_resource(
+            is_agent_memory_enabled=False,
+            properties={"memory": {"isEnabled": True}},
+        )
+        agent = SimpleNamespace(
+            features=[
+                {
+                    "$featureType": "memorySpace",
+                    "isEnabled": True,
+                    "memorySpaceName": "MemorySpace",
+                    "dynamicFewShotSettings": {"isEnabled": False},
+                }
+            ]
+        )
+
+        assert _get_escalation_memory_space_name(resource, agent) == "MemorySpace"
 
     @patch("uipath_langchain.agent.tools.escalation_memory.UiPath")
     def test_space_name_resolution_returns_none_when_lookup_fails(
@@ -409,6 +504,27 @@ class TestResolveUserId:
         assert result is None
 
     @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.tools.escalation_memory.UiPathConfig")
+    @patch("uipath_langchain.agent.tools.escalation_memory.UiPath")
+    async def test_skips_directory_entries_for_different_email(
+        self,
+        mock_uipath_cls: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        mock_config.organization_id = "org-123"
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {"email": "other@example.com", "identifier": USER_GUID}
+        ]
+        mock_sdk = MagicMock()
+        mock_sdk.api_client.request_async = AsyncMock(return_value=mock_response)
+        mock_uipath_cls.return_value = mock_sdk
+
+        result = await _resolve_user_id({"emailAddress": "reviewer@example.com"})
+
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_user_has_no_email(self) -> None:
         assert await _resolve_user_id({"displayName": "Reviewer"}) is None
 
@@ -473,6 +589,223 @@ class TestCheckEscalationMemoryCache:
         assert result.output == {"action": "approve", "reason": "meets criteria"}
         assert result.outcome == "approved"
         mock_record_metric.assert_called_once_with(MEMORY_CACHE_HIT_METRIC, "space-123")
+
+    @pytest.mark.asyncio
+    async def test_retriever_search_succeeds_without_opentelemetry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        original_import = builtins.__import__
+
+        def import_without_otel(
+            name: str,
+            globals: dict[str, Any] | None = None,
+            locals: dict[str, Any] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> Any:
+            if name == "opentelemetry":
+                raise ImportError("opentelemetry unavailable")
+            return original_import(name, globals, locals, fromlist, level)
+
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_search_async = AsyncMock(
+            return_value={
+                "results": [
+                    {
+                        "answer": {
+                            "output": {"approved": True},
+                            "outcome": "approved",
+                        }
+                    }
+                ]
+            }
+        )
+        monkeypatch.setattr(builtins, "__import__", import_without_otel)
+
+        result = await EscalationMemoryRetriever(
+            "space-123",
+            uipath_sdk=mock_sdk,
+        ).aretrieve({"Content": "Is the sky blue?"})
+
+        assert result is not None
+        assert result.output == {"approved": True}
+        assert result.outcome == "approved"
+
+    @pytest.mark.asyncio
+    async def test_adds_memory_lookup_spans(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from opentelemetry import trace
+
+        from uipath_langchain.agent.tools import escalation_memory
+
+        fake_tracer = _FakeTracer()
+        tracer_names: list[str] = []
+
+        def get_tracer(name: str) -> _FakeTracer:
+            tracer_names.append(name)
+            return fake_tracer
+
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_search_async = AsyncMock(
+            return_value={
+                "results": [
+                    {
+                        "answer": {
+                            "output": {
+                                "action": "approve",
+                                "reason": "meets criteria",
+                            },
+                            "outcome": "approved",
+                        }
+                    }
+                ]
+            }
+        )
+        mock_record_metric = MagicMock()
+        monkeypatch.setattr(trace, "get_tracer", get_tracer)
+        monkeypatch.setattr(
+            escalation_memory, "UiPath", MagicMock(return_value=mock_sdk)
+        )
+        monkeypatch.setattr(
+            escalation_memory,
+            "_record_custom_metric",
+            mock_record_metric,
+        )
+
+        result = await _check_escalation_memory_cache(
+            "space-123",
+            {"Content": "Is the sky blue?"},
+            folder_path="/Memory/Folder",
+            memory_space_name="MemorySpace",
+        )
+
+        assert result is not None
+        assert [span.name for span in fake_tracer.spans] == [
+            "Find previous memories",
+            "Apply escalation memory",
+        ]
+        assert tracer_names == ["uipath_langchain.memory"]
+        lookup_span, apply_memory_span = fake_tracer.spans
+        assert lookup_span.attributes == {
+            "openinference.span.kind": "agentMemoryLookup",
+            "type": "agentMemoryLookup",
+            "span_type": "agentMemoryLookup",
+            "uipath.custom_instrumentation": True,
+            "memorySpaceName": "MemorySpace",
+            "memorySpaceId": "space-123",
+            "strategy": ESCALATION_MEMORY_STRATEGY,
+            "memoryItemsMatched": 1,
+            "result": json.dumps(
+                {
+                    "output": {
+                        "action": "approve",
+                        "reason": "meets criteria",
+                    },
+                    "outcome": "approved",
+                }
+            ),
+        }
+        assert (
+            apply_memory_span.attributes["openinference.span.kind"]
+            == "applyDynamicFewShot"
+        )
+        assert apply_memory_span.attributes["type"] == "applyDynamicFewShot"
+        assert apply_memory_span.attributes["span_type"] == "applyDynamicFewShot"
+        assert apply_memory_span.attributes["uipath.custom_instrumentation"] is True
+        assert apply_memory_span.attributes["memorySpaceName"] == "MemorySpace"
+        assert apply_memory_span.attributes["memorySpaceId"] == "space-123"
+        assert apply_memory_span.attributes["strategy"] == ESCALATION_MEMORY_STRATEGY
+        assert apply_memory_span.attributes["fromMemory"] is True
+        request_payload = json.loads(str(apply_memory_span.attributes["request"]))
+        assert request_payload["fields"][0]["keyPath"] == [
+            "escalation-input",
+            "Content",
+        ]
+        assert request_payload["fields"][0]["value"] == "Is the sky blue?"
+        assert request_payload["definitionSystemPrompt"] == ""
+        response_payload = json.loads(str(apply_memory_span.attributes["response"]))
+        assert response_payload["results"][0]["answer"]["outcome"] == "approved"
+        mock_record_metric.assert_called_once_with(MEMORY_CACHE_HIT_METRIC, "space-123")
+
+    @pytest.mark.asyncio
+    async def test_adds_memory_lookup_spans_on_cache_miss(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from opentelemetry import trace
+
+        from uipath_langchain.agent.tools import escalation_memory
+
+        fake_tracer = _FakeTracer()
+        tracer_names: list[str] = []
+
+        def get_tracer(name: str) -> _FakeTracer:
+            tracer_names.append(name)
+            return fake_tracer
+
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_search_async = AsyncMock(
+            return_value={"results": []}
+        )
+        mock_record_metric = MagicMock()
+        monkeypatch.setattr(trace, "get_tracer", get_tracer)
+        monkeypatch.setattr(
+            escalation_memory, "UiPath", MagicMock(return_value=mock_sdk)
+        )
+        monkeypatch.setattr(
+            escalation_memory,
+            "_record_custom_metric",
+            mock_record_metric,
+        )
+
+        result = await _check_escalation_memory_cache(
+            "space-123",
+            {"Content": "Is the sky blue?"},
+            folder_path="/Memory/Folder",
+            memory_space_name="MemorySpace",
+        )
+
+        assert result is None
+        assert tracer_names == ["uipath_langchain.memory"]
+        lookup_span, apply_memory_span = fake_tracer.spans
+        assert lookup_span.attributes["memoryItemsMatched"] == 0
+        assert lookup_span.attributes["memorySpaceName"] == "MemorySpace"
+        assert "result" not in lookup_span.attributes
+        assert apply_memory_span.attributes["memorySpaceName"] == "MemorySpace"
+        assert apply_memory_span.attributes["strategy"] == ESCALATION_MEMORY_STRATEGY
+        assert apply_memory_span.attributes["fromMemory"] is False
+        request_payload = json.loads(str(apply_memory_span.attributes["request"]))
+        assert request_payload["fields"][0]["value"] == "Is the sky blue?"
+        response_payload = json.loads(str(apply_memory_span.attributes["response"]))
+        assert response_payload == {"results": []}
+        mock_record_metric.assert_called_once_with(
+            MEMORY_CACHE_MISS_METRIC, "space-123"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sets_memory_lookup_spans_to_error_on_search_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from opentelemetry import trace
+
+        fake_tracer = _FakeTracer()
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_search_async = AsyncMock(
+            side_effect=RuntimeError("search down")
+        )
+        monkeypatch.setattr(trace, "get_tracer", lambda _name: fake_tracer)
+
+        with pytest.raises(RuntimeError, match="search down"):
+            await EscalationMemoryRetriever(
+                "space-123",
+                memory_space_name="MemorySpace",
+                uipath_sdk=mock_sdk,
+            ).aretrieve({"Content": "Is the sky blue?"})
+
+        lookup_span, apply_memory_span = fake_tracer.spans
+        expected_status = (trace.StatusCode.ERROR, "RuntimeError('search down')")
+        assert lookup_span.statuses == [expected_status]
+        assert apply_memory_span.statuses == [expected_status]
 
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.tools.escalation_memory._record_custom_metric")
@@ -607,6 +940,14 @@ class TestCheckEscalationMemoryCache:
 
 
 class TestBuildSearchFields:
+    def test_search_settings_preserve_enum_search_mode(self) -> None:
+        settings = EscalationMemorySettings(searchMode=SearchMode.Semantic)
+
+        assert settings.search_mode is SearchMode.Semantic
+
+    def test_search_mode_validator_returns_unknown_values(self) -> None:
+        assert EscalationMemorySettings._normalize_search_mode("keyword") == "keyword"
+
     def test_search_request_includes_required_definition_prompt(self) -> None:
         request = EscalationMemoryRetriever("space-123")._build_search_request(
             {"keep": "value"}
@@ -728,6 +1069,25 @@ class TestIngestEscalationMemory:
 
 
 class TestEscalationMemoryUtilities:
+    def test_serialize_search_response_for_trace_uses_model_dump(self) -> None:
+        class SearchResponse(BaseModel):
+            model_config = ConfigDict(populate_by_name=True)
+
+            system_prompt_injection: str = ""
+
+        payload = _serialize_search_response_for_trace(
+            SearchResponse(system_prompt_injection="cached")
+        )
+
+        assert json.loads(payload) == {"system_prompt_injection": "cached"}
+
+    def test_safe_len_returns_zero_when_len_fails(self) -> None:
+        class BadLen:
+            def __len__(self) -> int:
+                raise RuntimeError("len unavailable")
+
+        assert _safe_len(BadLen()) == 0
+
     def test_record_custom_metric_creates_and_reuses_counter(self, monkeypatch) -> None:
         from opentelemetry import metrics, trace
 

--- a/tests/agent/tools/test_escalation_tool.py
+++ b/tests/agent/tools/test_escalation_tool.py
@@ -795,6 +795,7 @@ class TestEscalationToolOutputSchema:
                 "memory": {
                     "isEnabled": True,
                     "memorySpaceId": "space-123",
+                    "memorySpaceName": "MemorySpace",
                     "folderPath": "/Memory/Folder",
                 }
             },
@@ -815,6 +816,10 @@ class TestEscalationToolOutputSchema:
         assert mock_check_memory_cache.await_args is not None
         assert (
             mock_check_memory_cache.await_args.kwargs["folder_path"] == "/Memory/Folder"
+        )
+        assert (
+            mock_check_memory_cache.await_args.kwargs["memory_space_name"]
+            == "MemorySpace"
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- wrap escalation memory cache search in custom OTel spans matching the episodic memory lookup shape
- attach escalation search request/response JSON, hit/miss state, matched count, and result data to the spans
- cover cache hit and cache miss span attributes in escalation memory tests

## Tests
- .venv/bin/ruff format src/uipath_langchain/agent/tools/escalation_memory.py tests/agent/tools/test_escalation_memory.py
- .venv/bin/ruff check src/uipath_langchain/agent/tools/escalation_memory.py tests/agent/tools/test_escalation_memory.py
- .venv/bin/pytest tests/agent/tools/test_escalation_memory.py