### PR TITLE
fix: detect job attachments independent of dynamic model build order

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.19"
+version = "0.11.20"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/json_utils.py
+++ b/src/uipath_langchain/agent/react/json_utils.py
@@ -160,16 +160,18 @@ def _create_type_matcher(type_name: str, target_type: Any) -> Any:
     """
 
     def matches_type(annotation: Any) -> bool:
-        """Check if an annotation matches the target type name."""
+        """Whether ``annotation`` refers to ``type_name``, by name or identity."""
         if isinstance(annotation, ForwardRef):
             return annotation.__forward_arg__ == type_name
         if isinstance(annotation, str):
             return annotation == type_name
-        if hasattr(annotation, "__name__") and annotation.__name__ == type_name:
-            return True
-        if target_type is not None and annotation is target_type:
-            return True
-        return False
+        # prefer the per-class marker: identity/target_type break when several
+        # dynamic models are built (they share the same module).
+        return (
+            getattr(annotation, "__uipath_marker_name__", None) == type_name
+            or getattr(annotation, "__name__", None) == type_name
+            or (target_type is not None and annotation is target_type)
+        )
 
     return matches_type
 

--- a/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
+++ b/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 from types import ModuleType
-from typing import Any, Type
+from typing import Any, Type, cast
 
 from jsonschema_pydantic_converter import transform_with_modules
 from pydantic import BaseModel, PydanticUndefinedAnnotation
@@ -53,6 +53,8 @@ def create_model(
         setattr(pseudo_module, type_name, type_def)
         if inspect.isclass(type_def) and issubclass(type_def, BaseModel):
             type_def.__module__ = _DYNAMIC_MODULE_NAME
+            # per-class marker; survives the shared module being overwritten.
+            cast(Any, type_def).__uipath_marker_name__ = type_name
 
     setattr(pseudo_module, model.__name__, model)
     model.__module__ = _DYNAMIC_MODULE_NAME

--- a/tests/agent/react/test_json_utils.py
+++ b/tests/agent/react/test_json_utils.py
@@ -2,6 +2,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, RootModel
 
+from uipath_langchain.agent.react.job_attachments import get_job_attachments
 from uipath_langchain.agent.react.json_utils import (
     coerce_json_strings,
     extract_values_by_paths,
@@ -477,3 +478,57 @@ class TestCoerceJsonStringsWithSchema:
         )
         assert result["child"]["value"] == '{"x": 1}'
         assert result["child"]["data"] == {"y": 2}
+
+
+class TestBuildOrderIndependence:
+    """Detection must not depend on which dynamic model was built last."""
+
+    _SCHEMA = {
+        "type": "object",
+        "properties": {"doc": {"$ref": "#/$defs/Job_attachment"}},
+        "$defs": {
+            "Job_attachment": {
+                "type": "object",
+                "properties": {
+                    "ID": {"type": "string"},
+                    "FullName": {"type": "string"},
+                    "MimeType": {"type": "string"},
+                },
+            }
+        },
+    }
+
+    _ATTACHMENT_ID = "123e4567-e89b-12d3-a456-426614174000"
+
+    def _data(self) -> dict[str, Any]:
+        return {
+            "doc": {
+                "ID": self._ATTACHMENT_ID,
+                "FullName": "file.pdf",
+                "MimeType": "application/pdf",
+            }
+        }
+
+    def test_first_model_still_detected_after_second_build(self) -> None:
+        """Building a second attachment model must not blank out the first."""
+        first = create_model(self._SCHEMA)
+        assert get_json_paths_by_type(first, "__Job_attachment") == ["$.doc"]
+
+        # The second build overwrites the shared module's marker; the first
+        # model's per-class marker keeps its detection working.
+        create_model(self._SCHEMA)
+        assert get_json_paths_by_type(first, "__Job_attachment") == ["$.doc"]
+
+    def test_get_job_attachments_after_second_build(self) -> None:
+        """User-facing attachment extraction must survive a later dynamic build."""
+        first = create_model(self._SCHEMA)
+
+        attachments = get_job_attachments(first, self._data())
+        assert [str(att.id) for att in attachments] == [self._ATTACHMENT_ID]
+
+        # Building a second model with the same JobAttachment definition must
+        # not blank out extraction on the first model.
+        create_model(self._SCHEMA)
+
+        attachments = get_job_attachments(first, self._data())
+        assert [str(att.id) for att in attachments] == [self._ATTACHMENT_ID]

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.19"
+version = "0.11.20"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- job attachment fields are now detected reliably even when several dynamic schemas (e.g. an agent's input and output, or a tool's args) are built in the same process

## Why

attachment detection compared field types by object identity against a single process-wide module attribute. each schema build registered its own attachment class under that attribute, so the most recent build won and detection on every other schema silently returned nothing.