### PR TITLE
Add span for escalation memory ingestion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.9"
+version = "0.13.10"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/escalation_memory.py
+++ b/src/uipath_langchain/agent/tools/escalation_memory.py
@@ -573,6 +573,7 @@ async def _ingest_escalation_memory(
     trace_id: str,
     user_id: str | None = None,
     folder_path: str | None = None,
+    memory_space_name: str | None = None,
 ) -> None:
     """Persist a resolved escalation outcome into memory."""
     normalized_user_id = _normalize_user_id(user_id)
@@ -602,6 +603,7 @@ async def _ingest_escalation_memory(
                 "type": "agentMemoryWrite",
                 "span_type": "agentMemoryWrite",
                 "uipath.custom_instrumentation": True,
+                "memorySpaceName": memory_space_name or "",
                 "memorySpaceId": memory_space_id,
                 "strategy": ESCALATION_MEMORY_STRATEGY,
             },
@@ -621,6 +623,14 @@ async def _ingest_escalation_memory(
                 attributes=attributes,
                 user_id=normalized_user_id,
             )
+            # Record what was saved as a JSON string; the exporter parses it
+            # back to an object and the Studio UI reads "request" to display
+            # the persisted memory item. Mirrors the lookup span's "request".
+            if ingest_span and hasattr(ingest_span, "set_attribute"):
+                ingest_span.set_attribute(
+                    "request",
+                    _json_dumps(request.model_dump(by_alias=True, exclude_none=True)),
+                )
             sdk = UiPath()
             await sdk.memory.escalation_ingest_async(
                 memory_space_id=memory_space_id,

--- a/src/uipath_langchain/agent/tools/escalation_memory.py
+++ b/src/uipath_langchain/agent/tools/escalation_memory.py
@@ -575,7 +575,6 @@ async def _ingest_escalation_memory(
     folder_path: str | None = None,
 ) -> None:
     """Persist a resolved escalation outcome into memory."""
-    set_span_attribute("fromMemory", False)
     normalized_user_id = _normalize_user_id(user_id)
     if user_id is not None and normalized_user_id is None:
         logger.info(
@@ -584,32 +583,68 @@ async def _ingest_escalation_memory(
         )
 
     try:
-        request = EscalationMemoryIngestRequest(
-            span_id=parent_span_id,
-            trace_id=trace_id,
-            answer=answer,
-            attributes=attributes,
-            user_id=normalized_user_id,
+        # Keep the OTel import local to match the lookup path and keep this
+        # module importable in runtimes where tracing is not installed.
+        from opentelemetry import trace as otel_trace
+
+        tracer = otel_trace.get_tracer("uipath_langchain.memory")
+    except ImportError:
+        tracer = None
+        otel_trace = None  # type: ignore[assignment]
+
+    # Span attribute keys match what the LlmOpsHttpExporter and Studio UI expect;
+    # "openinference.span.kind" sets the SpanType.
+    ingest_span_ctx = (
+        tracer.start_as_current_span(
+            "Save escalation memory",
+            attributes={
+                "openinference.span.kind": "agentMemoryWrite",
+                "type": "agentMemoryWrite",
+                "span_type": "agentMemoryWrite",
+                "uipath.custom_instrumentation": True,
+                "memorySpaceId": memory_space_id,
+                "strategy": ESCALATION_MEMORY_STRATEGY,
+            },
         )
-        sdk = UiPath()
-        await sdk.memory.escalation_ingest_async(
-            memory_space_id=memory_space_id,
-            request=request,
-            folder_path=folder_path,
-        )
-        set_span_attribute("savedToMemory", True)
-        logger.info(
-            "Ingested escalation outcome into memory space '%s'", memory_space_id
-        )
-    except Exception as error:
-        set_span_attribute("savedToMemory", False)
-        set_current_span_error(error)
-        logger.warning(
-            "Failed to ingest escalation outcome into memory space '%s': %s",
-            memory_space_id,
-            error,
-            exc_info=True,
-        )
+        if tracer
+        else _noop_context()
+    )
+
+    with ingest_span_ctx as ingest_span:
+        if ingest_span and hasattr(ingest_span, "set_attribute"):
+            ingest_span.set_attribute("fromMemory", False)
+        try:
+            request = EscalationMemoryIngestRequest(
+                span_id=parent_span_id,
+                trace_id=trace_id,
+                answer=answer,
+                attributes=attributes,
+                user_id=normalized_user_id,
+            )
+            sdk = UiPath()
+            await sdk.memory.escalation_ingest_async(
+                memory_space_id=memory_space_id,
+                request=request,
+                folder_path=folder_path,
+            )
+            if ingest_span and hasattr(ingest_span, "set_attribute"):
+                ingest_span.set_attribute("savedToMemory", True)
+            logger.info(
+                "Ingested escalation outcome into memory space '%s'", memory_space_id
+            )
+        except Exception as error:
+            if ingest_span and hasattr(ingest_span, "set_attribute"):
+                ingest_span.set_attribute("savedToMemory", False)
+            if otel_trace and ingest_span and hasattr(ingest_span, "set_status"):
+                ingest_span.set_status(otel_trace.StatusCode.ERROR, repr(error))
+            if ingest_span and hasattr(ingest_span, "record_exception"):
+                ingest_span.record_exception(error)
+            logger.warning(
+                "Failed to ingest escalation outcome into memory space '%s': %s",
+                memory_space_id,
+                error,
+                exc_info=True,
+            )
 
 
 def _build_search_fields(

--- a/src/uipath_langchain/agent/tools/escalation_tool.py
+++ b/src/uipath_langchain/agent/tools/escalation_tool.py
@@ -489,6 +489,7 @@ def create_escalation_tool(
                 trace_id=trace_id,
                 user_id=user_id,
                 folder_path=_memory_folder_path or folder_path,
+                memory_space_name=_memory_space_name,
             )
             if user_id is None:
                 _escalation_logger.info(

--- a/tests/agent/tools/test_escalation_memory.py
+++ b/tests/agent/tools/test_escalation_memory.py
@@ -1067,6 +1067,80 @@ class TestIngestEscalationMemory:
             user_id="reviewer@example.com",
         )
 
+    @pytest.mark.asyncio
+    async def test_adds_memory_write_span(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from opentelemetry import trace
+
+        from uipath_langchain.agent.tools import escalation_memory
+
+        fake_tracer = _FakeTracer()
+        tracer_names: list[str] = []
+
+        def get_tracer(name: str) -> _FakeTracer:
+            tracer_names.append(name)
+            return fake_tracer
+
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_ingest_async = AsyncMock()
+        monkeypatch.setattr(trace, "get_tracer", get_tracer)
+        monkeypatch.setattr(
+            escalation_memory, "UiPath", MagicMock(return_value=mock_sdk)
+        )
+
+        await _ingest_escalation_memory(
+            "space-123",
+            answer='{"approved": true}',
+            attributes='{"input": "test"}',
+            parent_span_id="abc123",
+            trace_id="def456",
+            user_id=USER_GUID,
+        )
+
+        assert tracer_names == ["uipath_langchain.memory"]
+        assert [span.name for span in fake_tracer.spans] == ["Save escalation memory"]
+        (write_span,) = fake_tracer.spans
+        assert write_span.attributes["openinference.span.kind"] == "agentMemoryWrite"
+        assert write_span.attributes["type"] == "agentMemoryWrite"
+        assert write_span.attributes["span_type"] == "agentMemoryWrite"
+        assert write_span.attributes["uipath.custom_instrumentation"] is True
+        assert write_span.attributes["memorySpaceId"] == "space-123"
+        assert write_span.attributes["strategy"] == ESCALATION_MEMORY_STRATEGY
+        assert write_span.attributes["fromMemory"] is False
+        assert write_span.attributes["savedToMemory"] is True
+
+    @pytest.mark.asyncio
+    async def test_sets_memory_write_span_to_error_on_ingest_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from opentelemetry import trace
+
+        from uipath_langchain.agent.tools import escalation_memory
+
+        fake_tracer = _FakeTracer()
+        monkeypatch.setattr(trace, "get_tracer", lambda _name: fake_tracer)
+        error = Exception("fail")
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_ingest_async = AsyncMock(side_effect=error)
+        monkeypatch.setattr(
+            escalation_memory, "UiPath", MagicMock(return_value=mock_sdk)
+        )
+
+        # Should swallow the error so a failed ingest never breaks the run.
+        await _ingest_escalation_memory(
+            "space-123",
+            answer="yes",
+            attributes="{}",
+            parent_span_id="abc123",
+            trace_id="def456",
+        )
+
+        (write_span,) = fake_tracer.spans
+        assert write_span.attributes["savedToMemory"] is False
+        assert write_span.recorded_errors == [error]
+        assert write_span.statuses
+
 
 class TestEscalationMemoryUtilities:
     def test_serialize_search_response_for_trace_uses_model_dump(self) -> None:

--- a/tests/agent/tools/test_escalation_memory.py
+++ b/tests/agent/tools/test_escalation_memory.py
@@ -1107,6 +1107,7 @@ class TestIngestEscalationMemory:
             parent_span_id="abc123",
             trace_id="def456",
             user_id=USER_GUID,
+            memory_space_name="MemorySpace",
         )
 
         assert tracer_names == ["uipath_langchain.memory"]
@@ -1116,10 +1117,16 @@ class TestIngestEscalationMemory:
         assert write_span.attributes["type"] == "agentMemoryWrite"
         assert write_span.attributes["span_type"] == "agentMemoryWrite"
         assert write_span.attributes["uipath.custom_instrumentation"] is True
+        assert write_span.attributes["memorySpaceName"] == "MemorySpace"
         assert write_span.attributes["memorySpaceId"] == "space-123"
         assert write_span.attributes["strategy"] == ESCALATION_MEMORY_STRATEGY
         assert write_span.attributes["fromMemory"] is False
         assert write_span.attributes["savedToMemory"] is True
+        # "request" captures what was saved as a JSON string the exporter
+        # parses back into an object for the Studio UI.
+        saved = json.loads(write_span.attributes["request"])
+        assert saved["answer"] == '{"approved": true}'
+        assert saved["attributes"] == '{"input": "test"}'
 
     @pytest.mark.asyncio
     async def test_sets_memory_write_span_to_error_on_ingest_failure(

--- a/tests/agent/tools/test_escalation_memory.py
+++ b/tests/agent/tools/test_escalation_memory.py
@@ -1124,7 +1124,9 @@ class TestIngestEscalationMemory:
         assert write_span.attributes["savedToMemory"] is True
         # "request" captures what was saved as a JSON string the exporter
         # parses back into an object for the Studio UI.
-        saved = json.loads(write_span.attributes["request"])
+        saved_request = write_span.attributes["request"]
+        assert isinstance(saved_request, str)
+        saved = json.loads(saved_request)
         assert saved["answer"] == '{"approved": true}'
         assert saved["attributes"] == '{"input": "test"}'
 

--- a/tests/agent/tools/test_escalation_memory.py
+++ b/tests/agent/tools/test_escalation_memory.py
@@ -311,6 +311,17 @@ class TestGetEscalationMemorySpaceId:
 
         assert result is None
 
+    def test_folder_path_returns_none_when_memory_disabled(self) -> None:
+        # No properties.memory.isEnabled and no isAgentMemoryEnabled -> disabled.
+        resource = _memory_resource()
+
+        assert _get_escalation_memory_folder_path(resource) is None
+
+    def test_space_name_returns_none_when_memory_disabled(self) -> None:
+        resource = _memory_resource()
+
+        assert _get_escalation_memory_space_name(resource) is None
+
 
 class TestGetMemorySpaceFolderOverride:
     def test_returns_none_without_matching_override(self) -> None:
@@ -1140,6 +1151,44 @@ class TestIngestEscalationMemory:
         assert write_span.attributes["savedToMemory"] is False
         assert write_span.recorded_errors == [error]
         assert write_span.statuses
+
+    @pytest.mark.asyncio
+    async def test_ingest_succeeds_without_opentelemetry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from uipath_langchain.agent.tools import escalation_memory
+
+        original_import = builtins.__import__
+
+        def import_without_otel(
+            name: str,
+            globals: dict[str, Any] | None = None,
+            locals: dict[str, Any] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> Any:
+            if name == "opentelemetry":
+                raise ImportError("opentelemetry unavailable")
+            return original_import(name, globals, locals, fromlist, level)
+
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_ingest_async = AsyncMock()
+        monkeypatch.setattr(builtins, "__import__", import_without_otel)
+        monkeypatch.setattr(
+            escalation_memory, "UiPath", MagicMock(return_value=mock_sdk)
+        )
+
+        # The ingest must still run when tracing is unavailable (no-op span).
+        await _ingest_escalation_memory(
+            "space-123",
+            answer='{"approved": true}',
+            attributes='{"input": "test"}',
+            parent_span_id="abc123",
+            trace_id="def456",
+            user_id=USER_GUID,
+        )
+
+        mock_sdk.memory.escalation_ingest_async.assert_called_once()
 
 
 class TestEscalationMemoryUtilities:

--- a/uv.lock
+++ b/uv.lock
@@ -4413,7 +4413,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.9"
+version = "0.13.10"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## What

Adds a dedicated OpenTelemetry span around the **escalation memory ingestion** call (`sdk.memory.escalation_ingest_async`) in `_ingest_escalation_memory`.

This is the write-side counterpart to the lookup spans added in #865 ("Add spans for escalation memory lookup"). Previously the ingest path had no span of its own — it only set attributes (`fromMemory`, `savedToMemory`) on whatever ambient span happened to be current. Now ingestion gets its own `Save escalation memory` span so the write shows up as a first-class step in the trace / Studio UI.

## Details

- Opens a `Save escalation memory` span (`openinference.span.kind = agentMemoryWrite`) carrying `memorySpaceId`, `strategy`, `uipath.custom_instrumentation`, and `fromMemory`/`savedToMemory`.
- On failure, records the exception and sets the span status to ERROR — while still swallowing the error so a failed write never breaks the run (unchanged behavior).
- Matches the existing lookup-span pattern in the same file: local OTel import, `tracer.start_as_current_span(...)` with a `_noop_context()` fallback when tracing isn't installed.
- Bumps version `0.13.9` → `0.13.10`.

## Tests

- `test_adds_memory_write_span` — asserts the span name, kind, and attributes on a successful ingest.
- `test_sets_memory_write_span_to_error_on_ingest_failure` — asserts `savedToMemory=False`, the recorded exception, and ERROR status on a failed ingest.

All 58 tests in `tests/agent/tools/test_escalation_memory.py` pass; `ruff format`, `ruff check`, and `mypy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)