### PR TITLE
feat: pass guardrail spanId through Command output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath-langchain"
-version = "0.12.2"
+version = "0.12.3"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
     "uipath>=2.10.79, <2.12.0",
-    "uipath-core>=0.5.17, <0.6.0",
-    "uipath-platform>=0.1.70, <0.2.0",
+    "uipath-core>=0.5.20, <0.6.0",
+    "uipath-platform>=0.1.71, <0.2.0",
     "uipath-runtime>=0.11.0, <0.12.0",
     "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.11, <2.0.0",

--- a/src/uipath_langchain/agent/guardrails/guardrail_nodes.py
+++ b/src/uipath_langchain/agent/guardrails/guardrail_nodes.py
@@ -105,26 +105,30 @@ def _create_validation_command(
     Raises:
         AgentRuntimeError: If the result is neither PASSED nor VALIDATION_FAILED.
     """
+    span_id = getattr(guardrail_result, "span_id", None)
+
     if guardrail_result.result == GuardrailValidationResultType.PASSED:
+        inner_state: dict[str, Any] = {
+            "guardrail_validation_result": True,
+            "guardrail_validation_details": guardrail_result.reason,
+        }
+        if span_id:
+            inner_state["guardrail_span_id"] = span_id
         return Command(
             goto=success_node,
-            update={
-                "inner_state": {
-                    "guardrail_validation_result": True,
-                    "guardrail_validation_details": guardrail_result.reason,
-                }
-            },
+            update={"inner_state": inner_state},
         )
 
     if guardrail_result.result == GuardrailValidationResultType.VALIDATION_FAILED:
+        inner_state = {
+            "guardrail_validation_result": False,
+            "guardrail_validation_details": guardrail_result.reason,
+        }
+        if span_id:
+            inner_state["guardrail_span_id"] = span_id
         return Command(
             goto=failure_node,
-            update={
-                "inner_state": {
-                    "guardrail_validation_result": False,
-                    "guardrail_validation_details": guardrail_result.reason,
-                }
-            },
+            update={"inner_state": inner_state},
         )
 
     # For other results (FEATURE_DISABLED, ENTITLEMENTS_MISSING, etc.), interrupt execution

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -27,6 +27,7 @@ class InnerAgentGuardrailsGraphState(InnerAgentGraphState):
 
     guardrail_validation_result: Optional[bool] = None
     guardrail_validation_details: Optional[str] = None
+    guardrail_span_id: Optional[str] = None
     agent_result: Optional[dict[str, Any]] = None
     hitl_task_info: Optional[Any] = {}
     escalation_review_data: Optional[dict[str, Any]] = None

--- a/tests/agent/guardrails/test_guardrail_nodes.py
+++ b/tests/agent/guardrails/test_guardrail_nodes.py
@@ -609,6 +609,65 @@ class TestGuardrailHelperFunctions:
             }
         }
 
+    def test_create_validation_command_success_with_span_id(self):
+        """Test validation command includes guardrail_span_id when span_id is present."""
+        from uipath_langchain.agent.guardrails.guardrail_nodes import (
+            _create_validation_command,
+        )
+
+        result = GuardrailValidationResult(
+            result=GuardrailValidationResultType.PASSED,
+            reason="validation passed",
+        )
+        result.span_id = "span-123"
+        command = _create_validation_command(result, "success_node", "failure_node")
+
+        assert command.goto == "success_node"
+        assert command.update == {
+            "inner_state": {
+                "guardrail_validation_result": True,
+                "guardrail_validation_details": "validation passed",
+                "guardrail_span_id": "span-123",
+            }
+        }
+
+    def test_create_validation_command_failure_with_span_id(self):
+        """Test validation command includes guardrail_span_id on failure when span_id is present."""
+        from uipath_langchain.agent.guardrails.guardrail_nodes import (
+            _create_validation_command,
+        )
+
+        result = GuardrailValidationResult(
+            result=GuardrailValidationResultType.VALIDATION_FAILED,
+            reason="policy_violation",
+        )
+        result.span_id = "span-456"
+        command = _create_validation_command(result, "success_node", "failure_node")
+
+        assert command.goto == "failure_node"
+        assert command.update == {
+            "inner_state": {
+                "guardrail_validation_result": False,
+                "guardrail_validation_details": "policy_violation",
+                "guardrail_span_id": "span-456",
+            }
+        }
+
+    def test_create_validation_command_without_span_id(self):
+        """Test validation command excludes guardrail_span_id when span_id is absent."""
+        from uipath_langchain.agent.guardrails.guardrail_nodes import (
+            _create_validation_command,
+        )
+
+        result = GuardrailValidationResult(
+            result=GuardrailValidationResultType.PASSED,
+            reason="validation passed",
+        )
+        command = _create_validation_command(result, "success_node", "failure_node")
+
+        assert command.goto == "success_node"
+        assert "guardrail_span_id" not in command.update["inner_state"]
+
     def test_create_validation_command_feature_disabled_raises_exception(self):
         """Test that FEATURE_DISABLED result raises AgentRuntimeError."""
         from uipath.runtime.errors import UiPathErrorCategory

--- a/tests/agent/guardrails/test_guardrail_nodes.py
+++ b/tests/agent/guardrails/test_guardrail_nodes.py
@@ -666,6 +666,7 @@ class TestGuardrailHelperFunctions:
         command = _create_validation_command(result, "success_node", "failure_node")
 
         assert command.goto == "success_node"
+        assert command.update is not None
         assert "guardrail_span_id" not in command.update["inner_state"]
 
     def test_create_validation_command_feature_disabled_raises_exception(self):

--- a/uv.lock
+++ b/uv.lock
@@ -4374,21 +4374,21 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.17"
+version = "0.5.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/80/a626eb3136a6765e0af06c9d5080ac0843c2a72f17b7a2170f1f45da40dd/uipath_core-0.5.17.tar.gz", hash = "sha256:13565e1eba9f059a8221494dfb3239257ddf7f265fc7057199ffe03ed066300a", size = 119023, upload-time = "2026-05-28T21:34:10.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/da/011ced5af57363caf7ca6d263261fc4b64f19bf7f7b2a5e54132906a36a6/uipath_core-0.5.20.tar.gz", hash = "sha256:2a2430185522869b10c05273128c23a81fbb8c53ee5dd8686c8b5089ea270fa7", size = 132363, upload-time = "2026-06-19T12:01:37.545Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/cf/f4b481970621e2a9aec869302773fa2c7d346aef294a553429626369633f/uipath_core-0.5.17-py3-none-any.whl", hash = "sha256:6e088eec5130bc492ac176ab85d4924d7d4cb07ee290ed7e6a46984e9de8c12b", size = 44957, upload-time = "2026-05-28T21:34:09.534Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/02/b518bb5569c9c35f4ed19a7f23c744c471352a1fa5233071dd75a4cc9324/uipath_core-0.5.20-py3-none-any.whl", hash = "sha256:2be116ec68d034348ea58fd541675863d73e96649f528648d533206b8c8853cc", size = 55005, upload-time = "2026-06-19T12:01:36.08Z" },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.12.2"
+version = "0.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4464,7 +4464,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "uipath", specifier = ">=2.10.79,<2.12.0" },
-    { name = "uipath-core", specifier = ">=0.5.17,<0.6.0" },
+    { name = "uipath-core", specifier = ">=0.5.20,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.14.0,<1.15.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.14.0,<1.15.0" },
     { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.14.0,<1.15.0" },
@@ -4472,7 +4472,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.14.0,<1.15.0" },
     { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.14.0,<1.15.0" },
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.14.0,<1.15.0" },
-    { name = "uipath-platform", specifier = ">=0.1.70,<0.2.0" },
+    { name = "uipath-platform", specifier = ">=0.1.71,<0.2.0" },
     { name = "uipath-runtime", specifier = ">=0.11.0,<0.12.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
@@ -4556,7 +4556,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.70"
+version = "0.1.71"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4566,9 +4566,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/1f/501807b656496d4f208af0b5d69ad379434e3ac56cee93e958d3ec4142a3/uipath_platform-0.1.70.tar.gz", hash = "sha256:2ad918aded5dcb65ed75510325c93f7f94eb15d1b3ee9ba0e357f85f55bddc7f", size = 376912, upload-time = "2026-06-17T10:09:08.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/98/72ed759c6938c2cb9df6994dab516ebdeb127201727591a2bcf3ce71df47/uipath_platform-0.1.71.tar.gz", hash = "sha256:c7b1ff062f894bcbaaff3a69457c47ef9d37712282917cb03b6c2ffda43394ed", size = 378313, upload-time = "2026-06-19T12:03:05.234Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/0d/33c21a2ddbb1f640320e4e115abd72b756b6465bdff64ab87185386803b3/uipath_platform-0.1.70-py3-none-any.whl", hash = "sha256:6ece293acb98df45f74a24b0ebd3689ee974eb324fdbbea3958a98ed2d20790f", size = 249849, upload-time = "2026-06-17T10:09:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7a/9ddf7027c7c73a5d94fa2649c4a20a207933b8d481236dc06ba5be662e1f/uipath_platform-0.1.71-py3-none-any.whl", hash = "sha256:8459c0f58255f7ebc1a401e53d62198d2b4845ada8231d9b37cfa71fcefa994f", size = 250513, upload-time = "2026-06-19T12:03:03.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Extract `span_id` from guardrail validation results and pass it through the `Command` output's `inner_state` as `guardrail_span_id`
- Bump `uipath-core` to >=0.5.20 and `uipath-platform` to >=0.1.71 to pick up span ID support
- Version bump to 0.12.3

## Test plan

- [ ] Verify guardrail input/output validation passes `span_id` when present in the result
- [ ] Verify `guardrail_span_id` is not included in `inner_state` when `span_id` is absent
- [ ] Confirm no regressions in existing guardrail flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)