### PR TITLE
fix: raise routing error for unwired router targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.0"
+version = "0.13.1"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/agent.py
+++ b/src/uipath_langchain/agent/react/agent.py
@@ -178,18 +178,21 @@ def create_agent(
     tool_node_names = list(tool_nodes_with_guardrails.keys())
 
     if config.is_conversational:
-        route_agent = create_route_agent_conversational()
-        target_node_names = [
+        target_node_names: list[str] = [
             *tool_node_names,
             AgentGraphNode.TERMINATE,
         ]
+        route_agent = create_route_agent_conversational(valid_targets=target_node_names)
     else:
-        route_agent = create_route_agent(config.thinking_messages_limit)
         target_node_names = [
             AgentGraphNode.AGENT,
             *tool_node_names,
             AgentGraphNode.TERMINATE,
         ]
+        route_agent = create_route_agent(
+            valid_targets=target_node_names,
+            thinking_messages_limit=config.thinking_messages_limit,
+        )
 
     builder.add_conditional_edges(
         AgentGraphNode.AGENT,

--- a/src/uipath_langchain/agent/react/router.py
+++ b/src/uipath_langchain/agent/react/router.py
@@ -15,15 +15,14 @@ from .utils import (
 
 
 def create_route_agent(
-    valid_targets: Container[str],
     thinking_messages_limit: int = 0,
+    valid_targets: Container[str] | None = None,
 ):
     """Create a routing function configured with thinking_messages_limit.
 
     Args:
-        valid_targets: Allowed routing destinations
         thinking_messages_limit: Max consecutive thinking messages before error
-
+        valid_targets: Allowed routing destinations
     Returns:
         Routing function for LangGraph conditional edges
     """
@@ -95,7 +94,7 @@ def create_route_agent(
         if current_tool_name in FLOW_CONTROL_TOOLS:
             return AgentGraphNode.TERMINATE
 
-        if current_tool_name not in valid_targets:
+        if valid_targets is not None and current_tool_name not in valid_targets:
             raise AgentRuntimeError(
                 code=AgentRuntimeErrorCode.ROUTING_ERROR,
                 title="Agent routed to an unknown destination",

--- a/src/uipath_langchain/agent/react/router.py
+++ b/src/uipath_langchain/agent/react/router.py
@@ -1,5 +1,6 @@
 """Routing functions for conditional edges in the agent graph."""
 
+from collections.abc import Container
 from typing import Literal
 
 from uipath.runtime.errors import UiPathErrorCategory
@@ -13,10 +14,14 @@ from .utils import (
 )
 
 
-def create_route_agent(thinking_messages_limit: int = 0):
+def create_route_agent(
+    valid_targets: Container[str],
+    thinking_messages_limit: int = 0,
+):
     """Create a routing function configured with thinking_messages_limit.
 
     Args:
+        valid_targets: Allowed routing destinations
         thinking_messages_limit: Max consecutive thinking messages before error
 
     Returns:
@@ -89,6 +94,17 @@ def create_route_agent(thinking_messages_limit: int = 0):
 
         if current_tool_name in FLOW_CONTROL_TOOLS:
             return AgentGraphNode.TERMINATE
+
+        if current_tool_name not in valid_targets:
+            raise AgentRuntimeError(
+                code=AgentRuntimeErrorCode.ROUTING_ERROR,
+                title="Agent routed to an unknown destination",
+                detail=(
+                    f"The agent attempted to route to '{current_tool_name}', "
+                    "which is not a registered tool or control node."
+                ),
+                category=UiPathErrorCategory.SYSTEM,
+            )
 
         return current_tool_name
 

--- a/src/uipath_langchain/agent/react/router_conversational.py
+++ b/src/uipath_langchain/agent/react/router_conversational.py
@@ -1,6 +1,7 @@
 """Routing functions for conditional edges in the agent graph."""
 
 import logging
+from collections.abc import Container
 from typing import Literal
 
 from uipath.runtime.errors import UiPathErrorCategory
@@ -20,10 +21,12 @@ from .types import AgentGraphNode
 logger = logging.getLogger(__name__)
 
 
-def create_route_agent_conversational():
+def create_route_agent_conversational(valid_targets: Container[str]):
     """Create a routing function for conversational agents. It routes between agent and tool calls until
     the agent response has no tool calls, then it routes to the USER_MESSAGE_WAIT node which does an interrupt.
 
+    Args:
+        valid_targets: Allowed routing destinations
     Returns:
         Routing function for LangGraph conditional edges
     """
@@ -60,6 +63,17 @@ def create_route_agent_conversational():
 
             current_tool_call = last_message.tool_calls[current_index]
             current_tool_name = current_tool_call["name"]
+
+            if current_tool_name not in valid_targets:
+                raise AgentRuntimeError(
+                    code=AgentRuntimeErrorCode.ROUTING_ERROR,
+                    title="Agent routed to an unknown destination",
+                    detail=(
+                        f"The agent attempted to route to '{current_tool_name}', "
+                        "which is not a registered tool or control node."
+                    ),
+                    category=UiPathErrorCategory.SYSTEM,
+                )
 
             return current_tool_name
         else:

--- a/src/uipath_langchain/agent/react/router_conversational.py
+++ b/src/uipath_langchain/agent/react/router_conversational.py
@@ -21,7 +21,7 @@ from .types import AgentGraphNode
 logger = logging.getLogger(__name__)
 
 
-def create_route_agent_conversational(valid_targets: Container[str]):
+def create_route_agent_conversational(valid_targets: Container[str] | None = None):
     """Create a routing function for conversational agents. It routes between agent and tool calls until
     the agent response has no tool calls, then it routes to the USER_MESSAGE_WAIT node which does an interrupt.
 
@@ -64,7 +64,7 @@ def create_route_agent_conversational(valid_targets: Container[str]):
             current_tool_call = last_message.tool_calls[current_index]
             current_tool_name = current_tool_call["name"]
 
-            if current_tool_name not in valid_targets:
+            if valid_targets is not None and current_tool_name not in valid_targets:
                 raise AgentRuntimeError(
                     code=AgentRuntimeErrorCode.ROUTING_ERROR,
                     title="Agent routed to an unknown destination",

--- a/tests/agent/react/test_router.py
+++ b/tests/agent/react/test_router.py
@@ -6,13 +6,14 @@ import pytest
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
 from pydantic import BaseModel
 from uipath.agent.react import END_EXECUTION_TOOL
+from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
     AgentRuntimeErrorCode,
 )
 from uipath_langchain.agent.react.router import create_route_agent
-from uipath_langchain.agent.react.types import AgentGraphNode
+from uipath_langchain.agent.react.types import AgentGraphNode, AgentGraphState
 
 
 class MockInnerState(BaseModel):
@@ -31,17 +32,27 @@ class MockAgentGraphState(BaseModel):
 
 # Module-level fixtures available to all test classes
 
+# Routing targets used across the test states (tools + control nodes).
+_VALID_TARGETS: list[str] = [
+    AgentGraphNode.AGENT,
+    AgentGraphNode.TERMINATE,
+    "search_tool",
+    "calculator_tool",
+    "weather_tool",
+    "test_tool",
+]
+
 
 @pytest.fixture
 def route_function_no_limit():
     """Fixture for routing function with no thinking messages limit."""
-    return create_route_agent(thinking_messages_limit=0)
+    return create_route_agent(valid_targets=_VALID_TARGETS, thinking_messages_limit=0)
 
 
 @pytest.fixture
 def route_function_with_limit():
     """Fixture for routing function with thinking messages limit of 2."""
-    return create_route_agent(thinking_messages_limit=2)
+    return create_route_agent(valid_targets=_VALID_TARGETS, thinking_messages_limit=2)
 
 
 @pytest.fixture
@@ -217,7 +228,9 @@ class TestRouteAgentThinkingMessages:
 
     def test_thinking_messages_limit_zero_forbids_thinking(self):
         """Should not allow any thinking messages when limit is 0."""
-        route_func = create_route_agent(thinking_messages_limit=0)
+        route_func = create_route_agent(
+            valid_targets=_VALID_TARGETS, thinking_messages_limit=0
+        )
         ai_message = AIMessage(content="thinking")
         state = MockAgentGraphState(
             messages=[HumanMessage(content="query"), ai_message]
@@ -232,7 +245,9 @@ class TestRouteAgentThinkingMessages:
 
     def test_thinking_messages_after_tool_execution_resets_count(self):
         """Should reset thinking count after tool execution."""
-        route_func = create_route_agent(thinking_messages_limit=1)
+        route_func = create_route_agent(
+            valid_targets=_VALID_TARGETS, thinking_messages_limit=1
+        )
         messages = [
             HumanMessage(content="query"),
             AIMessage(
@@ -286,3 +301,41 @@ class TestRouteAgentErrorHandling:
         assert exc_info.value.error_info.code == AgentRuntimeError.full_code(
             AgentRuntimeErrorCode.ROUTING_ERROR
         )
+
+
+class TestRouteAgentTargetValidation:
+    """Test guarding of router return values against valid graph targets."""
+
+    def test_unknown_target_raises_routing_error(self):
+        """Should raise ROUTING_ERROR (SYSTEM) when the routed tool is unwired."""
+        route_func = create_route_agent(
+            valid_targets=[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE, "real_tool"],
+            thinking_messages_limit=0,
+        )
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "context", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            route_func(state)
+
+        assert exc_info.value.error_info.code == AgentRuntimeError.full_code(
+            AgentRuntimeErrorCode.ROUTING_ERROR
+        )
+        assert exc_info.value.error_info.category == UiPathErrorCategory.SYSTEM
+
+    def test_known_target_returns_tool_name(self):
+        """Should return the tool name when it is in the valid target set."""
+        route_func = create_route_agent(
+            valid_targets=[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE, "real_tool"],
+            thinking_messages_limit=0,
+        )
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "real_tool", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        assert route_func(state) == "real_tool"

--- a/tests/agent/react/test_router.py
+++ b/tests/agent/react/test_router.py
@@ -339,3 +339,18 @@ class TestRouteAgentTargetValidation:
         state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
 
         assert route_func(state) == "real_tool"
+
+    def test_default_valid_targets_skips_guard(self):
+        """Should skip the destination guard when valid_targets is left unset.
+
+        Backwards-compatible contract: callers predating valid_targets must keep
+        the old unguarded behavior, returning any routed tool name as-is.
+        """
+        route_func = create_route_agent(thinking_messages_limit=0)
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "unwired_tool", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        assert route_func(state) == "unwired_tool"

--- a/tests/agent/react/test_router_conversational.py
+++ b/tests/agent/react/test_router_conversational.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from pydantic import BaseModel
+from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
@@ -13,7 +14,7 @@ from uipath_langchain.agent.exceptions import (
 from uipath_langchain.agent.react.router_conversational import (
     create_route_agent_conversational,
 )
-from uipath_langchain.agent.react.types import AgentGraphNode
+from uipath_langchain.agent.react.types import AgentGraphNode, AgentGraphState
 
 
 class MockInnerState(BaseModel):
@@ -30,13 +31,26 @@ class MockAgentGraphState(BaseModel):
     inner_state: MockInnerState = MockInnerState()
 
 
+# Routing targets used across the test states (tools + control nodes).
+_VALID_TARGETS: list[str] = [
+    AgentGraphNode.AGENT,
+    AgentGraphNode.TERMINATE,
+    "search_tool",
+    "calculator_tool",
+    "weather_tool",
+    "first_tool",
+    "second_tool",
+    "third_tool",
+]
+
+
 class TestCreateRouteAgentConversational:
     """Test cases for create_route_agent_conversational function."""
 
     @pytest.fixture
     def route_function(self):
         """Fixture for the conversational routing function."""
-        return create_route_agent_conversational()
+        return create_route_agent_conversational(valid_targets=_VALID_TARGETS)
 
     @pytest.fixture
     def state_with_single_tool_call(self):
@@ -220,13 +234,49 @@ class TestRouteAgentConversationalFactory:
 
     def test_returns_callable(self):
         """Should return a callable routing function."""
-        result = create_route_agent_conversational()
+        result = create_route_agent_conversational(valid_targets=_VALID_TARGETS)
 
         assert callable(result)
 
     def test_each_call_returns_new_function(self):
         """Should return a new function instance each time."""
-        func1 = create_route_agent_conversational()
-        func2 = create_route_agent_conversational()
+        func1 = create_route_agent_conversational(valid_targets=_VALID_TARGETS)
+        func2 = create_route_agent_conversational(valid_targets=_VALID_TARGETS)
 
         assert func1 is not func2
+
+
+class TestRouteAgentConversationalTargetValidation:
+    """Test guarding of router return values against valid graph targets."""
+
+    def test_unknown_target_raises_routing_error(self):
+        """Should raise ROUTING_ERROR (SYSTEM) when the routed tool is unwired."""
+        route_func = create_route_agent_conversational(
+            valid_targets=[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE, "real_tool"],
+        )
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "context", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            route_func(state)
+
+        assert exc_info.value.error_info.code == AgentRuntimeError.full_code(
+            AgentRuntimeErrorCode.ROUTING_ERROR
+        )
+        assert exc_info.value.error_info.category == UiPathErrorCategory.SYSTEM
+
+    def test_known_target_returns_tool_name(self):
+        """Should return the tool name when it is in the valid target set."""
+        route_func = create_route_agent_conversational(
+            valid_targets=[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE, "real_tool"],
+        )
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "real_tool", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        assert route_func(state) == "real_tool"

--- a/tests/agent/react/test_router_conversational.py
+++ b/tests/agent/react/test_router_conversational.py
@@ -280,3 +280,18 @@ class TestRouteAgentConversationalTargetValidation:
         state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
 
         assert route_func(state) == "real_tool"
+
+    def test_default_valid_targets_skips_guard(self):
+        """Should skip the destination guard when valid_targets is left unset.
+
+        Backwards-compatible contract: callers predating valid_targets must keep
+        the old unguarded behavior, returning any routed tool name as-is.
+        """
+        route_func = create_route_agent_conversational()
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "unwired_tool", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        assert route_func(state) == "unwired_tool"

--- a/uv.lock
+++ b/uv.lock
@@ -4404,7 +4404,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Guard route_agent / route_agent_conversational return values against the set of destinations wired into the conditional edge. A tool name outside that set previously escaped as a bare KeyError from LangGraph's _branch._finish (e.g. "KeyError: 'context'"), landing in the AGENT_RUNTIME.UNEXPECTED_ERROR catch-all. Now raises a structured ROUTING_ERROR (SYSTEM) at the call site.

The factories accept an optional valid_targets; agent.py passes the live target_node_names list so the guard stays in sync with add_conditional_edges, including the AGENT target appended for conversational graphs.