### PR TITLE
fix: enrich attachment name and mimetype for start tool call event [JAR-9834]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.12.1"
+version = "0.12.2"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.18"
+version = "0.11.19"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -70,8 +70,36 @@ class UiPathChatMessagesMapper:
         self.tools_requiring_confirmation: dict[str, Any] = {}
         self.client_side_tools: dict[str, ClientSideToolInfo] = {}
         self.seen_message_ids: set[str] = set()
+        self._attachment_metadata: dict[str, dict[str, str]] = {}
         self._storage_lock = asyncio.Lock()
         self._citation_stream_processor = CitationStreamProcessor()
+
+    def _enrich_tool_call_input(self, args: Any) -> Any:
+        """Enrich attachment objects in tool call args with stored metadata.
+
+        Walks one level into the args dict, looking for values that are either
+        a single attachment dict ({"ID": "..."}) or a list of them, and merges
+        in FullName / MimeType so the conversation event carries the same
+        enriched data the C# Agents backend provided.
+        """
+        if not self._attachment_metadata or not isinstance(args, dict):
+            return args
+        result = dict(args)
+        for key, value in result.items():
+            if isinstance(value, dict) and "ID" in value:
+                att_id = str(value["ID"])
+                if att_id in self._attachment_metadata:
+                    result[key] = {**value, **self._attachment_metadata[att_id]}
+            elif isinstance(value, list):
+                result[key] = [
+                    {**item, **self._attachment_metadata[str(item["ID"])]}
+                    if isinstance(item, dict)
+                    and "ID" in item
+                    and str(item["ID"]) in self._attachment_metadata
+                    else item
+                    for item in value
+                ]
+        return result
 
     @staticmethod
     def _extract_text(content: Any) -> str:
@@ -161,15 +189,21 @@ class UiPathChatMessagesMapper:
                         attachment_id = self.parse_attachment_id_from_content_part_uri(
                             data.uri
                         )
-                        full_name = uipath_content_part.name
-                        if attachment_id and full_name:
+                        if attachment_id:
+                            resolved_name = (
+                                uipath_content_part.name or "attachment"
+                            )
                             attachments.append(
                                 {
                                     "id": attachment_id,
-                                    "full_name": full_name,
+                                    "full_name": resolved_name,
                                     "mime_type": uipath_content_part.mime_type,
                                 }
                             )
+                            self._attachment_metadata[attachment_id] = {
+                                "FullName": resolved_name,
+                                "MimeType": uipath_content_part.mime_type,
+                            }
 
             # Add attachment references as a text block for LLM visibility
             if attachments:
