### PR TITLE
fix(a2a-tool): prefer UiPath proxy url over cached agent card url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.2"
+version = "0.13.3"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.11.7, <2.12.0",
+    "uipath>=2.11.10, <2.12.0",
     "uipath-core>=0.5.20, <0.6.0",
     "uipath-platform>=0.1.71, <0.2.0",
     "uipath-runtime>=0.11.2, <0.12.0",

--- a/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
+++ b/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
@@ -156,10 +156,10 @@ def _build_description(card: AgentCard) -> str:
 
 
 def _resolve_a2a_url(config: AgentA2aResourceConfig) -> str:
-    """Resolve the A2A endpoint URL from the cached agent card."""
-    if config.cached_agent_card and "url" in config.cached_agent_card:
-        return config.cached_agent_card["url"]
-    raise ValueError(f"A2A resource '{config.name}' has no URL in cachedAgentCard")
+    """Resolve the A2A endpoint URL, using the UiPath-hosted proxy URL."""
+    if config.a2a_url:
+        return config.a2a_url
+    raise ValueError(f"A2A resource '{config.name}' has no URL")
 
 
 async def _send_a2a_message(
@@ -340,6 +340,9 @@ def create_a2a_tools_and_clients(
                 default_input_modes=["text/plain"],
                 default_output_modes=["text/plain"],
             )
+
+        if resource.a2a_url:
+            agent_card.url = resource.a2a_url
 
         a2a_client = A2aClient(agent_card)
         tool = _create_a2a_tool(resource, a2a_client, agent_card)

--- a/tests/agent/tools/test_a2a_tool.py
+++ b/tests/agent/tools/test_a2a_tool.py
@@ -1,0 +1,90 @@
+"""Tests for A2A tool URL resolution.
+
+Focuses on the behavior of preferring the UiPath-hosted proxy URL
+(``a2a_url``) over any URL cached in the agent card.
+"""
+
+from typing import Any
+
+import pytest
+from uipath.agent.models.agent import AgentA2aResourceConfig
+
+from uipath_langchain.agent.tools.a2a.a2a_tool import (
+    _resolve_a2a_url,
+    create_a2a_tools_and_clients,
+)
+
+PROXY_URL = "https://cloud.uipath.com/proxy/a2a/remote-agent"
+CACHED_URL = "https://internal.example.com/agents/remote-agent"
+
+
+def _make_resource(
+    *,
+    a2a_url: str = PROXY_URL,
+    cached_agent_card: dict[str, Any] | None = None,
+    is_enabled: bool = True,
+) -> AgentA2aResourceConfig:
+    """Build an A2A resource config for tests."""
+    return AgentA2aResourceConfig(
+        id="resource-id",
+        name="remote-agent",
+        description="A remote A2A agent",
+        is_enabled=is_enabled,
+        slug="remote-agent-slug",
+        folder_path="Shared",
+        a2a_url=a2a_url,
+        cached_agent_card=cached_agent_card,
+    )
+
+
+def test_resolve_a2a_url_returns_proxy_url() -> None:
+    resource = _make_resource(a2a_url=PROXY_URL)
+    assert _resolve_a2a_url(resource) == PROXY_URL
+
+
+def test_resolve_a2a_url_raises_when_missing() -> None:
+    resource = _make_resource(a2a_url="")
+    with pytest.raises(ValueError, match="has no URL"):
+        _resolve_a2a_url(resource)
+
+
+def test_create_tools_prefers_proxy_url_over_cached_card_url() -> None:
+    """The proxy a2a_url must override the URL embedded in the cached card."""
+    resource = _make_resource(
+        a2a_url=PROXY_URL,
+        cached_agent_card={
+            "url": CACHED_URL,
+            "name": "Remote Agent",
+            "description": "cached",
+            "version": "1.0.0",
+            "skills": [],
+            "capabilities": {},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+        },
+    )
+
+    tools, clients = create_a2a_tools_and_clients([resource])
+
+    assert len(tools) == 1
+    assert len(clients) == 1
+    # The client's agent card URL is rewritten to the proxy URL.
+    assert clients[0]._agent_card.url == PROXY_URL
+
+
+def test_create_tools_sets_url_when_no_cached_card() -> None:
+    resource = _make_resource(a2a_url=PROXY_URL, cached_agent_card=None)
+
+    tools, clients = create_a2a_tools_and_clients([resource])
+
+    assert len(tools) == 1
+    assert clients[0]._agent_card.url == PROXY_URL
+
+
+def test_create_tools_skips_disabled_resource() -> None:
+    resource = _make_resource(is_enabled=False)
+
+    tools, clients = create_a2a_tools_and_clients([resource])
+
+    assert tools == []
+    assert clients == []

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-22T08:30:41.9090029Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -4369,7 +4369,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.9"
+version = "2.11.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -4392,9 +4392,9 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/67/c836a4ea44368baf20c06c5a4d751bfce530f39637b86ea22e7c4c26b86a/uipath-2.11.9.tar.gz", hash = "sha256:709cd423fc7952d3095e9df979c7f45caab0e48395e84d85fafaacbd54b95f72", size = 4460654, upload-time = "2026-06-23T09:34:02.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/43/6638a921c457370a3e316fa61c9363b32ba6381bdbdcd8fb9d84e16e38cf/uipath-2.11.10.tar.gz", hash = "sha256:b342ec67995da67ff560eade479abc010ed4df56202c3d629e96580a8fee6751", size = 4461131, upload-time = "2026-06-23T15:33:18.96Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/d2/162deb25b1861e6b5d2598a89e91fcb6c85dd8f224a0059959241376e9ae/uipath-2.11.9-py3-none-any.whl", hash = "sha256:1bb1878623dae8130b9b94cbc22bf0d1c44d080c4ab52be26947a0f13ee5d9ac", size = 405408, upload-time = "2026-06-23T09:34:00.354Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/db/208fa8c75776f47211f1c9845a1843d7f787abe176719d107395c8d2abdd/uipath-2.11.10-py3-none-any.whl", hash = "sha256:e5c186f6c80b4e960f3fa3de44fa49f23d21a21b224a5f9716704fc76cca325a", size = 405746, upload-time = "2026-06-23T15:33:17.333Z" },
 ]
 
 [[package]]
@@ -4413,7 +4413,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4488,7 +4488,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.11.7,<2.12.0" },
+    { name = "uipath", specifier = ">=2.11.10,<2.12.0" },
     { name = "uipath-core", specifier = ">=0.5.20,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.14.0,<1.15.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.14.0,<1.15.0" },


### PR DESCRIPTION
- resolve the A2A URL from a2a_url when present
- will bump after https://github.com/UiPath/uipath-python/pull/1743 merges