### PR TITLE
test(agent): use canonical actionCenter channel type in escalation fixture

### DIFF
--- a/tests/agent/tools/test_tool_factory.py
+++ b/tests/agent/tools/test_tool_factory.py
@@ -132,7 +132,7 @@ def escalation_resource() -> AgentEscalationResourceConfig:
         channels=[
             AgentEscalationChannel(
                 name="test_channel",
-                type="action_center",
+                type="actionCenter",
                 description="Test channel description",
                 task_title="Test Task",
                 input_schema=EMPTY_SCHEMA,


### PR DESCRIPTION
## Summary

`tests/agent/tools/test_tool_factory.py`'s `escalation_resource` fixture set the escalation channel `type` to `action_center` (snake_case). It only ever validated because the channel `type` is currently an open `str`. Every other escalation fixture in the suite already uses the canonical `actionCenter` (the real wire value).

Aligning this single fixture makes it parse under the stricter, discriminated escalation-channel model introduced in [uipath-python#1686](https://github.com/UiPath/uipath-python/pull/1686), which surfaced it via the `uipath-langchain` cross-test (`Input should be 'actionCenter'`). No behavior change — the fixture targets an Action Center channel either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)