### PR TITLE
fix: pass escalation review data via state instead of metadata mutations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.17"
+version = "0.11.18"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/guardrails/actions/escalate_action.py
+++ b/src/uipath_langchain/agent/guardrails/actions/escalate_action.py
@@ -261,34 +261,39 @@ class EscalateAction(GuardrailAction):
                 )
             )
 
-            # Store reviewed inputs/outputs in metadata for observability
+            # Build review data for observability (passed via state, not metadata,
+            # because metadata dicts get shallow-copied by the LangGraph config
+            # pipeline and mutations from the node body are not visible to callbacks).
+            review_data: Dict[str, Any] = {}
             if escalation_result.data:
                 reviewed_inputs = escalation_result.data.get("ReviewedInputs")
                 reviewed_outputs = escalation_result.data.get("ReviewedOutputs")
                 reason = escalation_result.data.get("Reason")
                 if reviewed_inputs:
-                    metadata["escalation_data"]["reviewed_inputs"] = (
-                        _parse_reviewed_data(reviewed_inputs)
+                    review_data["reviewed_inputs"] = _parse_reviewed_data(
+                        reviewed_inputs
                     )
                 if reviewed_outputs:
-                    metadata["escalation_data"]["reviewed_outputs"] = (
-                        _parse_reviewed_data(reviewed_outputs)
+                    review_data["reviewed_outputs"] = _parse_reviewed_data(
+                        reviewed_outputs
                     )
                 if reason:
-                    metadata["escalation_data"]["reason"] = reason
+                    review_data["reason"] = reason
 
-            # Store reviewed_by from completed_by_user
             completed_by_user = getattr(escalation_result, "completed_by_user", None)
             if completed_by_user:
                 reviewed_by = completed_by_user.get(
                     "displayName"
                 ) or completed_by_user.get("emailAddress")
                 if reviewed_by:
-                    metadata["escalation_data"]["reviewed_by"] = reviewed_by
+                    review_data["reviewed_by"] = reviewed_by
 
-            # Clear the stored task data
+            # Clear the stored task data and publish review data for observability
             cleanup_update: Dict[str, Any] = {
-                "inner_state": {"hitl_task_info": {create_task_node_name: None}},
+                "inner_state": {
+                    "hitl_task_info": {create_task_node_name: None},
+                    "escalation_review_data": review_data if review_data else None,
+                },
             }
 
             if escalation_result.action == "Approve":
@@ -308,12 +313,14 @@ class EscalateAction(GuardrailAction):
                     result = cleanup_update
                 return result
 
-            raise AgentRuntimeError(
+            err = AgentRuntimeError(
                 code=AgentRuntimeErrorCode.TERMINATION_ESCALATION_REJECTED,
                 title="Escalation rejected",
                 detail=f"Action was rejected after reviewing the task created by guardrail [{guardrail.name}], with reason: {escalation_result.data.get('Reason', None)}",
                 category=UiPathErrorCategory.USER,
             )
+            err.escalation_review_data = review_data  # type: ignore[attr-defined]
+            raise err
 
         _interrupt_node.__metadata__ = metadata  # type: ignore[attr-defined]
 

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -29,6 +29,7 @@ class InnerAgentGuardrailsGraphState(InnerAgentGraphState):
     guardrail_validation_details: Optional[str] = None
     agent_result: Optional[dict[str, Any]] = None
     hitl_task_info: Optional[Any] = {}
+    escalation_review_data: Optional[dict[str, Any]] = None
 
 
 class AgentGraphState(BaseModel):

--- a/tests/agent/guardrails/actions/test_escalate_action.py
+++ b/tests/agent/guardrails/actions/test_escalate_action.py
@@ -1447,10 +1447,8 @@ class TestEscalateAction:
 
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.interrupt")
-    async def test_interrupt_node_stores_reviewed_data_in_metadata(
-        self, mock_interrupt
-    ):
-        """Interrupt node stores reviewed inputs/outputs/reason in metadata."""
+    async def test_interrupt_node_stores_reviewed_data_in_state(self, mock_interrupt):
+        """Interrupt node publishes reviewed inputs/outputs/reason via inner_state."""
         action = _make_default_action()
         guardrail = _make_default_guardrail()
 
@@ -1476,14 +1474,16 @@ class TestEscalateAction:
             create_task_name=create_task_name,
         )
 
-        await interrupt_fn(state)
+        result = await interrupt_fn(state)
 
-        metadata = getattr(interrupt_fn, "__metadata__", None)
-        assert metadata is not None
-        assert metadata["escalation_data"]["reviewed_inputs"] == {"updated": "input"}
-        assert metadata["escalation_data"]["reviewed_outputs"] == {"updated": "output"}
-        assert metadata["escalation_data"]["reason"] == "Looks good"
-        assert metadata["escalation_data"]["reviewed_by"] == "Jane Doe"
+        # Review data is published via inner_state.escalation_review_data
+        update = result.update if isinstance(result, Command) else result
+        assert update is not None
+        review_data = update["inner_state"]["escalation_review_data"]
+        assert review_data["reviewed_inputs"] == {"updated": "input"}
+        assert review_data["reviewed_outputs"] == {"updated": "output"}
+        assert review_data["reason"] == "Looks good"
+        assert review_data["reviewed_by"] == "Jane Doe"
 
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.interrupt")
@@ -1509,11 +1509,12 @@ class TestEscalateAction:
             create_task_name=create_task_name,
         )
 
-        await interrupt_fn(state)
+        result = await interrupt_fn(state)
 
-        metadata = getattr(interrupt_fn, "__metadata__", None)
-        assert metadata is not None
-        assert metadata["escalation_data"]["reviewed_by"] == "jane@example.com"
+        update = result.update if isinstance(result, Command) else result
+        assert update is not None
+        review_data = update["inner_state"]["escalation_review_data"]
+        assert review_data["reviewed_by"] == "jane@example.com"
 
     # ── Content extraction (pure function tests – no change needed) ───────
 

--- a/tests/cli/test_agent_with_guardrails.py
+++ b/tests/cli/test_agent_with_guardrails.py
@@ -1103,6 +1103,7 @@ graph = create_agent(
                         # Return approved escalation result as an object with attributes
                         mock_result = MagicMock()
                         mock_result.action = "Approve"
+                        mock_result.completed_by_user = None
                         mock_result.data = {
                             "ReviewedMessages": json.dumps(
                                 [

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.17"
+version = "0.11.18"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- Escalation review data (`reviewed_inputs`, `reviewed_outputs`, `reviewed_by`, `reason`) was being passed to the observability callback via metadata dict mutations inside the interrupt node body. This never worked because LangGraph's config pipeline copies metadata dicts, so the callback received a different object.
- Fix: publish review data through `inner_state.escalation_review_data` (same pattern as `hitl_task_info`)
  - **Approve path**: included in the node's return value → visible in `on_chain_end` outputs
  - **Reject path**: attached to the error object → visible in `on_chain_error`
- Added `escalation_review_data` field to `InnerAgentGuardrailsGraphState`

## Test plan
- [ ] Run existing guardrail escalation tests
- [ ] E2E: trigger HITL escalation → approve with modified inputs → verify `reviewedInputs` and `reviewedBy` appear on the Review task span
- [ ] E2E: trigger HITL escalation → reject → verify `reviewedBy` appears on the Review task span

🤖 Generated with [Claude Code](https://claude.com/claude-code)