### PR TITLE
feat(runtime): treat service-role messages as user messages

### DIFF
--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -184,7 +184,7 @@ class UiPathChatMessagesMapper:
                 metadata["attachments"] = attachments
 
             role = uipath_message.role
-            if role == "user":
+            if role == "user" or role == "service":
                 converted_messages.append(
                     HumanMessage(
                         id=uipath_message.message_id,

--- a/tests/runtime/test_chat_message_mapper.py
+++ b/tests/runtime/test_chat_message_mapper.py
@@ -274,6 +274,36 @@ class TestMapMessages:
         assert msg.content == []  # Empty content_blocks list
         assert msg.additional_kwargs["message_id"] == "msg-1"
 
+    def test_map_messages_converts_service_role_to_human_message(self):
+        """Should convert UiPath service-role messages (from UiPath Conversational Service) to HumanMessages."""
+        mapper = UiPathChatMessagesMapper("test-runtime", None)
+        uipath_msg = UiPathConversationMessage(
+            message_id="msg-1",
+            role="service",
+            created_at=TEST_TIMESTAMP,
+            updated_at=TEST_TIMESTAMP,
+            content_parts=[
+                UiPathConversationContentPart(
+                    content_part_id="part-1",
+                    mime_type="text/plain",
+                    data=UiPathInlineValue(inline="service-provided context"),
+                    citations=[],
+                    created_at=TEST_TIMESTAMP,
+                    updated_at=TEST_TIMESTAMP,
+                )
+            ],
+            tool_calls=[],
+            interrupts=[],
+        )
+
+        result = mapper.map_messages([uipath_msg])
+
+        assert len(result) == 1
+        msg = result[0]
+        assert isinstance(msg, HumanMessage)
+        assert msg.content_blocks[0]["text"] == "service-provided context"  # type: ignore[typeddict-item]
+        assert msg.additional_kwargs["message_id"] == "msg-1"
+
     def test_map_messages_handles_assistant_message_without_tool_calls(self):
         """Should convert assistant role to AIMessage."""
         mapper = UiPathChatMessagesMapper("test-runtime", None)


### PR DESCRIPTION
## Summary
- Map UiPath `service`-role messages to `HumanMessage` alongside `user`-role. `service`-role messages are carrying context for the model to see — they should reach the LLM as user input rather than be dropped
   - These service-level messages [were already treated as user-type messages for Temporal agent inputs](https://github.com/UiPath/AgentInterfaces/pull/816) - so this PR ports the change over to unified-runtime low-code convo agents as well.

- Added a mapper test covering the new branch


## Test plan
- [x] `uv run pytest tests/runtime/test_chat_message_mapper.py` (85 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)