### PR TITLE
chore: update uipath version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.11.20"
+version = "0.12.0"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.10.79, <2.11.0",
+    "uipath>=2.10.79, <2.12.0",
     "uipath-core>=0.5.17, <0.6.0",
     "uipath-platform>=0.1.61, <0.2.0",
     "uipath-runtime>=0.11.0, <0.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.11.20"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4463,7 +4463,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.10.79,<2.11.0" },
+    { name = "uipath", specifier = ">=2.10.79,<2.12.0" },
     { name = "uipath-core", specifier = ">=0.5.17,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.14.0,<1.15.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.14.0,<1.15.0" },


### PR DESCRIPTION
* Bumped the package version from `0.11.20` to `0.12.0` in `pyproject.toml` to prepare for a new release.
* Expanded the supported `uipath` dependency range from `<2.11.0` to `<2.12.0` in `pyproject.toml`, allowing compatibility with future `uipath` versions up to but not including `2.12.0`.