### PR TITLE
fix(errors): categorize unresolvable Bedrock model id as Deployment

### DIFF
--- a/src/uipath_langchain/chat/_legacy/bedrock.py
+++ b/src/uipath_langchain/chat/_legacy/bedrock.py
@@ -58,6 +58,65 @@ from langchain_aws import (
     ChatBedrock,
     ChatBedrockConverse,
 )
+from uipath.runtime.errors import UiPathErrorCategory
+
+from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErrorCode
+
+_KNOWN_BEDROCK_PROVIDERS = frozenset(
+    {
+        "ai21",
+        "amazon",
+        "anthropic",
+        "cohere",
+        "deepseek",
+        "meta",
+        "mistral",
+        "openai",
+        "qwen",
+        "writer",
+    }
+)
+
+_REGION_PREFIXES = frozenset(
+    {"eu", "us", "us-gov", "apac", "sa", "amer", "global", "jp", "au"}
+)
+
+
+def _resolve_bedrock_provider(model_id: str) -> Optional[str]:
+    """Extract the Bedrock provider from a model id, mirroring langchain_aws.
+
+    Returns ``None`` for an ARN, which carries no inline provider segment and
+    is left to langchain_aws to validate against an explicit ``provider``.
+    """
+    if model_id.startswith("arn"):
+        return None
+    parts = model_id.split(".", maxsplit=2)
+    if len(parts) > 1 and parts[0].lower() in _REGION_PREFIXES:
+        return parts[1]
+    return parts[0]
+
+
+def _validate_bedrock_model(model_id: str) -> None:
+    """Reject a model id that cannot resolve to a known Bedrock provider.
+
+    A tenant-supplied alias with no provider segment (e.g. no dot to split
+    provider from model) otherwise reaches langchain_aws as an unknown provider
+    and surfaces only as an opaque ``NotImplementedError`` at invoke time. Fail
+    fast at construction with a Deployment-categorized error so the misconfigured
+    model is attributable instead of bucketing as Unknown.
+    """
+    provider = _resolve_bedrock_provider(model_id)
+    if provider is None or provider.lower() in _KNOWN_BEDROCK_PROVIDERS:
+        return
+    raise AgentStartupError(
+        code=AgentStartupErrorCode.LLM_INVALID_MODEL,
+        title="Invalid model",
+        detail=(
+            f"Model '{model_id}' does not resolve to a supported Bedrock provider. "
+            "Configure a valid Bedrock model id for the agent."
+        ),
+        category=UiPathErrorCategory.DEPLOYMENT,
+    )
 
 
 class AwsBedrockCompletionsPassthroughClient:
@@ -223,6 +282,8 @@ class UiPathChatBedrockConverse(ChatBedrockConverse):
                 "UIPATH_ACCESS_TOKEN environment variable or token parameter is required"
             )
 
+        _validate_bedrock_model(model_name)
+
         passthrough_client = AwsBedrockCompletionsPassthroughClient(
             model=model_name,
             token=token,
@@ -284,6 +345,8 @@ class UiPathChatBedrock(ChatBedrock):
             raise ValueError(
                 "UIPATH_ACCESS_TOKEN environment variable or token parameter is required"
             )
+
+        _validate_bedrock_model(model_name)
 
         header_capture = HeaderCapture(name=f"bedrock_headers_{id(self)}")
 

--- a/tests/chat/test_bedrock.py
+++ b/tests/chat/test_bedrock.py
@@ -4,16 +4,59 @@ from typing import Any
 from unittest.mock import patch
 
 import botocore
+import pytest
 from langchain_aws import ChatBedrock
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.messages.content import create_file_block
 from langchain_core.outputs import ChatGeneration, ChatResult
+from uipath.runtime.errors import UiPathErrorCategory
 
+from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErrorCode
 from uipath_langchain.chat._legacy.bedrock import (
     AwsBedrockCompletionsPassthroughClient,
     UiPathChatBedrock,
     UiPathChatBedrockConverse,
 )
+
+
+class TestModelResolutionValidation:
+    """An unresolvable model id is a deployment misconfiguration, not an Unknown.
+
+    A model id with no provider segment (no dot to split provider from model)
+    cannot be mapped to a known Bedrock provider, so langchain_aws raises an
+    opaque ``NotImplementedError`` ("Provider <id> model does not support chat")
+    deep at invoke time. Validate at construction and raise a typed,
+    Deployment-categorized error instead.
+    """
+
+    _ENV = {
+        "UIPATH_URL": "https://example.com",
+        "UIPATH_ORGANIZATION_ID": "org",
+        "UIPATH_TENANT_ID": "tenant",
+        "UIPATH_ACCESS_TOKEN": "token",
+    }
+
+    @patch.dict(os.environ, _ENV)
+    def test_unresolvable_model_raises_deployment_error(self):
+        with pytest.raises(AgentStartupError) as exc_info:
+            UiPathChatBedrock(model_name="not-a-real-bedrock-model")
+
+        error_info = exc_info.value.error_info
+        assert error_info.category == UiPathErrorCategory.DEPLOYMENT
+        assert error_info.code == AgentStartupError.full_code(
+            AgentStartupErrorCode.LLM_INVALID_MODEL
+        )
+
+    @patch.dict(os.environ, _ENV)
+    def test_unresolvable_model_raises_deployment_error_converse(self):
+        with pytest.raises(AgentStartupError) as exc_info:
+            UiPathChatBedrockConverse(model_name="not-a-real-bedrock-model")
+
+        assert exc_info.value.error_info.category == UiPathErrorCategory.DEPLOYMENT
+
+    @patch.dict(os.environ, _ENV)
+    def test_known_model_constructs(self):
+        UiPathChatBedrock(model_name="anthropic.claude-haiku-4-5-20251001-v1:0")
 
 
 class TestGetClientSkipsImds:


### PR DESCRIPTION
## Problem

A Bedrock model id with no provider segment (no dot to split provider from model) cannot be mapped to a known Bedrock provider. `langchain_aws` derives the provider from the model id by splitting on `.`; a bare alias yields the whole alias as the "provider", which is not in the supported set. This only fails deep at invoke time with an opaque `NotImplementedError` ("Provider <id> model does not support chat"), so it buckets as an Unknown runtime error rather than the deployment misconfiguration it is.

## Fix

Validate the model id at `UiPathChatBedrock` / `UiPathChatBedrockConverse` construction. A `_resolve_bedrock_provider` helper mirrors the library's own region-prefix-aware split; if the resolved provider is not a known Bedrock provider, raise `AgentStartupError(LLM_INVALID_MODEL)` categorized as `Deployment`. ARNs (which carry no inline provider) are left for `langchain_aws` to validate against an explicit `provider`.

This fails fast at startup with an attributable, Deployment-categorized error instead of an opaque Unknown at invoke time.

## Tests

`tests/chat/test_bedrock.py::TestModelResolutionValidation` — an unresolvable synthetic model id raises a Deployment-categorized `AgentStartupError` (both invoke and converse variants); a known model id still constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)