### PR TITLE
feat(guardrails): allow llm_as_judge validator in pre and post stages

### DIFF
--- a/src/uipath_langchain/agent/react/guardrails/guardrails_subgraph.py
+++ b/src/uipath_langchain/agent/react/guardrails/guardrails_subgraph.py
@@ -91,8 +91,7 @@ def _create_guardrails_subgraph(
     """
     inner_name, inner_node = main_inner_node
 
-    CompleteAgentGuardrailsGraphState = create_guardrails_state_with_input(input_schema)
-    subgraph = StateGraph(CompleteAgentGuardrailsGraphState)
+    subgraph = StateGraph(create_guardrails_state_with_input(input_schema))
 
     subgraph.add_node(inner_name, inner_node)
 
@@ -356,8 +355,7 @@ def create_agent_init_guardrails_subgraph(
         return init_node[1]
 
     inner_name, inner_node = init_node
-    CompleteAgentGuardrailsGraphState = create_guardrails_state_with_input(input_schema)
-    subgraph = StateGraph(CompleteAgentGuardrailsGraphState)
+    subgraph = StateGraph(create_guardrails_state_with_input(input_schema))
     subgraph.add_node(inner_name, inner_node)
     subgraph.add_edge(START, inner_name)
 

--- a/src/uipath_langchain/agent/react/guardrails/guardrails_subgraph.py
+++ b/src/uipath_langchain/agent/react/guardrails/guardrails_subgraph.py
@@ -36,6 +36,7 @@ _VALIDATOR_ALLOWED_STAGES = {
     "harmful_content": {ExecutionStage.PRE_EXECUTION, ExecutionStage.POST_EXECUTION},
     "intellectual_property": {ExecutionStage.POST_EXECUTION},
     "user_prompt_attacks": {ExecutionStage.PRE_EXECUTION},
+    "llm_as_judge": {ExecutionStage.PRE_EXECUTION, ExecutionStage.POST_EXECUTION},
 }
 
 

--- a/tests/agent/guardrails/test_guardrail_stage_filtering.py
+++ b/tests/agent/guardrails/test_guardrail_stage_filtering.py
@@ -57,3 +57,24 @@ class TestGuardrailStageFiltering:
         assert post_filtered[0][0] == generic_guardrail
         # Other builtin should be there
         assert post_filtered[1][0] == other_builtin
+
+    def test_filter_by_stage_llm_as_judge(self):
+        """llm_as_judge guardrails should run in both PRE and POST execution."""
+        judge_guardrail = MagicMock(spec=BuiltInValidatorGuardrail)
+        judge_guardrail.validator_type = "llm_as_judge"
+        judge_guardrail.name = "LLM-as-Judge"
+
+        action = MagicMock(spec=GuardrailAction)
+        guardrails = [(judge_guardrail, action)]
+
+        pre_filtered = uipath_langchain.agent.react.guardrails.guardrails_subgraph._filter_guardrails_by_stage(
+            guardrails, ExecutionStage.PRE_EXECUTION
+        )
+        assert len(pre_filtered) == 1
+        assert pre_filtered[0][0] == judge_guardrail
+
+        post_filtered = uipath_langchain.agent.react.guardrails.guardrails_subgraph._filter_guardrails_by_stage(
+            guardrails, ExecutionStage.POST_EXECUTION
+        )
+        assert len(post_filtered) == 1
+        assert post_filtered[0][0] == judge_guardrail


### PR DESCRIPTION
## Summary
- Register the new \`llm_as_judge\` builtin guardrail validator in \`_VALIDATOR_ALLOWED_STAGES\` with both PRE_EXECUTION and POST_EXECUTION stages, so it is not filtered out by \`_filter_guardrails_by_stage\` in the ReAct guardrails subgraph.

## Test plan
- [ ] Configure an agent with an \`llm_as_judge\` builtin validator at LLM/AGENT/TOOL scope and verify it runs in both pre- and post-execution stages.
- [ ] \`uv run pytest tests/agent/guardrails\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)