### PR TITLE
fix(exceptions): categorize LLM provider HTTP errors by status class

### DIFF
--- a/src/uipath_langchain/agent/exceptions/licensing.py
+++ b/src/uipath_langchain/agent/exceptions/licensing.py
@@ -21,6 +21,20 @@ _LLM_STATUS_CODE_MAP: dict[int, AgentRuntimeErrorCode] = {
 }
 
 
+def _category_for_status(status_code: int) -> UiPathErrorCategory:
+    """Map an LLM provider HTTP status to a runtime error category.
+
+    401/403 are tenant deployment/entitlement issues; 408, 429 and any 5xx are
+    system-side (timeout, throttling, provider/gateway failure). Anything else is
+    left UNKNOWN for the last-resort mapper to classify.
+    """
+    if status_code in (401, 403):
+        return UiPathErrorCategory.DEPLOYMENT
+    if status_code == 408 or status_code == 429 or status_code >= 500:
+        return UiPathErrorCategory.SYSTEM
+    return UiPathErrorCategory.UNKNOWN
+
+
 def raise_for_provider_http_error(e: BaseException) -> None:
     """Re-raise provider-specific HTTP errors as a structured AgentRuntimeError.
 
@@ -33,11 +47,7 @@ def raise_for_provider_http_error(e: BaseException) -> None:
         return
 
     code = _LLM_STATUS_CODE_MAP.get(err.status_code, AgentRuntimeErrorCode.HTTP_ERROR)
-    category = (
-        UiPathErrorCategory.DEPLOYMENT
-        if err.status_code == 403
-        else UiPathErrorCategory.UNKNOWN
-    )
+    category = _category_for_status(err.status_code)
 
     raise AgentRuntimeError(
         code=code,

--- a/tests/chat/test_provider_errors.py
+++ b/tests/chat/test_provider_errors.py
@@ -117,9 +117,37 @@ class TestRaiseForProviderHttpError:
 
         info = exc_info.value.error_info
         assert info.status == 500
-        assert info.category == UiPathErrorCategory.UNKNOWN
         assert info.code.endswith(AgentRuntimeErrorCode.HTTP_ERROR.value)
         assert "boom" in info.detail  # str(e) fallback
+
+    @pytest.mark.parametrize(
+        ("status_code", "expected_category"),
+        [
+            (401, UiPathErrorCategory.DEPLOYMENT),
+            (403, UiPathErrorCategory.DEPLOYMENT),
+            (408, UiPathErrorCategory.SYSTEM),
+            (429, UiPathErrorCategory.SYSTEM),
+            (500, UiPathErrorCategory.SYSTEM),
+            (503, UiPathErrorCategory.SYSTEM),
+            (400, UiPathErrorCategory.UNKNOWN),
+            (404, UiPathErrorCategory.UNKNOWN),
+        ],
+    )
+    def test_status_code_maps_to_expected_category(
+        self, status_code: int, expected_category: UiPathErrorCategory
+    ) -> None:
+        class _ProviderError(Exception):
+            def __init__(self, status: int) -> None:
+                super().__init__("boom")
+                self.status_code = status
+                self.body: dict[str, str] = {}
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            raise_for_provider_http_error(_ProviderError(status_code))
+
+        info = exc_info.value.error_info
+        assert info.status == status_code
+        assert info.category == expected_category
 
     def test_no_status_does_not_raise(self) -> None:
         # No extractable HTTP status → no-op (the original exception is left to


### PR DESCRIPTION
## Problem

`raise_for_provider_http_error` (the single point where an LLM provider HTTP status becomes a runtime error category) mapped only `403 → DEPLOYMENT` and dumped **every other status to `UNKNOWN`**:

```python
category = DEPLOYMENT if status_code == 403 else UNKNOWN
```

This is a root cause behind a large share of the miscategorized "Unknown" agent-execution failures in **SRE-610701**. Concretely:
- A provider **429** rate-limit (investigation Cat 14) surfaced as `Unknown` instead of `System`, even though it never reached the uipath-agents exception mapper's own `429 → SYSTEM` path (it was already wrapped here).
- The awsbedrock **503** family (Cat 2) and gateway timeouts (**408**) likewise fell to `Unknown`.

## Fix

Map by status class at the source:

| Status | Category | Why |
|--------|----------|-----|
| 401, 403 | `DEPLOYMENT` | auth / entitlement / licensing |
| 408, 429, 5xx | `SYSTEM` | timeout / throttling / provider/gateway failure |
| else | `UNKNOWN` | left to the last-resort mapper |

`403 → DEPLOYMENT` behavior is preserved. Categorizing here means these errors no longer fall through to `uipath-agents`' `exception_mapper.py` as `Unknown`.

## Tests

- Corrected `test_other_status_falls_back_to_http_error_and_str` (no longer asserts `500 → UNKNOWN`).
- Added a parametrized `test_status_code_maps_to_expected_category` covering 401/403/408/429/500/503/400/404.
- Full file: **17 passed**; `ruff` + `mypy` clean.

Found via the `investigate-alert-execution-failures` run on SRE-610701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)