### PR TITLE
feat: Governance runtime implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.22"
+version = "0.13.23"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
     "uipath>=2.12.7, <2.13.0",
-    "uipath-core>=0.5.20, <0.6.0",
+    "uipath-core>=0.5.28, <0.6.0",
     "uipath-platform>=0.1.91, <0.2.0",
-    "uipath-runtime>=0.11.4, <0.12.0",
+    "uipath-runtime>=0.11.7, <0.12.0",
     "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.27, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",

--- a/src/uipath_langchain/governance/__init__.py
+++ b/src/uipath_langchain/governance/__init__.py
@@ -1,0 +1,16 @@
+"""Governance integration for ``uipath-langchain``.
+
+Exposes :class:`GovernanceCallbackHandler` — a LangChain callback
+handler that calls an :class:`~uipath.core.adapters.EvaluatorProtocol`
+on the model and tool lifecycle. Wired into a run by passing an
+``evaluator`` to :class:`UiPathLangGraphRuntimeFactory`; the factory
+builds the handler and hands it to the runtime through the existing
+``callbacks`` channel.
+
+Importing this module has no side effects: no adapter is registered,
+no global state is mutated.
+"""
+
+from .callbacks import GovernanceCallbackHandler
+
+__all__ = ["GovernanceCallbackHandler"]

