### PR TITLE
feat(agent/tools): cover Flow process tool type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.3"
+version = "0.11.4"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.10.68, <2.11.0",
+    "uipath>=2.10.69, <2.11.0",
     "uipath-core>=0.5.15, <0.6.0",
     "uipath-platform>=0.1.45, <0.2.0",
     "uipath-runtime>=0.10.0, <0.11.0",

--- a/tests/agent/tools/test_process_tool.py
+++ b/tests/agent/tools/test_process_tool.py
@@ -32,6 +32,22 @@ def process_resource():
 
 
 @pytest.fixture
+def flow_resource():
+    """Create a process tool resource config of type Flow (Maestro Flow release)."""
+    return AgentProcessToolResourceConfig(
+        type=AgentToolType.FLOW,
+        name="test_flow",
+        description="Test flow description",
+        input_schema={"type": "object", "properties": {}},
+        output_schema={"type": "object", "properties": {}},
+        properties=AgentProcessToolProperties(
+            process_name="MyFlow",
+            folder_path="/Shared/Flows",
+        ),
+    )
+
+
+@pytest.fixture
 def process_resource_with_inputs():
     """Create a process tool resource config with input arguments."""
     return AgentProcessToolResourceConfig(
@@ -453,3 +469,84 @@ class TestProcessToolRunAsMe:
 
         call_kwargs = mock_client.processes.invoke_async.call_args[1]
         assert call_kwargs["run_as_me"] is None
+
+
+class TestProcessToolFlowType:
+    """Test that a Flow-type resource flows through create_process_tool correctly."""
+
+    def test_flow_tool_metadata_has_flow_tool_type(self, flow_resource):
+        """A Flow resource produces a tool with metadata.tool_type == 'flow'."""
+        tool = create_process_tool(flow_resource)
+        assert tool.metadata is not None
+        assert tool.metadata["tool_type"] == "flow"
+
+    def test_flow_tool_metadata_has_display_name(self, flow_resource):
+        """Flow tool metadata exposes the process_name as display_name."""
+        tool = create_process_tool(flow_resource)
+        assert tool.metadata is not None
+        assert tool.metadata["display_name"] == "MyFlow"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Shared/Flows"})
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_flow_tool_invokes_processes_invoke_async(
+        self, mock_uipath_class, mock_interrupt, flow_resource
+    ):
+        """Flow tool invokes client.processes.invoke_async (same path as Process)."""
+        mock_job = MagicMock(spec=Job)
+        mock_job.key = "flow-job-key"
+        mock_job.folder_key = "flow-folder-key"
+
+        mock_resumed_job = MagicMock(spec=Job)
+        mock_resumed_job.state = "successful"
+
+        mock_client = MagicMock()
+        mock_client.processes.invoke_async = AsyncMock(return_value=mock_job)
+        mock_client.jobs.extract_output_async = AsyncMock(return_value=None)
+        mock_uipath_class.return_value = mock_client
+
+        mock_interrupt.return_value = mock_resumed_job
+
+        tool = create_process_tool(flow_resource)
+        await tool.ainvoke({})
+
+        mock_client.processes.invoke_async.assert_called_once_with(
+            name="MyFlow",
+            input_arguments={},
+            folder_path="/Shared/Flows",
+            attachments=[],
+            parent_span_id=None,
+            parent_operation_id=None,
+            run_as_me=None,
+        )
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_flow_tool_uses_non_agent_bts_key(
+        self, mock_uipath_class, mock_interrupt, flow_resource
+    ):
+        """Flow tool stores the BTS tracking key under 'wait_for_job_key' (not agent variant)."""
+        mock_job = MagicMock(spec=Job)
+        mock_job.key = "flow-job-key"
+        mock_job.folder_key = "flow-folder-key"
+
+        mock_resumed_job = MagicMock(spec=Job)
+        mock_resumed_job.state = "successful"
+
+        mock_client = MagicMock()
+        mock_client.processes.invoke_async = AsyncMock(return_value=mock_job)
+        mock_client.jobs.extract_output_async = AsyncMock(return_value=None)
+        mock_uipath_class.return_value = mock_client
+
+        mock_interrupt.return_value = mock_resumed_job
+
+        tool = create_process_tool(flow_resource)
+        assert tool.metadata is not None
+
+        await tool.ainvoke({})
+
+        bts_context = tool.metadata["_bts_context"]
+        assert bts_context.get("wait_for_job_key") == "flow-job-key"
+        assert "wait_for_agent_job_key" not in bts_context

--- a/tests/agent/tools/test_tool_factory.py
+++ b/tests/agent/tools/test_tool_factory.py
@@ -69,6 +69,22 @@ def process_resource() -> AgentProcessToolResourceConfig:
 
 
 @pytest.fixture
+def flow_resource() -> AgentProcessToolResourceConfig:
+    """Create a process tool resource config of type Flow."""
+    return AgentProcessToolResourceConfig(
+        type=AgentToolType.FLOW,
+        name="test_flow",
+        description="Test flow description",
+        input_schema=EMPTY_SCHEMA,
+        output_schema=EMPTY_SCHEMA,
+        properties=AgentProcessToolProperties(
+            process_name="MyFlow",
+            folder_path="/Shared/Flows",
+        ),
+    )
+
+
+@pytest.fixture
 def context_resource() -> AgentContextResourceConfig:
     """Create a context tool resource config."""
     return AgentContextResourceConfig(
@@ -270,6 +286,7 @@ class TestCreateToolsFromResources:
         "resource_fixture",
         [
             "process_resource",
+            "flow_resource",
             "context_resource",
             "escalation_resource",
             "integration_resource",
@@ -288,3 +305,19 @@ class TestCreateToolsFromResources:
         mock_llm = AsyncMock(spec=BaseChatModel)
         tool = await _build_tool_for_resource(resource, mock_llm)
         assert_tool_is_base_uipath(tool)
+
+    async def test_flow_resource_routes_through_process_tool_path(
+        self, flow_resource, mock_uipath_sdk
+    ):
+        """A Flow-type resource is dispatched via the process_tool factory path."""
+        mock_llm = AsyncMock(spec=BaseChatModel)
+        with patch(
+            "uipath_langchain.agent.tools.tool_factory.create_process_tool"
+        ) as mock_create_process_tool:
+            mock_create_process_tool.return_value = MagicMock(
+                spec=BaseUiPathStructuredTool
+            )
+            tool = await _build_tool_for_resource(flow_resource, mock_llm)
+
+        mock_create_process_tool.assert_called_once_with(flow_resource, run_as_me=False)
+        assert tool is not None

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-18T13:33:18.218624Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -4344,7 +4344,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.68"
+version = "2.10.69"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -4367,9 +4367,9 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/83/d15796221896fb73c38835a4669043a59fb1a5b32c8637ea4f18897a28e4/uipath-2.10.68.tar.gz", hash = "sha256:a9dab84960133ff9d8fa618e98b187e5ae5a8874d0afe4648b094e4879d08d44", size = 2942178, upload-time = "2026-05-20T13:27:56.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/1c/bfb47ee7ad8822ef9f86f270a02e98df048cce96247de2f8ff001c53b5da/uipath-2.10.69.tar.gz", hash = "sha256:8976b16bff085afedc922d5ba05734dc091e6db219ef1c09251a61335e243159", size = 2942472, upload-time = "2026-05-21T11:45:06.074Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/ae/9f8a77694dac09cc3dbe43b4e65ba33efcbbbf632ba860d57739b9a87eb3/uipath-2.10.68-py3-none-any.whl", hash = "sha256:5b9d9d727805791ad050945662b163d6da0cc760db0fc298eea2ce66653a5ab1", size = 390746, upload-time = "2026-05-20T13:27:54.291Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/79/8548bc3bd1b2b2e4ceed9beb96dd08df5797a968276b6ef36a0741ed8e8e/uipath-2.10.69-py3-none-any.whl", hash = "sha256:c076aa7ca394c208cbf52d4e72e06c1da2fd150d343ee9c3358672e4bc9b7877", size = 390772, upload-time = "2026-05-21T11:45:03.813Z" },
 ]
 
 [[package]]
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.3"
+version = "0.11.4"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4463,7 +4463,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.10.68,<2.11.0" },
+    { name = "uipath", specifier = ">=2.10.69,<2.11.0" },
     { name = "uipath-core", specifier = ">=0.5.15,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.11.0,<1.12.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.11.0,<1.12.0" },


### PR DESCRIPTION
Add tests verifying the new AgentToolType.FLOW value routes through create_process_tool — including metadata (tool_type="flow"), invocation via processes.invoke_async, BTS key selection (uses wait_for_job_key, not the AGENT variant), and tool_factory dispatch. No production change in this package; the existing isinstance(AgentProcessToolResourceConfig) dispatch already absorbs Flow tools.