### PR TITLE
fix(static-args): surface malformed argumentPath as a typed SYSTEM error

### DIFF
--- a/src/uipath_langchain/agent/tools/static_args.py
+++ b/src/uipath_langchain/agent/tools/static_args.py
@@ -6,6 +6,7 @@ import re
 from typing import Any, Iterator, Mapping, Sequence, TypeVar
 
 from jsonpath_ng import parse  # type: ignore[import-untyped]
+from jsonpath_ng.exceptions import JsonPathParserError  # type: ignore[import-untyped]
 from langchain_core.messages import ToolCall
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel
@@ -57,6 +58,7 @@ _SENSITIVE_ITEM_PLACEHOLDER = "<hidden>"
 def _resolve_argument_properties(
     argument_properties: Mapping[str, AgentToolArgumentProperties],
     agent_input: dict[str, Any],
+    tool_name: str | None = None,
 ) -> dict[str, ToolStaticArgument]:
     """Resolves the different variants of argument properties to static arguments."""
 
@@ -73,7 +75,21 @@ def _resolve_argument_properties(
                     is_sensitive=props.is_sensitive,
                 )
             case AgentToolArgumentArgumentProperties():
-                agent_argument = parse(props.argument_path).find(agent_input)
+                try:
+                    argument_expr = parse(props.argument_path)
+                except JsonPathParserError as e:
+                    tool_ref = f" of tool '{tool_name}'" if tool_name else ""
+                    raise AgentRuntimeError(
+                        code=AgentRuntimeErrorCode.INVALID_STATIC_ARGUMENT,
+                        title="Malformed argument path in tool configuration",
+                        detail=(
+                            f"The argument binding '{json_path}'{tool_ref} has a "
+                            f"malformed JSONPath expression {props.argument_path!r}: {e} "
+                            "Fix the argument path in the agent configuration."
+                        ),
+                        category=UiPathErrorCategory.SYSTEM,
+                    ) from e
+                agent_argument = argument_expr.find(agent_input)
                 if not agent_argument:
                     return None
                 else:
@@ -312,7 +328,7 @@ class StaticArgsHandler:
                 and tool.argument_properties
             ):
                 static_args = _resolve_argument_properties(
-                    tool.argument_properties, agent_input
+                    tool.argument_properties, agent_input, tool_name=tool.name
                 )
                 modified_tool, applied_paths = _apply_static_arguments_to_schema(
                     tool, static_args

--- a/tests/agent/tools/test_static_args.py
+++ b/tests/agent/tools/test_static_args.py
@@ -205,6 +205,53 @@ class TestStaticArgsHandler:
         handler.apply_to_response([call])
         assert call["args"] == {"host": "h"}
 
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["output.", "$.foo.", "foo[", "$.foo[*", "", "$['a'"],
+        ids=[
+            "trailing-dot",
+            "trailing-dot-dollar",
+            "open-bracket",
+            "open-filter",
+            "empty",
+            "open-quote",
+        ],
+    )
+    def test_initialize_raises_typed_error_on_malformed_argument_path(
+        self, bad_path: str
+    ):
+        """A malformed (truncated) JSONPath argument_path surfaces as a typed
+        SYSTEM AgentRuntimeError naming the tool, argument, and offending path -
+        not an opaque jsonpath_ng JsonPathParserError that lands as Unknown
+        (SRE-610701 cat-5)."""
+
+        class InputSchema(BaseModel):
+            present: str = ""
+
+        tool = _create_tool(
+            "verification_tool",
+            {
+                "$['query']": AgentToolArgumentArgumentProperties(
+                    is_sensitive=False, argument_path=bad_path
+                ),
+            },
+        )
+        handler = StaticArgsHandler()
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            handler.initialize([tool], InputSchema(), InputSchema)
+
+        error = exc_info.value
+        assert error.error_info.category == UiPathErrorCategory.SYSTEM
+        assert error.error_info.code.endswith(
+            AgentRuntimeErrorCode.INVALID_STATIC_ARGUMENT.value
+        )
+        # The offending path, argument key, and tool name must all be named so
+        # the failure is debuggable (the raw error names none of them).
+        assert repr(bad_path) in error.error_info.detail
+        assert "$['query']" in error.error_info.detail
+        assert "verification_tool" in error.error_info.detail
+
     def test_apply_to_response_merges_with_existing_args(self):
         """Test that apply_to_response merges static args with existing tool call args."""
         tool = _create_tool(


### PR DESCRIPTION
## Why

A tool argument binding whose `argumentPath` is a **malformed (truncated) JSONPath** — e.g. a trailing dot `output.`, an unclosed bracket `foo[`, an open filter `$.foo[*`, or an empty string — was parsed bare at `static_args.py` (`parse(props.argument_path)`). `jsonpath_ng` raised an opaque `JsonPathParserError("Parse error near the end of string!")` that names **neither the tool, the argument, nor the offending path**. Being neither `EnrichedException` nor `HTTPStatusError`, it fell through the exception mapper to `ErrorCategory=Unknown` and surfaced as an undebuggable failure (observed recurring in production).

`"Parse error near the end of string!"` specifically means the path was **truncated** (ran out of tokens before closing) — consistent with a half-written `argumentPath` persisted into the agent config.

## What

Guard the parse: on `JsonPathParserError`, raise an `AgentRuntimeError` that names the **tool + argument key + offending `argumentPath`**, categorized **SYSTEM** (structural invalidity in the agent config artifact that the authoring layer should have rejected is a System defect, not `Unknown`). `tool_name` is threaded into `_resolve_argument_properties` so the message can name the tool.

**Surfacing fix only** — it makes the failure legible and correctly categorized; it does not make the run succeed.

## Tests

`test_initialize_raises_typed_error_on_malformed_argument_path` (6 parametrized truncation shapes) asserts a SYSTEM `AgentRuntimeError` whose detail names the path, argument key, and tool. Full `test_static_args.py` suite passes (47); mypy + ruff clean.

## Follow-up (not in this PR)

Durable fix is **author-time JSONPath validation** in the agent authoring layer so a malformed `argumentPath` can never be persisted into the agent config. Optional defense-in-depth: a `field_validator` on `AgentToolArgumentArgumentProperties.argument_path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)