--- a/src/uipath_langchain/governance/callbacks.py
+++ b/src/uipath_langchain/governance/callbacks.py
@@ -1,0 +1,393 @@
+"""LangChain governance callback handler.
+
+A :class:`langchain_core.callbacks.BaseCallbackHandler` that calls a
+framework-agnostic :class:`~uipath.core.adapters.EvaluatorProtocol`
+on the model and tool lifecycle.
+
+Wiring lives in :class:`UiPathLangGraphRuntimeFactory`: passing an
+``evaluator`` to ``new_runtime`` causes the factory to build this
+handler and hand it to :class:`UiPathLangGraphRuntime` through the
+existing ``callbacks`` constructor arg. No adapter registry, no global
+state, no import-time mutation.
+
+Intercepts:
+
+- ``on_llm_start`` / ``on_chat_model_start`` / ``on_llm_end`` → BEFORE_MODEL / AFTER_MODEL
+- ``on_tool_start`` / ``on_tool_end``                         → TOOL_CALL / AFTER_TOOL
+
+Chain-level boundaries (BEFORE_AGENT / AFTER_AGENT) are intentionally
+*not* fired from here — they are owned by the governance host that
+drives the agent. ``ignore_chain = True`` makes LangChain skip chain
+notifications entirely, avoiding duplicate boundary evaluations.
+
+Audit emission and enforcement (raising
+:class:`GovernanceBlockException` on DENY) are owned by the evaluator
+itself. This module just hooks the framework callbacks, extracts the
+data, and calls ``evaluator.evaluate_*``; block exceptions propagate,
+everything else is logged and swallowed so a governance bug never
+breaks an agent run.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import (
+    ChatGeneration,
+    ChatGenerationChunk,
+    Generation,
+    GenerationChunk,
+    LLMResult,
+)
+from uipath.core.adapters import EvaluatorProtocol
+from uipath.core.governance.exceptions import GovernanceBlockException
+
+GenerationLike = Generation | ChatGeneration | GenerationChunk | ChatGenerationChunk
+
+logger = logging.getLogger(__name__)
+
+# Cap on the text scanned per model hook, so a long history / runaway
+# response can't blow scan-time budgets.
+_BEFORE_MODEL_TEXT_CAP = 64000
+
+
+class GovernanceCallbackHandler(BaseCallbackHandler):
+    """LangChain callback handler that fires governance evaluation.
+
+    The evaluator owns audit emission and DENY-raising. Each ``on_*``
+    callback only extracts the relevant payload and calls the matching
+    ``evaluate_*`` method; :class:`GovernanceBlockException` is allowed
+    to propagate, anything else is logged and swallowed.
+    """
+
+    run_inline: bool = True
+    raise_error: bool = True
+    ignore_llm: bool = False
+    # Chain-level events (BEFORE_AGENT / AFTER_AGENT) are owned by the
+    # governance host, so this handler skips them to avoid duplicate
+    # boundary evaluations.
+    ignore_chain: bool = True
+    ignore_agent: bool = False
+    ignore_retriever: bool = True
+    ignore_retry: bool = True
+    ignore_chat_model: bool = False
+    ignore_custom_event: bool = True
+
+    def __init__(
+        self,
+        evaluator: EvaluatorProtocol,
+        agent_name: str,
+        session_id: str,
+    ) -> None:
+        self._evaluator = evaluator
+        self._agent_name = agent_name
+        self._session_id = session_id
+        # ``trace_id`` is intentionally NOT held here. Trace correlation
+        # is owned by the layer below: OTel-backed sinks read the live
+        # span via ``trace.get_current_span()`` on the caller's thread;
+        # HTTP-bound consumers resolve the canonical trace id at call
+        # time. The callback handler is env-free and just forwards
+        # extracted payload to the evaluator.
+        self._session_state: dict[str, Any] = {"tool_calls": 0, "llm_calls": 0}
+        # Tool name lookup keyed by LangChain ``run_id`` so ``on_tool_end``
+        # can report the actual tool name to AFTER_TOOL evaluation.
+        self._tool_runs: dict[str, str] = {}
+
+    # ----- LLM callbacks ---------------------------------------------------
+
+    def on_llm_start(
+        self,
+        serialized: dict[str, Any],
+        prompts: list[str],
+        **kwargs: Any,
+    ) -> None:
+        """Evaluate BEFORE_MODEL rules at LLM start (non-chat completion).
+
+        ``prompts`` is a LangChain *batch* of independent completion
+        requests (``BaseLLM.generate(prompts=[...])``), not turns of a
+        single conversation. Every prompt is evaluated so a governed
+        request cannot bypass BEFORE_MODEL merely by not being the last
+        item in the batch; any DENY propagates.
+        """
+        try:
+            self._session_state["llm_calls"] = (
+                self._session_state.get("llm_calls", 0) + 1
+            )
+            for prompt in prompts:
+                self._evaluator.evaluate_before_model(
+                    model_input=prompt[:_BEFORE_MODEL_TEXT_CAP],
+                    agent_name=self._agent_name,
+                    runtime_id=self._session_id,
+                )
+        except GovernanceBlockException:
+            raise
+        except Exception as e:
+            logger.warning("on_llm_start governance check failed (continuing): %s", e)
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        **kwargs: Any,
+    ) -> None:
+        """Evaluate BEFORE_MODEL rules for chat models.
+
+        ``messages`` is LangChain's nested batch shape
+        ``list[list[BaseMessage]]``: the **outer** list is the batch of
+        independent requests, each **inner** list is one request's full
+        message history. Every batch item is evaluated so an earlier
+        independent request cannot bypass BEFORE_MODEL, but within each
+        item only the **latest message** is scanned — not the full
+        history. The LLM still receives the entire history (this
+        callback doesn't mutate ``messages``); scoping to the newest
+        message keeps a violation in an earlier turn from re-firing on
+        every later turn that still carries it for context. Any DENY
+        propagates.
+
+        List-of-blocks content (multimodal, function-call, tool_use,
+        extended thinking) is walked via :meth:`_extract_block_text` so
+        dict-syntax noise from ``str(list)`` doesn't leak into the
+        regex-scanned blob.
+        """
+        try:
+            self._session_state["llm_calls"] = (
+                self._session_state.get("llm_calls", 0) + 1
+            )
+            for message_list in messages:
+                self._evaluator.evaluate_before_model(
+                    model_input=self._latest_message_input(message_list),
+                    agent_name=self._agent_name,
+                    runtime_id=self._session_id,
+                )
+        except GovernanceBlockException:
+            raise
+        except Exception as e:
+            logger.warning(
+                "on_chat_model_start governance check failed (continuing): %s", e
+            )
+
+    @staticmethod
+    def _latest_message_input(message_list: list[BaseMessage]) -> str:
+        """Extract content from the most-recent message of one batch item.
+
+        ``message_list`` is a single request's full message stack — one
+        inner list of LangChain's ``list[list[BaseMessage]]`` batch
+        shape. We take its last entry. For string content, that's used
+        directly; for list-of-blocks content, :meth:`_extract_block_text`
+        pulls the text / arguments / input / thinking fields cleanly.
+
+        Returns ``""`` (empty) when the message stack is empty or the
+        last message carries no extractable content.
+        """
+        if not message_list:
+            return ""
+        last_msg = message_list[-1]
+        # BaseMessage exposes ``.content``; dict-shaped messages
+        # (LangGraph state, raw OpenAI format) carry it under the same
+        # key.
+        content = getattr(last_msg, "content", None)
+        if content is None and isinstance(last_msg, dict):
+            content = last_msg.get("content")
+        if isinstance(content, str):
+            return content[:_BEFORE_MODEL_TEXT_CAP]
+        if isinstance(content, list):
+            return GovernanceCallbackHandler._blocks_to_text(content)
+        return ""
+
+    @staticmethod
+    def _blocks_to_text(content: list[str | dict[str, Any]]) -> str:
+        """Concatenate governance-relevant text from a list of content blocks.
+
+        Walks list-of-blocks message content (multimodal, function-call,
+        tool_use, extended thinking) via :meth:`_extract_block_text`,
+        capping the joined result at ``_BEFORE_MODEL_TEXT_CAP``.
+        """
+        pieces = (
+            GovernanceCallbackHandler._extract_block_text(block)
+            for block in content
+            if isinstance(block, dict)
+        )
+        return GovernanceCallbackHandler._join_within_cap(pieces, "\n")
+
+    @staticmethod
+    def _join_within_cap(pieces: Iterable[str], sep: str) -> str:
+        """Join non-empty ``pieces`` with ``sep``, stopping at the text cap.
+
+        Shared accumulator for the model-input/output scan blobs: appends
+        pieces until ``_BEFORE_MODEL_TEXT_CAP`` characters are reached
+        (counting the separator), then caps the joined result.
+        """
+        out: list[str] = []
+        remaining = _BEFORE_MODEL_TEXT_CAP
+        for piece in pieces:
+            if remaining <= 0:
+                break
+            if piece:
+                out.append(piece)
+                remaining -= len(piece) + len(sep)
+        return sep.join(out)[:_BEFORE_MODEL_TEXT_CAP]
+
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        """Evaluate AFTER_MODEL rules at LLM end.
+
+        Concatenates text from every generation. The result is capped at
+        ``_BEFORE_MODEL_TEXT_CAP`` to match the BEFORE_MODEL budget, so
+        batched calls or a runaway single response can't blow scan budgets.
+        """
+        try:
+            model_output = self._collect_generations_text(response)
+            self._evaluator.evaluate_after_model(
+                model_output=model_output,
+                agent_name=self._agent_name,
+                runtime_id=self._session_id,
+            )
+        except GovernanceBlockException:
+            raise
+        except Exception as e:
+            logger.warning("on_llm_end governance check failed (continuing): %s", e)
+
+    def _collect_generations_text(self, response: LLMResult) -> str:
+        """Concatenate text across all generations, capped at the text budget."""
+        pieces = (
+            self._extract_generation_text(gen)
+            for gen_list in response.generations
+            for gen in gen_list
+        )
+        return self._join_within_cap(pieces, "")
+
+    @staticmethod
+    def _extract_generation_text(gen: GenerationLike) -> str:
+        """Return the text payload of a LangChain generation.
+
+        ``Generation.text`` is set from ``message.content`` only when content
+        is a plain ``str``. For chat models whose content is a list of
+        content blocks (multimodal, tool calls, "submit final answer"
+        function calls, extended thinking) ``.text`` is ``""``. In that case
+        walk ``gen.message.content`` so the governance evaluator sees the
+        actual assistant text.
+        """
+        if isinstance(gen, (ChatGeneration, ChatGenerationChunk)):
+            content = gen.message.content
+            if isinstance(content, list):
+                parts = [
+                    GovernanceCallbackHandler._extract_block_text(block)
+                    for block in content
+                    if isinstance(block, dict)
+                ]
+                joined = "\n".join(p for p in parts if p)
+                if joined:
+                    return joined
+        return gen.text or ""
+
+    @staticmethod
+    def _extract_block_text(block: dict[str, Any]) -> str:
+        """Return any governance-relevant text from a content block.
+
+        Covers the common block shapes across providers:
+
+        - ``{"type": "text", "text": "..."}`` — plain text block.
+        - ``{"type": "function_call", "arguments": "<json>"}`` — OpenAI
+          function call; ``arguments`` is JSON-encoded and routinely
+          carries the user-visible reply (e.g. ``end_execution(content=...)``
+          tools used as a "submit final answer" pattern).
+        - ``{"type": "tool_use", "input": {...}}`` — Anthropic tool use;
+          string values in ``input`` are the assistant's outgoing payload.
+        - ``{"type": "thinking", "thinking": "..."}`` — Claude extended
+          thinking (governance-relevant: hidden reasoning can also leak
+          commitments and PII).
+
+        Metadata-only keys (``id``, ``call_id``, ``name``, ``status``,
+        ``type``, ...) are excluded so the scanned text isn't padded with
+        opaque identifiers that could false-positive a rule.
+        """
+        parts: list[str] = []
+        text_value = block.get("text")
+        if isinstance(text_value, str):
+            parts.append(text_value)
+        arguments_value = block.get("arguments")
+        if isinstance(arguments_value, str):
+            parts.append(arguments_value)
+        thinking_value = block.get("thinking")
+        if isinstance(thinking_value, str):
+            parts.append(thinking_value)
+        input_value = block.get("input")
+        if isinstance(input_value, dict):
+            parts.extend(v for v in input_value.values() if isinstance(v, str))
+        return "\n".join(p for p in parts if p)
+
+    def on_llm_error(self, error: BaseException, **kwargs: Any) -> None:
+        logger.warning("LLM error in governed session %s: %s", self._session_id, error)
+
+    # ----- Tool callbacks --------------------------------------------------
+
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        inputs: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Evaluate TOOL_CALL rules at tool start.
+
+        ``run_id → tool_name`` is recorded so ``on_tool_end`` /
+        ``on_tool_error`` can report the actual tool. If the evaluator
+        BLOCKS, the tool is aborted, ``on_tool_end`` will not fire, and
+        the mapping is dropped to keep ``_tool_runs`` from growing
+        unbounded across blocked turns.
+        """
+        run_id = kwargs.get("run_id")
+        run_id_str = str(run_id) if run_id is not None else None
+        try:
+            self._session_state["tool_calls"] = (
+                self._session_state.get("tool_calls", 0) + 1
+            )
+            tool_name = (serialized or {}).get("name", "unknown")
+            if run_id_str is not None:
+                self._tool_runs[run_id_str] = tool_name
+            tool_args = inputs or {"input": input_str}
+            self._evaluator.evaluate_tool_call(
+                tool_name=tool_name,
+                tool_args=tool_args,
+                agent_name=self._agent_name,
+                runtime_id=self._session_id,
+                session_state=self._session_state,
+            )
+        except GovernanceBlockException:
+            # Tool will not run → no on_tool_end is coming. Drop the
+            # mapping so it does not accumulate across blocked turns.
+            if run_id_str is not None:
+                self._tool_runs.pop(run_id_str, None)
+            raise
+        except Exception as e:
+            logger.warning("on_tool_start governance check failed (continuing): %s", e)
+
+    def on_tool_end(self, output: Any, **kwargs: Any) -> None:
+        """Evaluate AFTER_TOOL rules at tool end."""
+        try:
+            run_id = kwargs.get("run_id")
+            tool_name = "unknown"
+            if run_id is not None:
+                tool_name = self._tool_runs.pop(str(run_id), "unknown")
+            tool_result = str(output) if output is not None else ""
+            self._evaluator.evaluate_after_tool(
+                tool_name=tool_name,
+                tool_result=tool_result,
+                agent_name=self._agent_name,
+                runtime_id=self._session_id,
+            )
+        except GovernanceBlockException:
+            raise
+        except Exception as e:
+            logger.warning("on_tool_end governance check failed (continuing): %s", e)
+
+    def on_tool_error(self, error: BaseException, **kwargs: Any) -> None:
+        # Tool errored out — on_tool_end will not fire. Pop the mapping
+        # so a session with many failing tool calls does not leak.
+        run_id = kwargs.get("run_id")
+        if run_id is not None:
+            self._tool_runs.pop(str(run_id), None)
+        logger.warning("Tool error in governed session %s: %s", self._session_id, error)

--- a/src/uipath_langchain/runtime/factory.py
+++ b/src/uipath_langchain/runtime/factory.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 from typing import Any, AsyncContextManager
 
+from langchain_core.callbacks import BaseCallbackHandler
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.graph.state import CompiledStateGraph, StateGraph
 from openinference.instrumentation.langchain import (
@@ -9,6 +10,7 @@ from openinference.instrumentation.langchain import (
     get_ancestor_spans,
     get_current_span,
 )
+from uipath.core.adapters import EvaluatorProtocol
 from uipath.core.tracing import UiPathSpanUtils, UiPathTraceManager
 from uipath.platform.resume_triggers import (
     UiPathResumeTriggerHandler,
@@ -23,11 +25,15 @@ from uipath.runtime import (
 from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain._tracing import _instrument_traceable_attributes
+from uipath_langchain.governance import GovernanceCallbackHandler
 from uipath_langchain.runtime.config import LangGraphConfig
 from uipath_langchain.runtime.errors import LangGraphErrorCode, LangGraphRuntimeError
 from uipath_langchain.runtime.graph import LangGraphLoader
 from uipath_langchain.runtime.runtime import UiPathLangGraphRuntime
 from uipath_langchain.runtime.storage import SqliteResumableStorage
+
+_AGENT_TYPE_CODED = "uipath_coded"
+_AGENT_FRAMEWORK = "langchain"
 
 
 class UiPathLangGraphRuntimeFactory:
@@ -234,10 +240,16 @@ class UiPathLangGraphRuntimeFactory:
         return config.entrypoints
 
     async def get_settings(self) -> UiPathRuntimeFactorySettings | None:
+        """Get the factory settings.
+
+        Advertises this factory's ``agent_type`` and ``agent_framework``
+        wire labels so hosts (governance audit, App Insights telemetry)
+        can stamp them onto events without any host-side classification.
         """
-        Get the factory settings.
-        """
-        return None
+        return UiPathRuntimeFactorySettings(
+            agent_type=_AGENT_TYPE_CODED,
+            agent_framework=_AGENT_FRAMEWORK,
+        )
 
     async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
         """
@@ -263,6 +275,10 @@ class UiPathLangGraphRuntimeFactory:
             compiled_graph: The compiled graph
             runtime_id: Unique identifier for the runtime instance
             entrypoint: Graph entrypoint name
+            **kwargs: Forwarded factory kwargs. Recognized:
+                ``evaluator`` (``EvaluatorProtocol``) — when present, the
+                factory builds a :class:`GovernanceCallbackHandler` and
+                hands it to the runtime via its ``callbacks`` arg.
 
         Returns:
             Configured runtime instance
@@ -271,10 +287,24 @@ class UiPathLangGraphRuntimeFactory:
         storage = SqliteResumableStorage(memory)
         trigger_manager = UiPathResumeTriggerHandler()
 
+        evaluator: EvaluatorProtocol | None = kwargs.get("evaluator")
+        callbacks: list[BaseCallbackHandler] | None = (
+            [
+                GovernanceCallbackHandler(
+                    evaluator=evaluator,
+                    agent_name=entrypoint,
+                    session_id=runtime_id,
+                )
+            ]
+            if evaluator is not None
+            else None
+        )
+
         base_runtime = UiPathLangGraphRuntime(
             graph=compiled_graph,
             runtime_id=runtime_id,
             entrypoint=entrypoint,
+            callbacks=callbacks,
             storage=storage,
         )
 
@@ -286,7 +316,10 @@ class UiPathLangGraphRuntimeFactory:
         )
 
     async def new_runtime(
-        self, entrypoint: str, runtime_id: str, **kwargs
+        self,
+        entrypoint: str,
+        runtime_id: str,
+        **kwargs,
     ) -> UiPathRuntimeProtocol:
         """
         Create a new LangGraph runtime instance.
@@ -294,6 +327,10 @@ class UiPathLangGraphRuntimeFactory:
         Args:
             entrypoint: Graph name from langgraph.json
             runtime_id: Unique identifier for the runtime instance
+            **kwargs: Forwarded factory kwargs. Recognized:
+                ``evaluator`` (``EvaluatorProtocol``) — when present, the
+                factory wires a :class:`GovernanceCallbackHandler` into
+                the runtime's callback list.
 
         Returns:
             Configured runtime instance with compiled graph

--- a/tests/governance/test_callbacks.py
+++ b/tests/governance/test_callbacks.py
@@ -1,0 +1,656 @@
+"""Tests for the LangChain governance callback handler."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, Generation, LLMResult
+from uipath.core.governance.exceptions import GovernanceBlockException
+
+from uipath_langchain.governance import GovernanceCallbackHandler
+from uipath_langchain.governance.callbacks import _BEFORE_MODEL_TEXT_CAP
+
+LOGGER_PATH = "uipath_langchain.governance.callbacks.logger"
+
+
+def _chat_batch(*message_lists: list[Any]) -> list[list[BaseMessage]]:
+    """
+    ``on_chat_model_start`` accepts real ``BaseMessage`` objects and
+    dict-shaped LangGraph-state messages alike (the handler falls back
+    to ``dict["content"]``); these tests exercise both with lightweight
+    stand-ins (``SimpleNamespace`` / ``dict``) that mypy can't statically
+    see as ``BaseMessage``. The cast keeps the framework-accurate
+    signature while letting tests use minimal fixtures. Each positional
+    argument is one batch item (one request's message stack).
+    """
+    return cast("list[list[BaseMessage]]", list(message_lists))
+
+
+@pytest.fixture
+def evaluator() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def handler(evaluator: MagicMock) -> GovernanceCallbackHandler:
+    return GovernanceCallbackHandler(
+        evaluator=evaluator,
+        agent_name="test-agent",
+        session_id="test-session",
+    )
+
+
+class TestSubclassesBaseCallbackHandler:
+    def test_is_base_callback_handler(self, handler: GovernanceCallbackHandler) -> None:
+        # The handler must be a real LangChain BaseCallbackHandler so
+        # LangChain's dispatch / tracer wiring treats it natively.
+        assert isinstance(handler, BaseCallbackHandler)
+
+    def test_ignore_flags_override_parent_properties(
+        self, handler: GovernanceCallbackHandler
+    ) -> None:
+        # Chain notifications skipped — the governance host owns
+        # BEFORE_AGENT / AFTER_AGENT and would otherwise double-fire.
+        assert handler.ignore_chain is True
+        assert handler.ignore_retriever is True
+        assert handler.ignore_retry is True
+        assert handler.ignore_custom_event is True
+        # LLM / chat model / tool / agent events stay on.
+        assert handler.ignore_llm is False
+        assert handler.ignore_chat_model is False
+        assert handler.ignore_agent is False
+
+
+class TestCallbackHandlerLLM:
+    def test_on_llm_start_evaluates_every_prompt_in_batch(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """Every prompt feeds BEFORE_MODEL. ``prompts`` is a batch of
+        independent completion requests, not turns of one conversation —
+        evaluating only the last would let earlier requests bypass
+        governance entirely."""
+        handler.on_llm_start({"name": "m"}, ["a", "b"])
+        assert evaluator.evaluate_before_model.call_count == 2
+        inputs = [
+            c.kwargs["model_input"]
+            for c in evaluator.evaluate_before_model.call_args_list
+        ]
+        assert inputs == ["a", "b"]
+        kwargs = evaluator.evaluate_before_model.call_args.kwargs
+        assert kwargs["agent_name"] == "test-agent"
+        assert kwargs["runtime_id"] == "test-session"
+        # ``trace_id`` is intentionally NOT passed — correlation is
+        # owned by the layer below the evaluator. The handler is
+        # env-free.
+        assert "trace_id" not in kwargs
+
+    def test_on_llm_start_batch_blocks_non_last_prompt(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """A DENY on an earlier batch item propagates: the blocked
+        request is first and a safe one is last, yet governance fires."""
+
+        def _block_blocked(**kwargs: Any) -> None:
+            if "blocked" in kwargs["model_input"]:
+                raise GovernanceBlockException("blocked")
+
+        evaluator.evaluate_before_model.side_effect = _block_blocked
+        with pytest.raises(GovernanceBlockException):
+            handler.on_llm_start(
+                {}, ["blocked independent request", "safe independent request"]
+            )
+
+    def test_on_llm_start_increments_counter(
+        self, handler: GovernanceCallbackHandler
+    ) -> None:
+        handler.on_llm_start({}, ["p"])
+        handler.on_llm_start({}, ["p"])
+        assert handler._session_state["llm_calls"] == 2
+
+    def test_on_llm_start_empty_prompts(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """No prompts → nothing to evaluate; the evaluator isn't called."""
+        handler.on_llm_start({}, [])
+        evaluator.evaluate_before_model.assert_not_called()
+
+    def test_on_llm_start_propagates_block(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        evaluator.evaluate_before_model.side_effect = GovernanceBlockException(
+            "blocked"
+        )
+        with pytest.raises(GovernanceBlockException):
+            handler.on_llm_start({}, ["p"])
+
+    def test_on_llm_start_swallows_other_exceptions(
+        self,
+        handler: GovernanceCallbackHandler,
+        evaluator: MagicMock,
+    ) -> None:
+        evaluator.evaluate_before_model.side_effect = RuntimeError("nope")
+        with patch(LOGGER_PATH) as mock_logger:
+            handler.on_llm_start({}, ["p"])  # must not raise
+        mock_logger.warning.assert_called_once()
+        assert "on_llm_start" in mock_logger.warning.call_args.args[0]
+
+    def test_on_chat_model_start_latest_message_only(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """Within a batch item only the LAST message is scanned.
+
+        Without this scoping, a violation in turn 3's user message
+        would keep re-firing on every subsequent LLM call because
+        that text stays in the prompt for context.
+        """
+        handler.on_chat_model_start(
+            {},
+            _chat_batch(
+                [SimpleNamespace(content="hello"), SimpleNamespace(content="world")]
+            ),
+        )
+        model_input = evaluator.evaluate_before_model.call_args.kwargs["model_input"]
+        assert model_input == "world"
+        assert "hello" not in model_input
+
+    def test_on_chat_model_start_evaluates_every_batch_item(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """The outer list is a batch of independent requests: each item
+        is evaluated (its latest message only), so an earlier item can't
+        bypass BEFORE_MODEL."""
+        handler.on_chat_model_start(
+            {},
+            _chat_batch(
+                [SimpleNamespace(content="first request")],
+                [SimpleNamespace(content="second request")],
+            ),
+        )
+        assert evaluator.evaluate_before_model.call_count == 2
+        inputs = [
+            c.kwargs["model_input"]
+            for c in evaluator.evaluate_before_model.call_args_list
+        ]
+        assert inputs == ["first request", "second request"]
+
+    def test_on_chat_model_start_batch_blocks_non_last_item(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """A DENY on an earlier independent batch item propagates."""
+
+        def _block_blocked(**kwargs: Any) -> None:
+            if "blocked" in kwargs["model_input"]:
+                raise GovernanceBlockException("blocked")
+
+        evaluator.evaluate_before_model.side_effect = _block_blocked
+        with pytest.raises(GovernanceBlockException):
+            handler.on_chat_model_start(
+                {},
+                _chat_batch(
+                    [SimpleNamespace(content="blocked independent chat request")],
+                    [SimpleNamespace(content="safe independent chat request")],
+                ),
+            )
+
+    def test_on_chat_model_start_dict_messages_latest_only(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """Dict-shaped (LangGraph state) messages: latest is extracted."""
+        handler.on_chat_model_start(
+            {},
+            _chat_batch(
+                [{"content": "from dict"}, {"role": "user", "content": "another"}]
+            ),
+        )
+        model_input = evaluator.evaluate_before_model.call_args.kwargs["model_input"]
+        assert model_input == "another"
+        assert "from dict" not in model_input
+
+    def test_on_chat_model_start_dict_message_missing_content(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_chat_model_start({}, _chat_batch([{"role": "user"}]))
+        assert evaluator.evaluate_before_model.call_args.kwargs["model_input"] == ""
+
+    def test_on_chat_model_start_list_of_blocks_content(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """Multi-block content (text + function_call) is extracted cleanly.
+
+        Regression for the prior ``str(msg.content)`` path which produced
+        ``[{'type': ..., 'text': ...}]`` dict-repr noise instead of
+        clean text. Field-precise rules can't navigate that shape.
+        """
+        latest = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "Here's the answer:"},
+                {
+                    "type": "function_call",
+                    "name": "end_execution",
+                    "arguments": '{"content":"Cost: $1,200"}',
+                    "id": "fc_abc",
+                },
+            ]
+        )
+        handler.on_chat_model_start(
+            {}, _chat_batch([SimpleNamespace(content="old"), latest])
+        )
+        model_input = evaluator.evaluate_before_model.call_args.kwargs["model_input"]
+        assert "Here's the answer:" in model_input
+        assert "Cost: $1,200" in model_input
+        # No dict-syntax noise from str(list).
+        assert "{'type'" not in model_input
+
+    def test_on_chat_model_start_empty_messages(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """Empty batch → nothing to evaluate; the evaluator isn't called."""
+        handler.on_chat_model_start({}, _chat_batch())
+        evaluator.evaluate_before_model.assert_not_called()
+
+    def test_on_chat_model_start_empty_inner_batch(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_chat_model_start({}, _chat_batch([]))
+        assert evaluator.evaluate_before_model.call_args.kwargs["model_input"] == ""
+
+    def test_on_chat_model_start_caps_model_input(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """``model_input`` is bounded so a runaway prompt can't dominate scan time."""
+        huge = SimpleNamespace(content="x" * (_BEFORE_MODEL_TEXT_CAP + 1000))
+        handler.on_chat_model_start({}, _chat_batch([huge]))
+        model_input = evaluator.evaluate_before_model.call_args.kwargs["model_input"]
+        assert len(model_input) == _BEFORE_MODEL_TEXT_CAP
+
+    def test_on_chat_model_start_block_list_stops_at_remaining_budget(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """The block walk exits early once the per-call cap is exhausted."""
+        first = "a" * _BEFORE_MODEL_TEXT_CAP  # consumes the entire budget
+        latest = SimpleNamespace(
+            content=[
+                {"type": "text", "text": first},
+                {"type": "text", "text": "MUST_NOT_APPEAR"},
+            ]
+        )
+        handler.on_chat_model_start({}, _chat_batch([latest]))
+        model_input = evaluator.evaluate_before_model.call_args.kwargs["model_input"]
+        assert "MUST_NOT_APPEAR" not in model_input
+        assert len(model_input) == _BEFORE_MODEL_TEXT_CAP
+
+    def test_on_chat_model_start_block_list_skips_non_dict_entries(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """Non-dict entries inside a content list are silently skipped."""
+        latest = SimpleNamespace(
+            content=[
+                "ignored-string-block",
+                {"type": "text", "text": "kept"},
+                42,
+                None,
+            ]
+        )
+        handler.on_chat_model_start({}, _chat_batch([latest]))
+        model_input = evaluator.evaluate_before_model.call_args.kwargs["model_input"]
+        assert model_input == "kept"
+
+    def test_on_chat_model_start_propagates_block(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        evaluator.evaluate_before_model.side_effect = GovernanceBlockException("x")
+        with pytest.raises(GovernanceBlockException):
+            handler.on_chat_model_start({}, _chat_batch([SimpleNamespace(content="x")]))
+
+    def test_on_chat_model_start_swallows_other_exceptions(
+        self,
+        handler: GovernanceCallbackHandler,
+        evaluator: MagicMock,
+    ) -> None:
+        evaluator.evaluate_before_model.side_effect = RuntimeError("oops")
+        with patch(LOGGER_PATH) as mock_logger:
+            handler.on_chat_model_start({}, _chat_batch([SimpleNamespace(content="x")]))
+        mock_logger.warning.assert_called_once()
+        assert "on_chat_model_start" in mock_logger.warning.call_args.args[0]
+
+    def test_on_llm_end_extracts_plain_text(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        response = LLMResult(generations=[[Generation(text="output")]])
+        handler.on_llm_end(response)
+        kwargs = evaluator.evaluate_after_model.call_args.kwargs
+        assert kwargs["model_output"] == "output"
+
+    def test_on_llm_end_response_without_generations(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_llm_end(LLMResult(generations=[]))
+        assert evaluator.evaluate_after_model.call_args.kwargs["model_output"] == ""
+
+    def test_on_llm_end_propagates_block(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        evaluator.evaluate_after_model.side_effect = GovernanceBlockException("x")
+        with pytest.raises(GovernanceBlockException):
+            handler.on_llm_end(LLMResult(generations=[]))
+
+    def test_on_llm_end_caps_model_output(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """A runaway / batched response is capped so the AFTER_MODEL
+        scan budget matches BEFORE_MODEL and the runtime side's cap.
+        """
+        # Many large generations across batched gen_lists.
+        big = "y" * 50_000
+        response = LLMResult(
+            generations=[
+                [Generation(text=big)],
+                [Generation(text=big), Generation(text=big)],
+            ]
+        )
+        handler.on_llm_end(response)
+        model_output = evaluator.evaluate_after_model.call_args.kwargs["model_output"]
+        assert len(model_output) == _BEFORE_MODEL_TEXT_CAP
+
+    def test_on_llm_end_skips_empty_generation_text(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """Generations with no extractable text don't bloat the output."""
+        response = LLMResult(
+            generations=[[Generation(text=""), Generation(text="kept")]]
+        )
+        handler.on_llm_end(response)
+        assert evaluator.evaluate_after_model.call_args.kwargs["model_output"] == "kept"
+
+    def test_on_llm_end_swallows_other_exceptions(
+        self,
+        handler: GovernanceCallbackHandler,
+        evaluator: MagicMock,
+    ) -> None:
+        evaluator.evaluate_after_model.side_effect = RuntimeError("nope")
+        with patch(LOGGER_PATH) as mock_logger:
+            handler.on_llm_end(LLMResult(generations=[]))
+        mock_logger.warning.assert_called_once()
+        assert "on_llm_end" in mock_logger.warning.call_args.args[0]
+
+    def test_on_llm_error_logs(
+        self,
+        handler: GovernanceCallbackHandler,
+    ) -> None:
+        with patch(LOGGER_PATH) as mock_logger:
+            handler.on_llm_error(RuntimeError("boom"))
+        mock_logger.warning.assert_called_once()
+        assert "LLM error" in mock_logger.warning.call_args.args[0]
+
+
+class TestExtractGenerationText:
+    def test_returns_text_for_plain_generation(self) -> None:
+        gen = Generation(text="hello")
+        assert GovernanceCallbackHandler._extract_generation_text(gen) == "hello"
+
+    def test_chat_generation_string_content(self) -> None:
+        gen = ChatGeneration(message=AIMessage(content="rich"))
+        assert GovernanceCallbackHandler._extract_generation_text(gen) == "rich"
+
+    def test_returns_empty_when_generation_text_empty(self) -> None:
+        assert (
+            GovernanceCallbackHandler._extract_generation_text(Generation(text=""))
+            == ""
+        )
+
+    def test_extracts_from_block_list_content(self) -> None:
+        gen = ChatGeneration(
+            message=AIMessage(
+                content=[
+                    {"type": "text", "text": "alpha"},
+                    {"type": "tool_use", "input": {"q": "beta"}},
+                ]
+            )
+        )
+        out = GovernanceCallbackHandler._extract_generation_text(gen)
+        assert "alpha" in out
+        assert "beta" in out
+
+    def test_block_list_skips_non_dict_entries(self) -> None:
+        gen = ChatGeneration(
+            message=AIMessage(
+                content=["string-entry", {"type": "text", "text": "kept"}]
+            )
+        )
+        assert GovernanceCallbackHandler._extract_generation_text(gen) == "kept"
+
+    def test_chat_generation_with_empty_block_list_falls_back_to_text(self) -> None:
+        """When all blocks yield no text, fall back to ``gen.text``."""
+        gen = ChatGeneration(message=AIMessage(content=[]))
+        assert GovernanceCallbackHandler._extract_generation_text(gen) == ""
+
+
+class TestExtractBlockText:
+    def test_plain_text_block(self) -> None:
+        assert (
+            GovernanceCallbackHandler._extract_block_text(
+                {"type": "text", "text": "hello"}
+            )
+            == "hello"
+        )
+
+    def test_function_call_arguments_block(self) -> None:
+        assert (
+            GovernanceCallbackHandler._extract_block_text(
+                {"type": "function_call", "arguments": '{"a":1}'}
+            )
+            == '{"a":1}'
+        )
+
+    def test_thinking_block(self) -> None:
+        assert (
+            GovernanceCallbackHandler._extract_block_text(
+                {"type": "thinking", "thinking": "step by step"}
+            )
+            == "step by step"
+        )
+
+    def test_tool_use_input_extracts_string_values(self) -> None:
+        result = GovernanceCallbackHandler._extract_block_text(
+            {"type": "tool_use", "input": {"query": "search", "id": "ignored"}}
+        )
+        assert "search" in result
+        assert "ignored" in result  # both are strings; metadata filtering is by key
+
+    def test_input_ignores_non_string_values(self) -> None:
+        result = GovernanceCallbackHandler._extract_block_text(
+            {"input": {"a": 123, "b": ["nested"], "c": "kept"}}
+        )
+        assert result == "kept"
+
+    def test_metadata_only_block_returns_empty(self) -> None:
+        assert (
+            GovernanceCallbackHandler._extract_block_text(
+                {"type": "tool_use", "id": "abc", "name": "search", "status": "ok"}
+            )
+            == ""
+        )
+
+    def test_combined_fields_all_collected(self) -> None:
+        result = GovernanceCallbackHandler._extract_block_text(
+            {
+                "type": "tool_use",
+                "text": "T",
+                "arguments": "A",
+                "thinking": "Th",
+                "input": {"k": "I"},
+            }
+        )
+        for token in ("T", "A", "Th", "I"):
+            assert token in result
+
+    def test_empty_block(self) -> None:
+        assert GovernanceCallbackHandler._extract_block_text({}) == ""
+
+
+class TestCallbackHandlerTools:
+    def test_on_tool_start_with_inputs(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_tool_start({"name": "search"}, "fallback", inputs={"q": "v"})
+        kwargs = evaluator.evaluate_tool_call.call_args.kwargs
+        assert kwargs["tool_name"] == "search"
+        assert kwargs["tool_args"] == {"q": "v"}
+        assert kwargs["session_state"] is handler._session_state
+
+    def test_on_tool_start_without_inputs_uses_input_str(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_tool_start({"name": "calc"}, "1+2")
+        kwargs = evaluator.evaluate_tool_call.call_args.kwargs
+        assert kwargs["tool_args"] == {"input": "1+2"}
+
+    def test_on_tool_start_unknown_name_when_missing(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_tool_start({}, "x")
+        assert evaluator.evaluate_tool_call.call_args.kwargs["tool_name"] == "unknown"
+
+    def test_on_tool_start_increments_counter(
+        self, handler: GovernanceCallbackHandler
+    ) -> None:
+        handler.on_tool_start({}, "x")
+        handler.on_tool_start({}, "y")
+        assert handler._session_state["tool_calls"] == 2
+
+    def test_on_tool_start_propagates_block(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        evaluator.evaluate_tool_call.side_effect = GovernanceBlockException("no")
+        with pytest.raises(GovernanceBlockException):
+            handler.on_tool_start({}, "x")
+
+    def test_on_tool_start_swallows_other_exceptions(
+        self,
+        handler: GovernanceCallbackHandler,
+        evaluator: MagicMock,
+    ) -> None:
+        evaluator.evaluate_tool_call.side_effect = RuntimeError("nope")
+        with patch(LOGGER_PATH) as mock_logger:
+            handler.on_tool_start({}, "x")
+        mock_logger.warning.assert_called_once()
+        assert "on_tool_start" in mock_logger.warning.call_args.args[0]
+
+    def test_on_tool_end_with_output(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_tool_end({"answer": 42})
+        kwargs = evaluator.evaluate_after_tool.call_args.kwargs
+        assert "42" in kwargs["tool_result"]
+        assert kwargs["tool_name"] == "unknown"
+
+    def test_on_tool_end_uses_tool_name_from_run_id(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_tool_start({"name": "search"}, "q", run_id="run-1")
+        handler.on_tool_end("result", run_id="run-1")
+        assert evaluator.evaluate_after_tool.call_args.kwargs["tool_name"] == "search"
+        # The run_id mapping is cleaned up so a stale entry isn't reused.
+        assert "run-1" not in handler._tool_runs
+
+    def test_on_tool_end_unknown_when_run_id_not_recorded(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_tool_end("r", run_id="never-started")
+        assert evaluator.evaluate_after_tool.call_args.kwargs["tool_name"] == "unknown"
+
+    def test_on_tool_start_handles_none_serialized(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_tool_start(None, "x")  # type: ignore[arg-type]
+        assert evaluator.evaluate_tool_call.call_args.kwargs["tool_name"] == "unknown"
+
+    def test_on_tool_end_with_none_output(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        handler.on_tool_end(None)
+        assert evaluator.evaluate_after_tool.call_args.kwargs["tool_result"] == ""
+
+    def test_on_tool_end_propagates_block(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        evaluator.evaluate_after_tool.side_effect = GovernanceBlockException("x")
+        with pytest.raises(GovernanceBlockException):
+            handler.on_tool_end("out")
+
+    def test_on_tool_end_swallows_other_exceptions(
+        self,
+        handler: GovernanceCallbackHandler,
+        evaluator: MagicMock,
+    ) -> None:
+        evaluator.evaluate_after_tool.side_effect = RuntimeError("err")
+        with patch(LOGGER_PATH) as mock_logger:
+            handler.on_tool_end("out")
+        mock_logger.warning.assert_called_once()
+        assert "on_tool_end" in mock_logger.warning.call_args.args[0]
+
+    def test_on_tool_error_logs(
+        self,
+        handler: GovernanceCallbackHandler,
+    ) -> None:
+        with patch(LOGGER_PATH) as mock_logger:
+            handler.on_tool_error(RuntimeError("broke"))
+        mock_logger.warning.assert_called_once()
+        assert "Tool error" in mock_logger.warning.call_args.args[0]
+
+    def test_on_tool_error_pops_run_id_mapping(
+        self, handler: GovernanceCallbackHandler
+    ) -> None:
+        """``on_tool_error`` cleans up ``_tool_runs`` so failed tool calls
+        don't accumulate over the lifetime of a governed session.
+        """
+        handler.on_tool_start({"name": "search"}, "q", run_id="run-err")
+        assert handler._tool_runs.get("run-err") == "search"
+        handler.on_tool_error(RuntimeError("boom"), run_id="run-err")
+        assert "run-err" not in handler._tool_runs
+
+    def test_on_tool_error_without_run_id_does_not_crash(
+        self, handler: GovernanceCallbackHandler
+    ) -> None:
+        # No run_id kwargs — should still log and not raise.
+        handler.on_tool_error(RuntimeError("boom"))
+        assert handler._tool_runs == {}
+
+    def test_on_tool_start_block_pops_run_id_mapping(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """If BEFORE_TOOL evaluation BLOCKS, the recorded mapping is
+        dropped — the tool never runs and ``on_tool_end`` will not fire.
+        Leaving the entry would leak across blocked turns.
+        """
+        evaluator.evaluate_tool_call.side_effect = GovernanceBlockException("nope")
+        with pytest.raises(GovernanceBlockException):
+            handler.on_tool_start({"name": "search"}, "q", run_id="run-blocked")
+        assert "run-blocked" not in handler._tool_runs
+
+    def test_on_tool_start_swallowed_error_preserves_mapping(
+        self, handler: GovernanceCallbackHandler, evaluator: MagicMock
+    ) -> None:
+        """When the evaluator raises a non-block exception, we swallow
+        and the tool still runs — the mapping must survive so
+        ``on_tool_end`` can resolve the tool name.
+        """
+        evaluator.evaluate_tool_call.side_effect = RuntimeError("flaky")
+        with patch(LOGGER_PATH):
+            handler.on_tool_start({"name": "search"}, "q", run_id="run-flaky")
+        assert handler._tool_runs.get("run-flaky") == "search"
+
+
+class TestCallbackHandlerInit:
+    def test_session_state_initialized(self, evaluator: MagicMock) -> None:
+        h = GovernanceCallbackHandler(
+            evaluator=evaluator, agent_name="a", session_id="s"
+        )
+        assert h._session_state == {"tool_calls": 0, "llm_calls": 0}
+        assert h._agent_name == "a"
+        assert h._session_id == "s"

--- a/tests/runtime/test_factory_governance.py
+++ b/tests/runtime/test_factory_governance.py
@@ -1,0 +1,134 @@
+"""Factory-level governance wiring: evaluator -> callbacks plumbing."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any, TypedDict
+from unittest.mock import MagicMock
+
+import pytest
+from langgraph.graph import END, START, StateGraph
+from uipath.core.adapters import EvaluatorProtocol
+from uipath.runtime import UiPathRuntimeContext
+
+from uipath_langchain.governance import GovernanceCallbackHandler
+from uipath_langchain.runtime.factory import UiPathLangGraphRuntimeFactory
+
+
+class _State(TypedDict):
+    v: int
+
+
+def _build_graph() -> StateGraph[Any, Any, Any]:
+    g = StateGraph(_State)
+    g.add_node("noop", lambda s: s)
+    g.add_edge(START, "noop")
+    g.add_edge("noop", END)
+    return g
+
+
+@pytest.fixture
+def context() -> UiPathRuntimeContext:
+    tmpdir = tempfile.mkdtemp()
+    ctx = UiPathRuntimeContext(
+        runtime_dir=tmpdir,
+        state_file=os.path.join(tmpdir, "state.db"),
+    )
+    return ctx
+
+
+@pytest.fixture
+def factory(context: UiPathRuntimeContext) -> UiPathLangGraphRuntimeFactory:
+    return UiPathLangGraphRuntimeFactory(context)
+
+
+class TestEvaluatorWiring:
+    """Passing ``evaluator`` to ``new_runtime`` should attach a
+    :class:`GovernanceCallbackHandler` to the underlying LangGraph
+    runtime's callback list. This is the entire surface change — the
+    previous adapter / register-on-import path is gone.
+    """
+
+    async def test_no_evaluator_means_no_callbacks(
+        self, factory: UiPathLangGraphRuntimeFactory
+    ) -> None:
+        compiled = _build_graph().compile()
+        await factory._get_memory()
+        runtime = await factory._create_runtime_instance(
+            compiled_graph=compiled,
+            runtime_id="rt-1",
+            entrypoint="ep",
+        )
+        # The resumable runtime wraps the langgraph runtime as ``delegate``.
+        assert runtime.delegate.callbacks == []  # type: ignore[attr-defined]
+        await factory.dispose()
+
+    async def test_evaluator_attaches_governance_handler(
+        self, factory: UiPathLangGraphRuntimeFactory
+    ) -> None:
+        evaluator: EvaluatorProtocol = MagicMock(spec=EvaluatorProtocol)
+        compiled = _build_graph().compile()
+        await factory._get_memory()  # ensure memory is initialized
+        runtime = await factory._create_runtime_instance(
+            compiled_graph=compiled,
+            runtime_id="rt-1",
+            entrypoint="ep",
+            evaluator=evaluator,
+        )
+        callbacks = runtime.delegate.callbacks  # type: ignore[attr-defined]
+        assert len(callbacks) == 1
+        handler = callbacks[0]
+        assert isinstance(handler, GovernanceCallbackHandler)
+        # Identity / session_id / agent_name come from the factory args.
+        assert handler._evaluator is evaluator
+        assert handler._agent_name == "ep"
+        assert handler._session_id == "rt-1"
+        await factory.dispose()
+
+    async def test_handler_built_per_runtime_instance(
+        self, factory: UiPathLangGraphRuntimeFactory
+    ) -> None:
+        """Two factory calls with the same evaluator yield two distinct
+        handler instances — each runtime gets its own session_state, so
+        concurrent sessions don't share counters."""
+        evaluator: EvaluatorProtocol = MagicMock(spec=EvaluatorProtocol)
+        compiled = _build_graph().compile()
+        await factory._get_memory()
+        first = await factory._create_runtime_instance(
+            compiled_graph=compiled,
+            runtime_id="rt-a",
+            entrypoint="ep",
+            evaluator=evaluator,
+        )
+        second = await factory._create_runtime_instance(
+            compiled_graph=compiled,
+            runtime_id="rt-b",
+            entrypoint="ep",
+            evaluator=evaluator,
+        )
+        h1 = first.delegate.callbacks[0]  # type: ignore[attr-defined]
+        h2 = second.delegate.callbacks[0]  # type: ignore[attr-defined]
+        assert h1 is not h2
+        assert h1._session_id == "rt-a"
+        assert h2._session_id == "rt-b"
+        assert h1._session_state is not h2._session_state
+        await factory.dispose()
+
+
+class TestGovernanceMetadataLabels:
+    """The factory advertises the governance metadata taxonomy wire labels
+    via ``get_settings()``. Hosts forward ``agent_type`` / ``agent_framework``
+    verbatim onto governance audit telemetry, so these must match the
+    canonical taxonomy: ``uipath_coded`` for this coded-agent surface and
+    ``langchain`` for the adapter framework (``langgraph`` is the project
+    marker/runtime flavor, not the framework label).
+    """
+
+    async def test_get_settings_advertises_taxonomy_labels(
+        self, factory: UiPathLangGraphRuntimeFactory
+    ) -> None:
+        settings = await factory.get_settings()
+        assert settings is not None
+        assert settings.agent_type == "uipath_coded"
+        assert settings.agent_framework == "langchain"

--- a/uv.lock
+++ b/uv.lock
@@ -4477,7 +4477,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.22"
+version = "0.13.23"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4555,7 +4555,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "uipath", specifier = ">=2.12.7,<2.13.0" },
-    { name = "uipath-core", specifier = ">=0.5.20,<0.6.0" },
+    { name = "uipath-core", specifier = ">=0.5.28,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.16.1,<1.17.0" },
@@ -4564,7 +4564,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-platform", specifier = ">=0.1.91,<0.2.0" },
-    { name = "uipath-runtime", specifier = ">=0.11.4,<0.12.0" },
+    { name = "uipath-runtime", specifier = ">=0.11.7,<0.12.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
 


### PR DESCRIPTION
**Dependent on : https://github.com/UiPath/uipath-python/pull/1761 for uipath-core package**

## Summary

Adds a LangChain / LangGraph governance adapter to `uipath-langchain`. It lets UiPath governance evaluate what a LangChain chain or LangGraph agent does at the model and tool level, and block disallowed actions, without the agent author writing governance code. This package contains only the LangChain-specific bridge.

## What it does

- Detects LangChain `Runnable` and LangGraph `CompiledStateGraph` objects and wraps them with a governance proxy.
- Hooks the model and tool lifecycle via LangChain's callback system and maps each event to a governance check:
  | LangChain event | Governance hook |
  |---|---|
  | `on_llm_start` / `on_chat_model_start` | `BEFORE_MODEL` |
  | `on_llm_end` | `AFTER_MODEL` |
  | `on_tool_start` | `TOOL_CALL` |
  | `on_tool_end` | `AFTER_TOOL` |
- Enforces by letting a `GovernanceBlockException` (raised on a DENY decision) propagate to stop the model call or tool. Any other error in the hook is logged and swallowed, so a governance failure cannot break an otherwise-healthy run.

## What it does not do

- Does not fire agent-level boundaries (`BEFORE_AGENT` / `AFTER_AGENT`); those are owned by the governance host.
- Does not depend on platform, auth, transport, or runtime internals — only on the shared governance contracts.
<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.13.23.dev1008995166",

  # Any version from PR
  "uipath-langchain>=0.13.23.dev1008990000,<0.13.23.dev1009000000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath-langchain>=0.13.23.dev1008990000,<0.13.23.dev1009000000",
]
```
<!-- DEV_PACKAGE_END -->
