### PR TITLE
feat: relocate advanced agent harness to uipath-langchain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.10"
+version = "0.13.11"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -13,6 +13,7 @@ dependencies = [
     "langchain-core>=1.2.27, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",
     "langchain>=1.2.15, <2.0.0",
+    "deepagents>=0.5.3, <0.6.0",
     "pydantic-settings>=2.6.0",
     "python-dotenv>=1.0.1",
     "httpx>=0.27.0",

--- a/src/uipath_langchain/agent/advanced/__init__.py
+++ b/src/uipath_langchain/agent/advanced/__init__.py
@@ -1,0 +1,21 @@
+"""UiPath Advanced agent implementation."""
+
+from deepagents import CompiledSubAgent, SubAgent
+from deepagents.backends import BackendProtocol, FilesystemBackend
+from deepagents.backends.protocol import BackendFactory
+
+from .agent import create_advanced_agent, create_advanced_agent_graph
+from .types import AdvancedAgentGraphState
+from .utils import create_state_with_input
+
+__all__ = [
+    "AdvancedAgentGraphState",
+    "BackendFactory",
+    "BackendProtocol",
+    "CompiledSubAgent",
+    "FilesystemBackend",
+    "SubAgent",
+    "create_advanced_agent",
+    "create_advanced_agent_graph",
+    "create_state_with_input",
+]

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -1,0 +1,102 @@
+"""Advanced agent builder."""
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from deepagents import CompiledSubAgent, SubAgent
+from deepagents import create_deep_agent as _create_deep_agent
+from deepagents.backends import BackendProtocol
+from deepagents.backends.protocol import BackendFactory
+from langchain.agents.structured_output import ResponseFormat
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import BaseTool
+from langgraph.graph import END, START
+from langgraph.graph.state import CompiledStateGraph, StateGraph
+from pydantic import BaseModel
+
+from uipath_langchain.agent.react.job_attachments import get_job_attachment_paths
+
+from .types import AdvancedAgentGraphState
+from .utils import create_state_with_input, resolve_input_attachments
+
+
+def create_advanced_agent(
+    model: BaseChatModel,
+    system_prompt: str = "",
+    tools: Sequence[BaseTool] = (),
+    subagents: Sequence[SubAgent | CompiledSubAgent] = (),
+    backend: BackendProtocol | BackendFactory | None = None,
+    response_format: ResponseFormat[Any] | None = None,
+) -> CompiledStateGraph[Any, Any, Any, Any]:
+    """Create a deepagents agent with planning, filesystem, and sub-agent tools."""
+    return _create_deep_agent(
+        model=model,
+        system_prompt=system_prompt,
+        tools=list(tools),
+        subagents=list(subagents),
+        backend=backend,
+        response_format=response_format,
+    )
+
+
+def create_advanced_agent_graph(
+    model: BaseChatModel,
+    tools: Sequence[BaseTool],
+    system_prompt: str,
+    backend: BackendProtocol | BackendFactory | None,
+    response_format: ResponseFormat[Any] | None,
+    input_schema: type[BaseModel] | None,
+    output_schema: type[BaseModel],
+    build_user_message: Callable[[dict[str, Any]], str],
+) -> StateGraph[Any, Any, Any, Any]:
+    """Wrap the advanced agent in a parent graph that maps typed I/O to/from messages.
+
+    With a ``FilesystemBackend``, attachment-shaped inputs are downloaded into the
+    workspace and given a ``FilePath`` before the user message is built.
+    """
+    inner_graph = create_advanced_agent(
+        model=model,
+        tools=tools,
+        system_prompt=system_prompt,
+        backend=backend,
+        response_format=response_format,
+    )
+
+    wrapper_state = create_state_with_input(input_schema)
+    internal_fields = set(AdvancedAgentGraphState.model_fields.keys())
+    attachment_paths = (
+        get_job_attachment_paths(input_schema) if input_schema is not None else []
+    )
+
+    async def transform_input_async(state: BaseModel) -> dict[str, Any]:
+        state_data = state.model_dump()
+        input_data = {k: v for k, v in state_data.items() if k not in internal_fields}
+        input_args = (
+            input_schema.model_validate(input_data).model_dump(by_alias=True)
+            if input_schema is not None
+            else {}
+        )
+        if attachment_paths:
+            input_args = await resolve_input_attachments(
+                backend, attachment_paths, input_args
+            )
+        user_text = build_user_message(input_args)
+        return {"messages": [HumanMessage(content=user_text, id="user-input")]}
+
+    def transform_output(state: BaseModel) -> dict[str, Any]:
+        structured = getattr(state, "structured_response", {})
+        return output_schema.model_validate(structured).model_dump()
+
+    wrapper: StateGraph[Any, Any, Any, Any] = StateGraph(
+        wrapper_state, input_schema=input_schema, output_schema=output_schema
+    )
+    wrapper.add_node("transform_input", transform_input_async)
+    wrapper.add_node("advanced_agent", inner_graph)
+    wrapper.add_node("transform_output", transform_output)
+    wrapper.add_edge(START, "transform_input")
+    wrapper.add_edge("transform_input", "advanced_agent")
+    wrapper.add_edge("advanced_agent", "transform_output")
+    wrapper.add_edge("transform_output", END)
+
+    return wrapper

--- a/src/uipath_langchain/agent/advanced/types.py
+++ b/src/uipath_langchain/agent/advanced/types.py
@@ -1,0 +1,14 @@
+"""State types for the advanced agent wrapper graph."""
+
+from typing import Annotated, Any
+
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+from pydantic import BaseModel
+
+
+class AdvancedAgentGraphState(BaseModel):
+    """Graph state for the advanced agent wrapper."""
+
+    messages: Annotated[list[AnyMessage], add_messages] = []
+    structured_response: dict[str, Any] = {}

--- a/src/uipath_langchain/agent/advanced/utils.py
+++ b/src/uipath_langchain/agent/advanced/utils.py
@@ -1,0 +1,98 @@
+"""Advanced agent utilities."""
+
+import asyncio
+import copy
+import logging
+import uuid
+from pathlib import Path
+from typing import Any, NamedTuple, cast
+
+from deepagents.backends import BackendProtocol, FilesystemBackend
+from deepagents.backends.protocol import BackendFactory
+from jsonpath_ng import parse as jsonpath_parse  # type: ignore[import-untyped]
+from pydantic import BaseModel
+from uipath.platform import UiPath
+from uipath.platform.attachments import Attachment
+
+from .types import AdvancedAgentGraphState
+
+logger = logging.getLogger(__name__)
+
+
+def create_state_with_input(
+    input_schema: type[BaseModel] | None,
+) -> type[AdvancedAgentGraphState]:
+    """Create combined state by merging AdvancedAgentGraphState with the input schema."""
+    if input_schema is None:
+        return AdvancedAgentGraphState
+    CompleteState = type(
+        "CompleteAdvancedAgentGraphState",
+        (AdvancedAgentGraphState, input_schema),
+        {},
+    )
+    cast(type[BaseModel], CompleteState).model_rebuild()
+    return CompleteState
+
+
+class _AttachmentDownload(NamedTuple):
+    """One input attachment to download and patch back into the args."""
+
+    location: Any
+    attachment_id: uuid.UUID
+    file_name: str
+    ticket: dict[str, Any]
+
+
+async def resolve_input_attachments(
+    backend: BackendProtocol | BackendFactory | None,
+    attachment_paths: list[str],
+    input_args: dict[str, Any],
+) -> dict[str, Any]:
+    """Download attachment-shaped inputs into the backend and add a ``FilePath``.
+
+    Each ticket is streamed to ``<backend.cwd>/<ID>_<name>`` and augmented with a
+    ``FilePath`` so the agent's file tools can open it. FilesystemBackend only.
+    """
+    if not isinstance(backend, FilesystemBackend):
+        raise NotImplementedError(
+            "Advanced agent with input attachments requires a FilesystemBackend, "
+            f"got {type(backend).__name__}"
+        )
+
+    result = copy.deepcopy(input_args)
+    client = UiPath()
+
+    worklist: list[_AttachmentDownload] = []
+    for path_expr in attachment_paths:
+        for match in jsonpath_parse(path_expr).find(result):
+            ticket = match.value
+            if not isinstance(ticket, dict) or "ID" not in ticket:
+                continue
+            att = Attachment.model_validate(ticket, from_attributes=True)
+            worklist.append(
+                _AttachmentDownload(
+                    location=match.full_path,
+                    attachment_id=att.id,
+                    # basename only: full_name is caller-controlled, keep the
+                    # download inside the workspace (no path traversal)
+                    file_name=f"{att.id}_{Path(att.full_name).name}",
+                    ticket=ticket,
+                )
+            )
+
+    logger.info(
+        "Downloading %d input attachment(s) into %s", len(worklist), backend.cwd
+    )
+
+    await asyncio.gather(
+        *(
+            client.attachments.download_async(
+                key=item.attachment_id,
+                destination_path=str(backend.cwd / item.file_name),
+            )
+            for item in worklist
+        )
+    )
+    for item in worklist:
+        item.location.update(result, {**item.ticket, "FilePath": f"/{item.file_name}"})
+    return result

--- a/tests/agent/advanced/__init__.py
+++ b/tests/agent/advanced/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the advanced agent harness."""

--- a/tests/agent/advanced/test_create_advanced_agent.py
+++ b/tests/agent/advanced/test_create_advanced_agent.py
@@ -1,0 +1,71 @@
+"""Tests for create_advanced_agent."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.tools import tool
+from langgraph.graph.state import CompiledStateGraph
+from langgraph.prebuilt import ToolNode
+
+from uipath_langchain.agent.advanced.agent import create_advanced_agent
+
+
+def _make_mock_model() -> MagicMock:
+    """Create a mock model with the attributes the upstream code reads."""
+    model = MagicMock(spec=BaseChatModel)
+    # upstream reads model.profile for summarization defaults
+    model.profile = None
+    return model
+
+
+@tool
+def _sample_tool(query: str) -> str:
+    """A sample tool for testing."""
+    return query
+
+
+class TestCreateAdvancedAgent:
+    """Test the create_advanced_agent function."""
+
+    @pytest.fixture
+    def mock_model(self) -> MagicMock:
+        return _make_mock_model()
+
+    def test_advanced_agent_with_tools(self, mock_model: MagicMock) -> None:
+        """Custom tool is registered alongside built-in advanced agent tools."""
+        result = create_advanced_agent(
+            mock_model, system_prompt="test", tools=[_sample_tool]
+        )
+        assert isinstance(result, CompiledStateGraph)
+        tools_node = result.nodes["tools"].bound
+        assert isinstance(tools_node, ToolNode)
+        tool_names = set(tools_node.tools_by_name.keys())
+        assert "_sample_tool" in tool_names
+
+    def test_advanced_agent_without_tools(self, mock_model: MagicMock) -> None:
+        """Built-in advanced agent tools are present even with no custom tools."""
+        result = create_advanced_agent(mock_model, system_prompt="test", tools=[])
+        assert isinstance(result, CompiledStateGraph)
+        tools_node = result.nodes["tools"].bound
+        assert isinstance(tools_node, ToolNode)
+        tool_names = set(tools_node.tools_by_name.keys())
+        assert "write_todos" in tool_names
+
+    def test_advanced_agent_converts_sequences_to_lists(
+        self, mock_model: MagicMock
+    ) -> None:
+        """Tuples for tools and subagents are converted to lists."""
+        with patch(
+            "uipath_langchain.agent.advanced.agent._create_deep_agent"
+        ) as mock_upstream:
+            mock_upstream.return_value = MagicMock(spec=CompiledStateGraph)
+            create_advanced_agent(
+                mock_model,
+                system_prompt="test",
+                tools=(_sample_tool,),
+                subagents=(),
+            )
+            _, kwargs = mock_upstream.call_args
+            assert isinstance(kwargs["tools"], list)
+            assert isinstance(kwargs["subagents"], list)

--- a/tests/agent/advanced/test_create_advanced_agent_graph.py
+++ b/tests/agent/advanced/test_create_advanced_agent_graph.py
@@ -1,0 +1,126 @@
+"""Tests for the create_advanced_agent_graph wrapper builder."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+from pydantic import BaseModel, ConfigDict, Field
+
+from uipath_langchain.agent.advanced.agent import create_advanced_agent_graph
+from uipath_langchain.agent.advanced.types import AdvancedAgentGraphState
+from uipath_langchain.agent.advanced.utils import create_state_with_input
+
+
+class _Output(BaseModel):
+    result: str = ""
+
+
+class _Input(BaseModel):
+    book: dict[str, Any] = {}
+    question: str = ""
+
+
+class _AliasedInput(BaseModel):
+    model_config = ConfigDict(validate_by_alias=True, validate_by_name=True)
+
+    schema_: str = Field(alias="schema")
+    question: str = ""
+
+
+def _mock_model() -> MagicMock:
+    model = MagicMock(spec=BaseChatModel)
+    model.profile = None
+    return model
+
+
+def _build(**overrides: Any) -> Any:
+    kwargs: dict[str, Any] = dict(
+        model=_mock_model(),
+        tools=[],
+        system_prompt="sys",
+        backend=None,
+        response_format=None,
+        input_schema=None,
+        output_schema=_Output,
+        build_user_message=lambda args: "hello",
+    )
+    kwargs.update(overrides)
+    return create_advanced_agent_graph(**kwargs)
+
+
+def test_wrapper_graph_has_io_nodes() -> None:
+    """The wrapper wires transform_input -> advanced_agent -> transform_output."""
+    graph = _build()
+    assert {"transform_input", "advanced_agent", "transform_output"} <= set(graph.nodes)
+
+
+@pytest.mark.asyncio
+async def test_transform_input_without_schema_builds_single_user_message() -> None:
+    """With no input schema, the built message comes straight from build_user_message."""
+    graph = _build(build_user_message=lambda args: "hi there")
+    out = await graph.nodes["transform_input"].runnable.ainvoke(
+        AdvancedAgentGraphState()
+    )
+    message = out["messages"][0]
+    assert isinstance(message, HumanMessage)
+    assert message.content == "hi there"
+    assert message.id == "user-input"
+
+
+@pytest.mark.asyncio
+async def test_transform_input_resolves_attachments_when_present() -> None:
+    """With an input schema and attachment paths, input attachments are resolved first."""
+    with (
+        patch(
+            "uipath_langchain.agent.advanced.agent.get_job_attachment_paths",
+            return_value=["$.book"],
+        ),
+        patch(
+            "uipath_langchain.agent.advanced.agent.resolve_input_attachments",
+            new_callable=AsyncMock,
+        ) as mock_resolve,
+    ):
+        mock_resolve.return_value = {"book": {"FilePath": "/x"}, "question": "q"}
+        graph = _build(
+            input_schema=_Input,
+            build_user_message=lambda args: f"msg:{args['question']}",
+        )
+        state_cls = create_state_with_input(_Input)
+        state = state_cls(book={"ID": "1"}, question="q")
+        out = await graph.nodes["transform_input"].runnable.ainvoke(state)
+
+    mock_resolve.assert_awaited_once()
+    assert out["messages"][0].content == "msg:q"
+
+
+@pytest.mark.asyncio
+async def test_transform_input_passes_alias_keyed_args_to_message_builder() -> None:
+    """Input args use JSON/schema field names, including aliases."""
+    captured_args: dict[str, Any] = {}
+
+    def build_user_message(args: dict[str, Any]) -> str:
+        captured_args.update(args)
+        return f"schema:{args['schema']}"
+
+    graph = _build(
+        input_schema=_AliasedInput,
+        build_user_message=build_user_message,
+    )
+    state_cls = create_state_with_input(_AliasedInput)
+    state = state_cls(schema="invoice", question="q")
+
+    out = await graph.nodes["transform_input"].runnable.ainvoke(state)
+
+    assert captured_args == {"schema": "invoice", "question": "q"}
+    assert out["messages"][0].content == "schema:invoice"
+
+
+def test_transform_output_validates_structured_response() -> None:
+    """transform_output coerces the agent's structured_response into the output schema."""
+    graph = _build()
+    out = graph.nodes["transform_output"].runnable.invoke(
+        AdvancedAgentGraphState(structured_response={"result": "done"})
+    )
+    assert out == {"result": "done"}

--- a/tests/agent/advanced/test_utils.py
+++ b/tests/agent/advanced/test_utils.py
@@ -1,0 +1,130 @@
+"""Tests for advanced agent utilities."""
+
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from deepagents.backends import FilesystemBackend
+from pydantic import BaseModel
+
+from uipath_langchain.agent.advanced.types import AdvancedAgentGraphState
+from uipath_langchain.agent.advanced.utils import (
+    create_state_with_input,
+    resolve_input_attachments,
+)
+
+
+class _InputSchema(BaseModel):
+    question: str = ""
+
+
+def test_create_state_returns_base_state_when_schema_is_none() -> None:
+    """With no input schema, returns the bare AdvancedAgentGraphState."""
+    assert create_state_with_input(None) is AdvancedAgentGraphState
+
+
+def test_create_state_merges_schema_with_state() -> None:
+    """Merged state carries both the base state fields and the input schema fields."""
+    merged = create_state_with_input(_InputSchema)
+    assert "messages" in merged.model_fields
+    assert "structured_response" in merged.model_fields
+    assert "question" in merged.model_fields
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_attachments_downloads_and_adds_filepath(
+    tmp_path: Path,
+) -> None:
+    """Happy path: download each ticket and augment it with a FilePath."""
+    backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+    attachment_id = uuid.uuid4()
+    input_args = {
+        "book": {
+            "ID": str(attachment_id),
+            "FullName": "novel.txt",
+            "MimeType": "text/plain",
+        },
+        "question": "summarize",
+    }
+
+    mock_client = MagicMock()
+    mock_client.attachments.download_async = AsyncMock()
+    with patch(
+        "uipath_langchain.agent.advanced.utils.UiPath",
+        return_value=mock_client,
+    ):
+        result = await resolve_input_attachments(backend, ["$.book"], input_args)
+
+    mock_client.attachments.download_async.assert_awaited_once()
+    call_kwargs = mock_client.attachments.download_async.call_args.kwargs
+    assert call_kwargs["key"] == attachment_id
+    expected_name = f"{attachment_id}_novel.txt"
+    assert call_kwargs["destination_path"] == str(backend.cwd / expected_name)
+    assert result["book"] == {
+        "ID": str(attachment_id),
+        "FullName": "novel.txt",
+        "MimeType": "text/plain",
+        "FilePath": f"/{expected_name}",
+    }
+    assert result["question"] == "summarize"
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_attachments_skips_non_ticket_matches(
+    tmp_path: Path,
+) -> None:
+    """A path match that isn't an attachment ticket is skipped, not downloaded."""
+    backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+    input_args: dict[str, Any] = {"book": "not-a-ticket"}
+
+    mock_client = MagicMock()
+    mock_client.attachments.download_async = AsyncMock()
+    with patch(
+        "uipath_langchain.agent.advanced.utils.UiPath",
+        return_value=mock_client,
+    ):
+        result = await resolve_input_attachments(backend, ["$.book"], input_args)
+
+    mock_client.attachments.download_async.assert_not_awaited()
+    assert result == {"book": "not-a-ticket"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_attachments_sanitizes_traversal_in_name(
+    tmp_path: Path,
+) -> None:
+    """A traversal-laden FullName is reduced to its basename, staying in the workspace."""
+    backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+    attachment_id = uuid.uuid4()
+    input_args: dict[str, Any] = {
+        "book": {
+            "ID": str(attachment_id),
+            "FullName": "../../../etc/passwd",
+            "MimeType": "text/plain",
+        }
+    }
+
+    mock_client = MagicMock()
+    mock_client.attachments.download_async = AsyncMock()
+    with patch(
+        "uipath_langchain.agent.advanced.utils.UiPath",
+        return_value=mock_client,
+    ):
+        result = await resolve_input_attachments(backend, ["$.book"], input_args)
+
+    expected_name = f"{attachment_id}_passwd"
+    dest = mock_client.attachments.download_async.call_args.kwargs["destination_path"]
+    assert dest == str(backend.cwd / expected_name)
+    assert result["book"]["FilePath"] == f"/{expected_name}"
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_attachments_raises_for_non_filesystem_backend() -> None:
+    """A backend that isn't FilesystemBackend surfaces a loud NotImplementedError."""
+    input_args: dict[str, Any] = {
+        "book": {"ID": str(uuid.uuid4()), "FullName": "book.txt"}
+    }
+    with pytest.raises(NotImplementedError, match="FilesystemBackend"):
+        await resolve_input_attachments(None, ["$.book"], input_args)

--- a/uv.lock
+++ b/uv.lock
@@ -532,6 +532,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -875,6 +884,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
     { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
     { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+]
+
+[[package]]
+name = "deepagents"
+version = "0.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-core" },
+    { name = "langchain-google-genai" },
+    { name = "langsmith" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/74/776e606f0508a4d7d4c9d061c797dcde43eed2452fea546ae29047aeaaa6/deepagents-0.5.9.tar.gz", hash = "sha256:74fe0f998641b20bda8adac662a018051c623a3c8e5ed4b6ff9ad53fc493a783", size = 165651, upload-time = "2026-05-10T22:31:17.095Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/f6/9698f98da72dfa8dc8e1d0f0542f2407a40a50cfdccf522fdb5cb43e39e2/deepagents-0.5.9-py3-none-any.whl", hash = "sha256:ce24a41763b2793bd21217411e9fb9f187a9128da6789f5a81654da1de9e4c7c", size = 188118, upload-time = "2026-05-10T22:31:15.974Z" },
 ]
 
 [[package]]
@@ -4413,10 +4439,11 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.10"
+version = "0.13.11"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
+    { name = "deepagents" },
     { name = "httpx" },
     { name = "jsonpath-ng" },
     { name = "jsonschema-pydantic-converter" },
@@ -4475,6 +4502,7 @@ dev = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.2.0,<1.0.0" },
     { name = "boto3-stubs", marker = "extra == 'bedrock'", specifier = ">=1.41.4" },
+    { name = "deepagents", specifier = ">=0.5.3,<0.6.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "jsonschema-pydantic-converter", specifier = ">=0.4.0" },
@@ -4739,6 +4767,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `uipath_langchain.agent.advanced` with the deepagents-based advanced agent harness (`create_advanced_agent` / `create_advanced_agent_graph`)
- input attachments are downloaded into the agent filesystem and given a readable `FilePath`, confined to the workspace
- preserve JSON/schema field names when transforming typed input into the advanced-agent user message, including aliased `Pydantic` fields.

## Why

the advanced (deepagents) harness now lives alongside the react harness in langchain so agents can consume it and drop its direct deepagents dependency. workspace-path resolution stays in the agents layer, so the harness takes its backend as a param and reads no env.