### PR TITLE
fix: add NOSTREAM tag for analyze-file-tool internal llm-call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.11"
+version = "0.13.12"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.12"
+version = "0.13.13"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
@@ -15,6 +15,7 @@ from langchain_core.messages import (
 )
 from langchain_core.runnables.config import RunnableConfig, var_child_runnable_config
 from langchain_core.tools import StructuredTool
+from langgraph.constants import TAG_NOSTREAM
 from opentelemetry import trace as otel_trace
 from uipath.agent.models.agent import (
     AgentInternalToolResourceConfig,
@@ -65,11 +66,6 @@ ANALYZE_FILES_SYSTEM_MESSAGE = (
 # that should render on the llmCall span. The LLMOps callback in uipath-agents
 # reads this and stamps it on the llmCall span as the ``attachments`` attribute.
 LLM_CALL_ATTACHMENTS_METADATA_KEY = "uipath_llm_call_attachments"
-
-# Tag applied to internal LLM calls to represent that the LLM call is part
-# of an internal tool execution. This is intended for the conversational runtime 
-# bridge to recognize that it should not forward the LLM call's response to the conversation.
-INTERNAL_TOOL_LLM_CALL_TAG = "uipath_internal_tool_llm_call"
 
 
 def _original_attachment_id(file: FileInfo) -> str:
@@ -143,10 +139,12 @@ def _llm_call_attachments_payload(files: list[FileInfo]) -> str | None:
     return json.dumps([att.model_dump(by_alias=True) for att in attachments])
 
 
-def _config_as_internal_llm_call(config: RunnableConfig | None) -> RunnableConfig:
-    """Return a config tagged so the runtime bridge ignores this LLM call's messages."""
+def _config_without_streaming(config: RunnableConfig | None) -> RunnableConfig:
+    """Tag config with TAG_NOSTREAM so LangGraph's StreamMessagesHandler skips
+    this LLM call — prevents its response from leaking into the conversation
+    stream as a visible content part."""
     new_config = cast(RunnableConfig, dict(config) if config else {})
-    new_config["tags"] = [*(new_config.get("tags") or []), INTERNAL_TOOL_LLM_CALL_TAG]
+    new_config["tags"] = [*(new_config.get("tags") or []), TAG_NOSTREAM]
     return new_config
 
 
@@ -339,7 +337,7 @@ def create_analyze_file_tool(
             cast(AnyMessage, human_message_with_files),
         ]
         config = var_child_runnable_config.get(None)
-        config = _config_as_internal_llm_call(config)
+        config = _config_without_streaming(config)
         config = _config_with_llm_call_attachments(config, files)
         result = await non_streaming_llm.ainvoke(messages, config=config)
 

--- a/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
@@ -66,6 +66,11 @@ ANALYZE_FILES_SYSTEM_MESSAGE = (
 # reads this and stamps it on the llmCall span as the ``attachments`` attribute.
 LLM_CALL_ATTACHMENTS_METADATA_KEY = "uipath_llm_call_attachments"
 
+# Tag applied to internal LLM calls to represent that the LLM call is part
+# of an internal tool execution. This is intended for the conversational runtime 
+# bridge to recognize that it should not forward the LLM call's response to the conversation.
+INTERNAL_TOOL_LLM_CALL_TAG = "uipath_internal_tool_llm_call"
+
 
 def _original_attachment_id(file: FileInfo) -> str:
     """Return the id to use for the original file in trace attachments.
@@ -136,6 +141,13 @@ def _llm_call_attachments_payload(files: list[FileInfo]) -> str | None:
             )
         )
     return json.dumps([att.model_dump(by_alias=True) for att in attachments])
+
+
+def _config_as_internal_llm_call(config: RunnableConfig | None) -> RunnableConfig:
+    """Return a config tagged so the runtime bridge ignores this LLM call's messages."""
+    new_config = cast(RunnableConfig, dict(config) if config else {})
+    new_config["tags"] = [*(new_config.get("tags") or []), INTERNAL_TOOL_LLM_CALL_TAG]
+    return new_config
 
 
 def _config_with_llm_call_attachments(
@@ -327,6 +339,7 @@ def create_analyze_file_tool(
             cast(AnyMessage, human_message_with_files),
         ]
         config = var_child_runnable_config.get(None)
+        config = _config_as_internal_llm_call(config)
         config = _config_with_llm_call_attachments(config, files)
         result = await non_streaming_llm.ainvoke(messages, config=config)
 

--- a/src/uipath_langchain/runtime/runtime.py
+++ b/src/uipath_langchain/runtime/runtime.py
@@ -32,9 +32,6 @@ from uipath.runtime.events import (
 from uipath.runtime.schema import UiPathRuntimeSchema
 
 from uipath_langchain.agent.tools.client_side_tool import ClientSideToolInfo
-from uipath_langchain.agent.tools.internal_tools.analyze_files_tool import (
-    INTERNAL_TOOL_LLM_CALL_TAG,
-)
 from uipath_langchain.chat.hitl import (
     IS_CONVERSATIONAL_CLIENT_SIDE_TOOL,
     get_confirmation_schema,
@@ -156,9 +153,7 @@ class UiPathLangGraphRuntime:
                 # Emit UiPathRuntimeMessageEvent for messages
                 if chunk_type == "messages":
                     if isinstance(data, tuple):
-                        message, metadata = data
-                        if INTERNAL_TOOL_LLM_CALL_TAG in (metadata.get("tags") or ()):
-                            continue
+                        message, _ = data
                         try:
                             events = await self.chat.map_event(message)
                         except Exception as e:

--- a/src/uipath_langchain/runtime/runtime.py
+++ b/src/uipath_langchain/runtime/runtime.py
@@ -32,6 +32,9 @@ from uipath.runtime.events import (
 from uipath.runtime.schema import UiPathRuntimeSchema
 
 from uipath_langchain.agent.tools.client_side_tool import ClientSideToolInfo
+from uipath_langchain.agent.tools.internal_tools.analyze_files_tool import (
+    INTERNAL_TOOL_LLM_CALL_TAG,
+)
 from uipath_langchain.chat.hitl import (
     IS_CONVERSATIONAL_CLIENT_SIDE_TOOL,
     get_confirmation_schema,
@@ -153,7 +156,9 @@ class UiPathLangGraphRuntime:
                 # Emit UiPathRuntimeMessageEvent for messages
                 if chunk_type == "messages":
                     if isinstance(data, tuple):
-                        message, _ = data
+                        message, metadata = data
+                        if INTERNAL_TOOL_LLM_CALL_TAG in (metadata.get("tags") or ()):
+                            continue
                         try:
                             events = await self.chat.map_event(message)
                         except Exception as e:

--- a/tests/agent/tools/internal_tools/test_analyze_files_tool.py
+++ b/tests/agent/tools/internal_tools/test_analyze_files_tool.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables.config import RunnableConfig
+from langgraph.constants import TAG_NOSTREAM
 from pydantic import BaseModel, ConfigDict, Field
 from uipath.agent.models.agent import (
     AgentInternalAnalyzeFilesToolProperties,
@@ -26,6 +27,7 @@ from uipath_langchain.agent.tools.internal_tools.analyze_files_tool import (
     ANALYZE_FILES_SYSTEM_MESSAGE,
     LLM_CALL_ATTACHMENTS_METADATA_KEY,
     _config_with_llm_call_attachments,
+    _config_without_streaming,
     _is_pii_scope_for_files,
     _resolve_job_attachment_arguments,
     create_analyze_file_tool,
@@ -1015,6 +1017,31 @@ class TestIsPiiScopeForFiles:
         )
 
 
+class TestConfigWithoutStreaming:
+    """Tests for _config_without_streaming — ensures TAG_NOSTREAM is injected."""
+
+    def test_adds_nostream_tag_to_empty_config(self) -> None:
+        result = _config_without_streaming(None)
+        assert TAG_NOSTREAM in result["tags"]
+
+    def test_adds_nostream_tag_to_existing_config(self) -> None:
+        config: RunnableConfig = {"tags": ["existing_tag"]}
+        result = _config_without_streaming(config)
+        assert "existing_tag" in result["tags"]
+        assert TAG_NOSTREAM in result["tags"]
+
+    def test_preserves_other_config_keys(self) -> None:
+        config: RunnableConfig = {"metadata": {"key": "value"}, "tags": ["t"]}
+        result = _config_without_streaming(config)
+        assert result["metadata"] == {"key": "value"}
+        assert TAG_NOSTREAM in result["tags"]
+
+    def test_handles_config_without_tags(self) -> None:
+        config: RunnableConfig = {"metadata": {"key": "value"}}
+        result = _config_without_streaming(config)
+        assert result["tags"] == [TAG_NOSTREAM]
+
+
 class TestConfigWithLlmCallAttachments:
     """The attachments payload travels to the llmCall span via langchain config metadata."""
 
@@ -1153,3 +1180,7 @@ class TestAnalyzeFileToolPassesAttachmentsViaConfig:
         attachments = json.loads(payload)
         assert attachments[0]["id"] == att_id
         assert attachments[0]["fileName"] == "doc.pdf"
+
+        # Verify TAG_NOSTREAM is set to prevent the internal LLM response
+        # from leaking into the conversation stream as a content part.
+        assert TAG_NOSTREAM in config_arg["tags"]

--- a/uv.lock
+++ b/uv.lock
@@ -4439,7 +4439,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.12"
+version = "0.13.13"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -4439,7 +4439,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.11"
+version = "0.13.12"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
**Bug:** The Analyze Files tool's internal LLM call was leaking its response into the conversation stream as a visible content part, causing duplicate content in the chat UI.

**Root cause:** Commit `67a85715` (2026-03-31) added `map_ai_message_to_events()` to handle full `AIMessage` objects for PII masking. This inadvertently caused the internal LLM's `AIMessage` — captured via inherited graph callbacks in `var_child_runnable_config` — to be processed and emitted as a content part.

**Fix:** Tag the internal LLM call's config with LangGraph's built-in `TAG_NOSTREAM`, which tells `StreamMessagesHandler` to skip capturing that call's messages entirely.

Single Response from Agent (Internal LLM output not streamed)

https://github.com/user-attachments/assets/b74a686c-c293-44a1-8284-f3605e564200

Autonomous agents still working with the tool:

<img width="1392" height="1522" alt="image" src="https://github.com/user-attachments/assets/d87b6631-1f12-4636-be03-ab6de86e59e6" />
