### PR TITLE
fix: do not add static args not found in the input schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.11"
+version = "0.11.12"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/static_args.py
+++ b/src/uipath_langchain/agent/tools/static_args.py
@@ -164,23 +164,30 @@ ToolT = TypeVar("ToolT", bound=StructuredTool)
 def _apply_static_arguments_to_schema(
     tool: ToolT,
     static_args: dict[str, ToolStaticArgument],
-) -> ToolT:
+) -> tuple[ToolT, set[str]]:
     """Modify tool schema based on pre-resolved static arguments.
 
     Args:
         tool: The tool to modify
         static_args: The mapping from JSON paths to static arguments
+
+    Returns:
+        The schema-modified tool and the set of json paths that were applied to
+        the schema. Paths that cannot be applied are skipped, so callers must
+        not thread them into the tool call: the synthesized schema rejects them
+        as extra inputs.
     """
     if not static_args:
-        return tool
+        return tool, set()
 
     if isinstance(tool.args_schema, dict):
         modified_json_schema = copy.deepcopy(tool.args_schema)
     elif tool.args_schema and issubclass(tool.args_schema, BaseModel):
         modified_json_schema = tool.args_schema.model_json_schema()
     else:
-        return tool
+        return tool, set(static_args)
 
+    applied_paths: set[str] = set()
     for json_path, static_arg in static_args.items():
         try:
             apply_static_value_to_schema(
@@ -189,6 +196,7 @@ def _apply_static_arguments_to_schema(
                 static_arg.display_value,
                 static_arg.is_sensitive,
             )
+            applied_paths.add(json_path)
         except SchemaModificationError as e:
             logger.warning(
                 f"Skipping invalid static argument path '{json_path}' for tool '{tool.name}': {e}"
@@ -197,7 +205,7 @@ def _apply_static_arguments_to_schema(
     modified_tool = tool.model_copy(deep=True)
     modified_tool.args_schema = create_model(modified_json_schema)
 
-    return modified_tool
+    return modified_tool, applied_paths
 
 
 @deprecated(
@@ -291,15 +299,24 @@ class StaticArgsHandler:
                 static_args = _resolve_argument_properties(
                     tool.argument_properties, agent_input
                 )
+                if isinstance(tool, StructuredTool):
+                    modified_tool, applied_paths = _apply_static_arguments_to_schema(
+                        tool, static_args
+                    )
+                    # Only thread args that survived schema modification: paths the
+                    # schema rejected would fail the synthesized strict validator.
+                    static_args = {
+                        path: sa
+                        for path, sa in static_args.items()
+                        if path in applied_paths
+                    }
+                    self._processed_tools.append(modified_tool)
+                else:
+                    self._processed_tools.append(tool)
                 self._sanitized_static_values[tool.name] = (
                     sanitize_dict_for_serialization(
                         {k: sa.value for k, sa in static_args.items()}
                     )
-                )
-                self._processed_tools.append(
-                    _apply_static_arguments_to_schema(tool, static_args)
-                    if isinstance(tool, StructuredTool)
-                    else tool
                 )
             else:
                 self._processed_tools.append(tool)

--- a/src/uipath_langchain/agent/tools/static_args.py
+++ b/src/uipath_langchain/agent/tools/static_args.py
@@ -173,9 +173,7 @@ def _apply_static_arguments_to_schema(
 
     Returns:
         The schema-modified tool and the set of json paths that were applied to
-        the schema. Paths that cannot be applied are skipped, so callers must
-        not thread them into the tool call: the synthesized schema rejects them
-        as extra inputs.
+        the schema. Paths that cannot be applied are skipped.
     """
     if not static_args:
         return tool, set()
@@ -306,18 +304,16 @@ class StaticArgsHandler:
                 modified_tool, applied_paths = _apply_static_arguments_to_schema(
                     tool, static_args
                 )
+                self._processed_tools.append(modified_tool)
                 # Only thread args that survived schema modification: paths the
                 # schema rejected would fail the synthesized strict validator.
-                static_args = {
-                    path: sa
+                applied_static_values = {
+                    path: sa.value
                     for path, sa in static_args.items()
                     if path in applied_paths
                 }
-                self._processed_tools.append(modified_tool)
                 self._sanitized_static_values[tool.name] = (
-                    sanitize_dict_for_serialization(
-                        {k: sa.value for k, sa in static_args.items()}
-                    )
+                    sanitize_dict_for_serialization(applied_static_values)
                 )
             else:
                 self._processed_tools.append(tool)

--- a/src/uipath_langchain/agent/tools/static_args.py
+++ b/src/uipath_langchain/agent/tools/static_args.py
@@ -295,24 +295,25 @@ class StaticArgsHandler:
         self._processed_tools = []
         self._sanitized_static_values = {}
         for tool in tools:
-            if isinstance(tool, ArgumentPropertiesMixin) and tool.argument_properties:
+            if (
+                isinstance(tool, ArgumentPropertiesMixin)
+                and isinstance(tool, StructuredTool)
+                and tool.argument_properties
+            ):
                 static_args = _resolve_argument_properties(
                     tool.argument_properties, agent_input
                 )
-                if isinstance(tool, StructuredTool):
-                    modified_tool, applied_paths = _apply_static_arguments_to_schema(
-                        tool, static_args
-                    )
-                    # Only thread args that survived schema modification: paths the
-                    # schema rejected would fail the synthesized strict validator.
-                    static_args = {
-                        path: sa
-                        for path, sa in static_args.items()
-                        if path in applied_paths
-                    }
-                    self._processed_tools.append(modified_tool)
-                else:
-                    self._processed_tools.append(tool)
+                modified_tool, applied_paths = _apply_static_arguments_to_schema(
+                    tool, static_args
+                )
+                # Only thread args that survived schema modification: paths the
+                # schema rejected would fail the synthesized strict validator.
+                static_args = {
+                    path: sa
+                    for path, sa in static_args.items()
+                    if path in applied_paths
+                }
+                self._processed_tools.append(modified_tool)
                 self._sanitized_static_values[tool.name] = (
                     sanitize_dict_for_serialization(
                         {k: sa.value for k, sa in static_args.items()}

--- a/tests/agent/tools/test_static_args.py
+++ b/tests/agent/tools/test_static_args.py
@@ -174,6 +174,31 @@ class TestStaticArgsHandler:
         assert call["args"]["existing_param"] == "exists"
         assert "missing_param" not in call["args"]
 
+    def test_initialize_with_all_argument_properties_unresolved(self):
+        """A tool whose argument properties all resolve to nothing is returned
+        unchanged and threads no static args into the call."""
+
+        class InputSchema(BaseModel):
+            present: str = ""
+
+        tool = _create_tool(
+            "test_tool",
+            {
+                "$['query']": AgentToolArgumentArgumentProperties(
+                    is_sensitive=False, argument_path="absentField"
+                ),
+            },
+        )
+        handler = StaticArgsHandler()
+        processed_tools = handler.initialize([tool], InputSchema(), InputSchema)
+
+        # No static args resolved, so the original tool passes through unmodified.
+        assert processed_tools[0] is tool
+
+        call = _make_tool_call("test_tool", {"host": "h"})
+        handler.apply_to_response([call])
+        assert call["args"] == {"host": "h"}
+
     def test_apply_to_response_merges_with_existing_args(self):
         """Test that apply_to_response merges static args with existing tool call args."""
         tool = _create_tool(

--- a/tests/agent/tools/test_static_args.py
+++ b/tests/agent/tools/test_static_args.py
@@ -88,6 +88,10 @@ class TestStaticArgsHandler:
             userId: str
             searchQuery: str
 
+        class ToolArgs(BaseModel):
+            user_id: str
+            query: str
+
         tool = _create_tool(
             "test_tool",
             {
@@ -98,6 +102,7 @@ class TestStaticArgsHandler:
                     is_sensitive=False, argument_path="searchQuery"
                 ),
             },
+            args_schema=ToolArgs,
         )
         handler = StaticArgsHandler()
         state = InputSchema(userId="user123", searchQuery="test search")
@@ -114,6 +119,10 @@ class TestStaticArgsHandler:
         class InputSchema(BaseModel):
             userId: str
 
+        class ToolArgs(BaseModel):
+            api_key: str
+            user_id: str
+
         tool = _create_tool(
             "test_tool",
             {
@@ -124,6 +133,7 @@ class TestStaticArgsHandler:
                     is_sensitive=False, argument_path="userId"
                 ),
             },
+            args_schema=ToolArgs,
         )
         handler = StaticArgsHandler()
         handler.initialize([tool], InputSchema(userId="user456"), InputSchema)
@@ -140,6 +150,10 @@ class TestStaticArgsHandler:
             existingArg: str
             missingArg: str = ""
 
+        class ToolArgs(BaseModel):
+            existing_param: str
+            missing_param: str = ""
+
         tool = _create_tool(
             "test_tool",
             {
@@ -150,6 +164,7 @@ class TestStaticArgsHandler:
                     is_sensitive=False, argument_path="nonExistentField"
                 ),
             },
+            args_schema=ToolArgs,
         )
         handler = StaticArgsHandler()
         handler.initialize([tool], InputSchema(existingArg="exists"), InputSchema)
@@ -274,6 +289,53 @@ class TestStaticArgsHandler:
         host_def = schema["$defs"]["Host"]
         assert host_def["enum"] == ["api.example.com"]
         assert "nonexistent_field" not in schema["properties"]
+
+    def test_static_arg_skipped_from_schema_is_not_applied_to_tool_call(self):
+        """
+        A static argument whose path cannot be applied to the schema (e.g. the
+        Integration-Service ``generateSchema`` button element, which is not a real
+        schema property) is correctly skipped during schema modification but must
+        also be stripped from the values threaded into the tool call. Otherwise the
+        leaked key is rejected by the synthesized strict (``extra='forbid'``) model.
+        """
+        dict_schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        }
+
+        async def tool_fn(**kwargs: Any) -> str:
+            return "ok"
+
+        tool = StructuredToolWithArgumentProperties(
+            name="Search_using_String",
+            description="An Integration-Service tool",
+            args_schema=dict_schema,
+            coroutine=tool_fn,
+            output_type=None,
+            argument_properties={
+                "$['generateSchema']": AgentToolStaticArgumentProperties(
+                    is_sensitive=False, value=None
+                ),
+            },
+        )
+        handler = StaticArgsHandler()
+        processed_tools = handler.initialize([tool], EmptyInput(), EmptyInput)
+        modified_tool = processed_tools[0]
+
+        call = _make_tool_call("Search_using_String", {"query": "hello"})
+        handler.apply_to_response([call])
+
+        # The un-inlineable path must not leak into the tool call args.
+        assert "generateSchema" not in call["args"]
+        assert call["args"] == {"query": "hello"}
+
+        # The applied args must validate against the synthesized strict model.
+        assert isinstance(modified_tool.args_schema, type) and issubclass(
+            modified_tool.args_schema, BaseModel
+        )
+        modified_tool.args_schema.model_validate(call["args"])
 
 
 class TestApplyStaticArgs:

--- a/tests/agent/tools/test_static_args.py
+++ b/tests/agent/tools/test_static_args.py
@@ -290,6 +290,33 @@ class TestStaticArgsHandler:
         assert len(processed_tools) == 1
         assert processed_tools[0] is tool
 
+    def test_initialize_keeps_static_args_when_schema_is_not_a_model(self):
+        """A tool without a dict/BaseModel schema can't be schema-filtered, so its
+        static args pass through unchanged and the tool is returned as-is."""
+
+        async def tool_fn(**kwargs: Any) -> str:
+            return "ok"
+
+        tool = StructuredToolWithArgumentProperties(
+            name="test_tool",
+            description="A test tool",
+            args_schema=None,
+            coroutine=tool_fn,
+            output_type=None,
+            argument_properties={
+                "$['x']": AgentToolStaticArgumentProperties(
+                    is_sensitive=False, value="v"
+                ),
+            },
+        )
+        handler = StaticArgsHandler()
+        processed_tools = handler.initialize([tool], EmptyInput(), EmptyInput)
+        assert processed_tools[0] is tool
+
+        call = _make_tool_call("test_tool")
+        handler.apply_to_response([call])
+        assert call["args"] == {"x": "v"}
+
     def test_initialize_skips_nonexistent_schema_fields(self):
         """Test that static properties referencing nonexistent schema fields are skipped."""
         tool = _create_tool(

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.11"
+version = "0.11.12"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
For certain IS tools, there was a bug where certain IS fields were interpreted as static args despite not being in the schema. It has been fixed at design time, but agents with IS tools already configured won't get fixed without manually re-adding the tool.

Since we already had a warning for fields that could not be found in the schema, I extended to skip adding them to the tool input as well.