@@ -599,7 +633,7 @@ class UiPathChatMessagesMapper:
                 start=UiPathConversationToolCallStartEvent(
                     tool_name=tool_call["name"],
                     timestamp=self.get_timestamp(),
-                    input=tool_call["args"],
+                    input=self._enrich_tool_call_input(tool_call["args"]),
                     require_confirmation=require_confirmation,
                     input_schema=input_schema,
                     is_client_side_tool=is_client_side_tool,

--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -87,15 +87,15 @@ class UiPathChatMessagesMapper:
         result = dict(args)
         for key, value in result.items():
             if isinstance(value, dict) and "ID" in value:
-                att_id = str(value["ID"])
+                att_id = str(value["ID"]).lower()
                 if att_id in self._attachment_metadata:
                     result[key] = {**value, **self._attachment_metadata[att_id]}
             elif isinstance(value, list):
                 result[key] = [
-                    {**item, **self._attachment_metadata[str(item["ID"])]}
+                    {**item, **self._attachment_metadata[str(item["ID"]).lower()]}
                     if isinstance(item, dict)
                     and "ID" in item
-                    and str(item["ID"]) in self._attachment_metadata
+                    and str(item["ID"]).lower() in self._attachment_metadata
                     else item
                     for item in value
                 ]
@@ -122,6 +122,8 @@ class UiPathChatMessagesMapper:
         """
         if not isinstance(messages, list):
             raise TypeError("messages must be a list")
+
+        self._attachment_metadata.clear()
 
         if not messages:
             return []

--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -192,9 +192,7 @@ class UiPathChatMessagesMapper:
                             data.uri
                         )
                         if attachment_id:
-                            resolved_name = (
-                                uipath_content_part.name or "attachment"
-                            )
+                            resolved_name = uipath_content_part.name or "attachment"
                             attachments.append(
                                 {
                                     "id": attachment_id,

--- a/tests/runtime/test_chat_message_mapper.py
+++ b/tests/runtime/test_chat_message_mapper.py
@@ -1133,13 +1133,17 @@ class TestMapMessages:
         )
         mapper.map_messages([uipath_msg])
 
-        enriched = mapper._enrich_tool_call_input({
-            "attachments": [{"ID": "a940a416-b97b-4146-3089-08de5f4d0a87"}],
-            "analysisTask": "summarize",
-        })
+        enriched = mapper._enrich_tool_call_input(
+            {
+                "attachments": [{"ID": "a940a416-b97b-4146-3089-08de5f4d0a87"}],
+                "analysisTask": "summarize",
+            }
+        )
 
         assert enriched["analysisTask"] == "summarize"
-        assert enriched["attachments"][0]["ID"] == "a940a416-b97b-4146-3089-08de5f4d0a87"
+        assert (
+            enriched["attachments"][0]["ID"] == "a940a416-b97b-4146-3089-08de5f4d0a87"
+        )
         assert enriched["attachments"][0]["FullName"] == "report.pdf"
         assert enriched["attachments"][0]["MimeType"] == "application/pdf"
 
@@ -1157,10 +1161,12 @@ class TestMapMessages:
             "MimeType": "text/plain",
         }
 
-        enriched = mapper._enrich_tool_call_input({
-            "file": {"ID": "abc-123"},
-            "task": "read",
-        })
+        enriched = mapper._enrich_tool_call_input(
+            {
+                "file": {"ID": "abc-123"},
+                "task": "read",
+            }
+        )
 
         assert enriched["file"]["FullName"] == "doc.txt"
         assert enriched["file"]["MimeType"] == "text/plain"
@@ -1191,10 +1197,12 @@ class TestMapMessages:
         )
         mapper.map_messages([uipath_msg])
 
-        enriched = mapper._enrich_tool_call_input({
-            "attachments": [{"ID": "a940a416-b97b-4146-3089-08de5f4d0a87"}],
-            "analysisTask": "summarize",
-        })
+        enriched = mapper._enrich_tool_call_input(
+            {
+                "attachments": [{"ID": "a940a416-b97b-4146-3089-08de5f4d0a87"}],
+                "analysisTask": "summarize",
+            }
+        )
 
         assert enriched["attachments"][0]["FullName"] == "attachment"
         assert enriched["attachments"][0]["MimeType"] == "application/pdf"

--- a/tests/runtime/test_chat_message_mapper.py
+++ b/tests/runtime/test_chat_message_mapper.py
@@ -1026,8 +1026,8 @@ class TestMapMessages:
         assert msg.content_blocks[0]["text"] == "Check this file"  # type: ignore[typeddict-item]
         assert "attachments" not in msg.additional_kwargs
 
-    def test_map_messages_external_value_without_name_skips_attachment(self):
-        """Should skip attachment when external value has no name."""
+    def test_map_messages_external_value_without_name_uses_fallback(self):
+        """Should use 'attachment' fallback name when external value has no name."""
         mapper = UiPathChatMessagesMapper("test-runtime", None)
         uipath_msg = UiPathConversationMessage(
             message_id="msg-1",
@@ -1055,9 +1055,15 @@ class TestMapMessages:
         assert len(result) == 1
         msg = result[0]
         assert isinstance(msg, HumanMessage)
-        # No content blocks at all (external value without name is skipped)
-        assert len(msg.content_blocks) == 0
-        assert "attachments" not in msg.additional_kwargs
+        assert len(msg.content_blocks) == 1
+        assert "<uip:attachments>" in msg.content_blocks[0]["text"]  # type: ignore[typeddict-item]
+        assert msg.additional_kwargs["attachments"] == [
+            {
+                "id": "a940a416-b97b-4146-3089-08de5f4d0a87",
+                "full_name": "attachment",
+                "mime_type": "application/pdf",
+            }
+        ]
 
     def test_map_messages_external_value_normalizes_uppercase_uuid(self):
         """Should normalize uppercase UUID in attachment URI to lowercase."""
@@ -1100,6 +1106,98 @@ class TestMapMessages:
                 "mime_type": "application/pdf",
             }
         ]
+
+    def test_enrich_tool_call_input_adds_attachment_metadata(self):
+        """startToolCall event should include FullName and MimeType from the user message."""
+        mapper = UiPathChatMessagesMapper("test-runtime", None)
+        uipath_msg = UiPathConversationMessage(
+            message_id="msg-1",
+            role="user",
+            created_at=TEST_TIMESTAMP,
+            updated_at=TEST_TIMESTAMP,
+            content_parts=[
+                UiPathConversationContentPart(
+                    content_part_id="part-file",
+                    mime_type="application/pdf",
+                    data=UiPathExternalValue(
+                        uri="urn:uipath:cas:file:orchestrator:a940a416-b97b-4146-3089-08de5f4d0a87"
+                    ),
+                    name="report.pdf",
+                    citations=[],
+                    created_at=TEST_TIMESTAMP,
+                    updated_at=TEST_TIMESTAMP,
+                ),
+            ],
+            tool_calls=[],
+            interrupts=[],
+        )
+        mapper.map_messages([uipath_msg])
+
+        enriched = mapper._enrich_tool_call_input({
+            "attachments": [{"ID": "a940a416-b97b-4146-3089-08de5f4d0a87"}],
+            "analysisTask": "summarize",
+        })
+
+        assert enriched["analysisTask"] == "summarize"
+        assert enriched["attachments"][0]["ID"] == "a940a416-b97b-4146-3089-08de5f4d0a87"
+        assert enriched["attachments"][0]["FullName"] == "report.pdf"
+        assert enriched["attachments"][0]["MimeType"] == "application/pdf"
+
+    def test_enrich_tool_call_input_no_op_without_attachments(self):
+        """Should return args unchanged when no attachment metadata is stored."""
+        mapper = UiPathChatMessagesMapper("test-runtime", None)
+        args = {"query": "hello", "attachments": [{"ID": "unknown-id"}]}
+        assert mapper._enrich_tool_call_input(args) == args
+
+    def test_enrich_tool_call_input_single_attachment(self):
+        """Should enrich a single attachment dict (not in a list)."""
+        mapper = UiPathChatMessagesMapper("test-runtime", None)
+        mapper._attachment_metadata["abc-123"] = {
+            "FullName": "doc.txt",
+            "MimeType": "text/plain",
+        }
+
+        enriched = mapper._enrich_tool_call_input({
+            "file": {"ID": "abc-123"},
+            "task": "read",
+        })
+
+        assert enriched["file"]["FullName"] == "doc.txt"
+        assert enriched["file"]["MimeType"] == "text/plain"
+        assert enriched["task"] == "read"
+
+    def test_enrich_tool_call_input_fallback_name(self):
+        """Should use 'attachment' fallback when content part has no name."""
+        mapper = UiPathChatMessagesMapper("test-runtime", None)
+        uipath_msg = UiPathConversationMessage(
+            message_id="msg-1",
+            role="user",
+            created_at=TEST_TIMESTAMP,
+            updated_at=TEST_TIMESTAMP,
+            content_parts=[
+                UiPathConversationContentPart(
+                    content_part_id="part-file",
+                    mime_type="application/pdf",
+                    data=UiPathExternalValue(
+                        uri="urn:uipath:cas:file:orchestrator:a940a416-b97b-4146-3089-08de5f4d0a87"
+                    ),
+                    citations=[],
+                    created_at=TEST_TIMESTAMP,
+                    updated_at=TEST_TIMESTAMP,
+                ),
+            ],
+            tool_calls=[],
+            interrupts=[],
+        )
+        mapper.map_messages([uipath_msg])
+
+        enriched = mapper._enrich_tool_call_input({
+            "attachments": [{"ID": "a940a416-b97b-4146-3089-08de5f4d0a87"}],
+            "analysisTask": "summarize",
+        })
+
+        assert enriched["attachments"][0]["FullName"] == "attachment"
+        assert enriched["attachments"][0]["MimeType"] == "application/pdf"
 
 
 class TestMapEvent:

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.18"
+version = "0.11.19"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
https://uipath.atlassian.net/browse/JAR-9834

Two changes:
The unified runtime's `startToolCall` event only included the attachment ID in tool call args, while the old C# backend included FullName and MimeType. This was a visible regression in the conversation UI. 
- Note: This didn't impact the LLM call since the LLM would populate these properties, but we should render it deterministically.
- In Temporal, the enrichment was done after the tool call is confirmed if applicable and before the tool call is executed.
- In URT: Changed a bit so we populate it after the LLM responds (similar to Autonomous agents) with the tool call e.g. {attachments: [{ID: "guid"}]} → startToolCall event is emitted

The fix stores attachment metadata (name, mime type) on the event mapper when user messages with file attachments are processed, then merges that metadata into tool call args when emitting the `startToolCall` event. If the SDK user didn't pass a file name on the content part, it falls back to `"attachment"` matching the old temporal behavior.
- SDK users could pass in attachments without the name property (because it is optional in the SDK docs). In temporal, `fetchRecentExchangesAsLegacyMessages` built the `attachment_object` with `FullName: cp.name || 'attachment'` — so even without a name, the attachment still got included in the message data sent to the C# Agents backend. The `ConversationalAttachmentEnricher` then found it and enriched the tool call args with `FullName: "attachment"`. https://github.com/UiPath/AgentInterfaces/blob/5e5e5443da8c7db8688347d4d6c84eaf74fb16e5/services/cloud-service/src/services/conversation_v1.service.ts#L3172

In URT(before this fix), the mapper had `if attachment_id and full_name:` — if `name` was missing, the attachment was skipped entirely. No metadata stored, no enrichment possible. The fix changes this to `if attachment_id:` with the same `"attachment"` fallback, so the enrichment pipeline works regardless of whether name was provided.

Before:

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/866df351-55c0-4515-956b-6322235cb7ec" />


After:

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/7e159cbf-a20c-4126-b63c-ce20d106bf21" />

