### PR TITLE
chore: replace deprecated gpt-4o-mini model in samples

### DIFF
--- a/samples/chat-uipath-agent/graph.py
+++ b/samples/chat-uipath-agent/graph.py
@@ -27,5 +27,5 @@ Always maintain an enthusiastic and knowledgeable tone about cinema. Provide acc
 DO NOT do any math calculations unless specifically related to movie statistics or box office figures.
 """
 
-llm = UiPathChatOpenAI(model="gpt-4o-mini-2024-07-18")
+llm = UiPathChatOpenAI(model="gpt-4.1-mini-2025-04-14")
 graph = create_agent(llm, tools=[search_tool], system_prompt=movie_system_prompt)

--- a/samples/email-triage-agent/graph.py
+++ b/samples/email-triage-agent/graph.py
@@ -92,7 +92,7 @@ class GraphState(BaseModel):
     triage_count: int = 0
 
 
-llm = UiPathChat(model="gpt-4o-mini-2024-07-18")
+llm = UiPathChat(model="gpt-4.1-mini-2025-04-14")
 
 
 def _email_str(email: dict[str, Any], *path: str, default: str = "") -> str:

--- a/samples/ticket-classification/main.py
+++ b/samples/ticket-classification/main.py
@@ -78,7 +78,7 @@ def decide_next_node(state: GraphState) -> Literal["classify", "notify_team"]:
 
 async def classify(state: GraphState) -> Command:
     """Classify the support ticket using LLM."""
-    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    llm = ChatOpenAI(model="gpt-4.1-mini-2025-04-14", temperature=0)
 
     if state.get("last_predicted_category", None):
         predicted_category = state["last_predicted_category"]


### PR DESCRIPTION
## Summary
- swap `gpt-4o-mini-2024-07-18` for `gpt-4.1-mini-2025-04-14` in the langchain samples

## Why

the `gpt-4o-mini-2024-07-18` model is deprecated, so samples should default to a current openai model resolved via `uip codedagent list-models`.