### PR TITLE
chore: bump uipath to 2.10.72 and uipath-langchain to 0.11.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.9"
+version = "0.11.10"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.10.70, <2.11.0",
+    "uipath>=2.10.72, <2.11.0",
     "uipath-core>=0.5.15, <0.6.0",
     "uipath-platform>=0.1.59, <0.2.0",
     "uipath-runtime>=0.10.0, <0.11.0",

--- a/tests/agent/tools/test_process_tool.py
+++ b/tests/agent/tools/test_process_tool.py
@@ -48,6 +48,22 @@ def flow_resource():
 
 
 @pytest.fixture
+def function_resource():
+    """Create a process tool resource config of type Function (coded function release)."""
+    return AgentProcessToolResourceConfig(
+        type=AgentToolType.FUNCTION,
+        name="test_function",
+        description="Test function description",
+        input_schema={"type": "object", "properties": {}},
+        output_schema={"type": "object", "properties": {}},
+        properties=AgentProcessToolProperties(
+            process_name="MyFunction",
+            folder_path="/Shared/Functions",
+        ),
+    )
+
+
+@pytest.fixture
 def process_resource_with_inputs():
     """Create a process tool resource config with input arguments."""
     return AgentProcessToolResourceConfig(
@@ -549,4 +565,85 @@ class TestProcessToolFlowType:
 
         bts_context = tool.metadata["_bts_context"]
         assert bts_context.get("wait_for_job_key") == "flow-job-key"
+        assert "wait_for_agent_job_key" not in bts_context
+
+
+class TestProcessToolFunctionType:
+    """Test that a Function-type resource flows through create_process_tool correctly."""
+
+    def test_function_tool_metadata_has_function_tool_type(self, function_resource):
+        """A Function resource produces a tool with metadata.tool_type == 'function'."""
+        tool = create_process_tool(function_resource)
+        assert tool.metadata is not None
+        assert tool.metadata["tool_type"] == "function"
+
+    def test_function_tool_metadata_has_display_name(self, function_resource):
+        """Function tool metadata exposes the process_name as display_name."""
+        tool = create_process_tool(function_resource)
+        assert tool.metadata is not None
+        assert tool.metadata["display_name"] == "MyFunction"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Shared/Functions"})
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_function_tool_invokes_processes_invoke_async(
+        self, mock_uipath_class, mock_interrupt, function_resource
+    ):
+        """Function tool invokes client.processes.invoke_async (same path as Process)."""
+        mock_job = MagicMock(spec=Job)
+        mock_job.key = "function-job-key"
+        mock_job.folder_key = "function-folder-key"
+
+        mock_resumed_job = MagicMock(spec=Job)
+        mock_resumed_job.state = "successful"
+
+        mock_client = MagicMock()
+        mock_client.processes.invoke_async = AsyncMock(return_value=mock_job)
+        mock_client.jobs.extract_output_async = AsyncMock(return_value=None)
+        mock_uipath_class.return_value = mock_client
+
+        mock_interrupt.return_value = mock_resumed_job
+
+        tool = create_process_tool(function_resource)
+        await tool.ainvoke({})
+
+        mock_client.processes.invoke_async.assert_called_once_with(
+            name="MyFunction",
+            input_arguments={},
+            folder_path="/Shared/Functions",
+            attachments=[],
+            parent_span_id=None,
+            parent_operation_id=None,
+            run_as_me=None,
+        )
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_function_tool_uses_non_agent_bts_key(
+        self, mock_uipath_class, mock_interrupt, function_resource
+    ):
+        """Function tool stores the BTS tracking key under 'wait_for_job_key' (not agent variant)."""
+        mock_job = MagicMock(spec=Job)
+        mock_job.key = "function-job-key"
+        mock_job.folder_key = "function-folder-key"
+
+        mock_resumed_job = MagicMock(spec=Job)
+        mock_resumed_job.state = "successful"
+
+        mock_client = MagicMock()
+        mock_client.processes.invoke_async = AsyncMock(return_value=mock_job)
+        mock_client.jobs.extract_output_async = AsyncMock(return_value=None)
+        mock_uipath_class.return_value = mock_client
+
+        mock_interrupt.return_value = mock_resumed_job
+
+        tool = create_process_tool(function_resource)
+        assert tool.metadata is not None
+
+        await tool.ainvoke({})
+
+        bts_context = tool.metadata["_bts_context"]
+        assert bts_context.get("wait_for_job_key") == "function-job-key"
         assert "wait_for_agent_job_key" not in bts_context

--- a/tests/agent/tools/test_tool_factory.py
+++ b/tests/agent/tools/test_tool_factory.py
@@ -85,6 +85,22 @@ def flow_resource() -> AgentProcessToolResourceConfig:
 
 
 @pytest.fixture
+def function_resource() -> AgentProcessToolResourceConfig:
+    """Create a process tool resource config of type Function."""
+    return AgentProcessToolResourceConfig(
+        type=AgentToolType.FUNCTION,
+        name="test_function",
+        description="Test function description",
+        input_schema=EMPTY_SCHEMA,
+        output_schema=EMPTY_SCHEMA,
+        properties=AgentProcessToolProperties(
+            process_name="MyFunction",
+            folder_path="/Shared/Functions",
+        ),
+    )
+
+
+@pytest.fixture
 def context_resource() -> AgentContextResourceConfig:
     """Create a context tool resource config."""
     return AgentContextResourceConfig(
@@ -287,6 +303,7 @@ class TestCreateToolsFromResources:
         [
             "process_resource",
             "flow_resource",
+            "function_resource",
             "context_resource",
             "escalation_resource",
             "integration_resource",
@@ -320,4 +337,22 @@ class TestCreateToolsFromResources:
             tool = await _build_tool_for_resource(flow_resource, mock_llm)
 
         mock_create_process_tool.assert_called_once_with(flow_resource, run_as_me=False)
+        assert tool is not None
+
+    async def test_function_resource_routes_through_process_tool_path(
+        self, function_resource, mock_uipath_sdk
+    ):
+        """A Function-type resource is dispatched via the process_tool factory path."""
+        mock_llm = AsyncMock(spec=BaseChatModel)
+        with patch(
+            "uipath_langchain.agent.tools.tool_factory.create_process_tool"
+        ) as mock_create_process_tool:
+            mock_create_process_tool.return_value = MagicMock(
+                spec=BaseUiPathStructuredTool
+            )
+            tool = await _build_tool_for_resource(function_resource, mock_llm)
+
+        mock_create_process_tool.assert_called_once_with(
+            function_resource, run_as_me=False
+        )
         assert tool is not None

--- a/uv.lock
+++ b/uv.lock
@@ -4344,7 +4344,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.70"
+version = "2.10.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -4367,28 +4367,28 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/61/60d35aadbb5baf1bb42ca7d8441a8d8b0cc924b261fac1c4c20ee6db5232/uipath-2.10.70.tar.gz", hash = "sha256:4b8e132cd8e7bf9e66830af08ef87940a203f2ad8601b4f167a8c9d5536c0544", size = 2942527, upload-time = "2026-05-21T13:41:15.814Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/9c/8a14a8b3c0ad5d012283a3e8bb4d908729a3223d19c337e1ff44eefa79af/uipath-2.10.72.tar.gz", hash = "sha256:102b1eacec0cc84b91a13586db2c94797cffb52121683954ac73c1f6e5bdc36f", size = 2945990, upload-time = "2026-05-28T12:51:12.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/33/eee2ff7f2cf2989cdf8335a43c4627c4ad99ba275fb4fd7fe971443c4e90/uipath-2.10.70-py3-none-any.whl", hash = "sha256:79d18858c076bf5d0dba003c0f982769fac9d543d9d9c47d9b82f54c3e7ccc05", size = 390821, upload-time = "2026-05-21T13:41:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0d/3176ee9cf5e78cfc54b1bd20a9a50de7e6962f0ea04fe747b2aab0ad358f/uipath-2.10.72-py3-none-any.whl", hash = "sha256:66496d6d5f9590c91a228ca41e979af4cc7c1e148c49c2b5da314d834dfb10b8", size = 391720, upload-time = "2026-05-28T12:51:11.345Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.15"
+version = "0.5.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/61/945ed075095ab2b4e5e4a43f3724f7d7d2e8897267e11e34bce290df96de/uipath_core-0.5.15.tar.gz", hash = "sha256:dc1049bff52029313f213ab87a6b39acae76c462543729fcea80ea5ac23366b5", size = 117892, upload-time = "2026-04-30T07:39:01.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/fe/3f97b915c8cb13e75eb9939d442c165647386b4d62a41992188e70df3f9f/uipath_core-0.5.16.tar.gz", hash = "sha256:672d264900a968a10a777fe32d10f522ed8ef7fb7aebdfb765426bf50a1ffa16", size = 118786, upload-time = "2026-05-22T16:43:27.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/e4/e763bb94dd08ea93e98937b1a229a29f2907bee75a273a0594d929528133/uipath_core-0.5.15-py3-none-any.whl", hash = "sha256:8aa50b1f1531151ef827d29454d63e409c38699cd5a5d63f943094f2b7d5ddd7", size = 44575, upload-time = "2026-04-30T07:38:59.427Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6c/ac4ebc1e4ae03c471fe4a241ae9a0c53849a8254418feb450d2c5098d8aa/uipath_core-0.5.16-py3-none-any.whl", hash = "sha256:f9d420fd188a1e03f3e56fc4a40df5f2ec2359ff7cce666086288d3a8ace07df", size = 44673, upload-time = "2026-05-22T16:43:26.194Z" },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.9"
+version = "0.11.10"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4463,7 +4463,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.10.70,<2.11.0" },
+    { name = "uipath", specifier = ">=2.10.72,<2.11.0" },
     { name = "uipath-core", specifier = ">=0.5.15,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.13.0,<1.14.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.13.0,<1.14.0" },


### PR DESCRIPTION
## Summary
- Bump `uipath` dependency floor to `>=2.10.72, <2.11.0`
- Bump `uipath-langchain` package version to `0.11.10`
- Add tests for the new Function-type process tool resource exposed by uipath 2.10.72

## Test plan
- [x] `uv run pytest tests/agent/tools/test_process_tool.py tests/agent/tools/test_tool_factory.py` (36 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)