### PR TITLE
fix(react): leave list[str] items uncoerced when a schema is provided

### DIFF
--- a/src/uipath_langchain/agent/react/json_utils.py
+++ b/src/uipath_langchain/agent/react/json_utils.py
@@ -238,10 +238,14 @@ def _coerce_field(key: str, value: Any, schema: type[BaseModel] | None) -> Any:
 
     if get_origin(annotation) is list:
         item_args = get_args(annotation)
-        item_schema = None
-        if item_args and _is_pydantic_model(item_args[0]):
-            item_schema = item_args[0]
         if isinstance(value, list):
+            # str-typed items are protected like a scalar str field: a list[str]
+            # element that merely looks like JSON must stay a string.
+            if item_args and _unwrap_optional(item_args[0]) is str:
+                return value
+            item_schema = (
+                item_args[0] if item_args and _is_pydantic_model(item_args[0]) else None
+            )
             return [coerce_json_strings(item, item_schema) for item in value]
 
     return coerce_json_strings(value)

--- a/tests/agent/react/test_json_utils.py
+++ b/tests/agent/react/test_json_utils.py
@@ -532,3 +532,40 @@ class TestBuildOrderIndependence:
 
         attachments = get_job_attachments(first, self._data())
         assert [str(att.id) for att in attachments] == [self._ATTACHMENT_ID]
+
+
+# -- coerce_json_strings: list[str] items are protected by the schema ----------
+
+
+class TestCoerceListOfStrProtected:
+    """The elements of a list[str] field are str-typed per the schema and must be
+    left untouched, exactly as a scalar str field is — even when an element looks
+    like JSON or a Python repr."""
+
+    def test_list_str_items_not_coerced(self) -> None:
+        class Schema(BaseModel):
+            tags: list[str]
+
+        data = {"tags": ['{"not": "a dict"}', "hello", "[1, 2]"]}
+        assert coerce_json_strings(data, Schema) == {
+            "tags": ['{"not": "a dict"}', "hello", "[1, 2]"]
+        }
+
+    def test_optional_list_str_items_not_coerced(self) -> None:
+        class Schema(BaseModel):
+            tags: Optional[list[str]] = None
+
+        data = {"tags": ["{'a': 1}"]}
+        assert coerce_json_strings(data, Schema) == {"tags": ["{'a': 1}"]}
+
+    def test_list_model_items_still_coerced(self) -> None:
+        """Regression guard: model-typed list items must still be coerced."""
+
+        class Item(BaseModel):
+            data: dict[str, Any] | None = None
+
+        class Schema(BaseModel):
+            items: list[Item]
+
+        data = {"items": [{"data": '{"size": 1}'}]}
+        assert coerce_json_strings(data, Schema) == {"items": [{"data": {"size": 1}}]}


### PR DESCRIPTION
## Summary

When `coerce_json_strings` is given a schema, it protects scalar `str`-typed fields from coercion
(`if annotation is str: return value`). But `_coerce_field`'s list branch never extended that
protection to `list[str]` item types: each element was passed to blind coercion, so a `list[str]`
element that merely looks like JSON (`'{"a": 1}'`, `'[1, 2]'`) was silently parsed into a
dict/list — against the declared `str` element type.

## The contract

`coerce_json_strings`' docstring: *"When a schema is provided, str-typed fields are left
untouched."* The elements of a `list[str]` field are `str`-typed per the schema and must be left
untouched, exactly like a scalar `str` field. The scalar-field form of this rule is already locked
by `test_str_field_preserved_dict_field_coerced`.

## Root cause & fix

`agent/react/json_utils.py::_coerce_field` — the list branch now mirrors the scalar guard: when the
(optional-unwrapped) item type is `str`, the list elements are returned untouched. Model-typed and
unknown item types are unchanged (model items still recurse with their child schema). One guard in
the shared producer every `coerce_json_strings(dict, schema)` field routes through — not a
per-caller patch.

## Tests

Added `TestCoerceListOfStrProtected`: `list[str]` items not coerced, `Optional[list[str]]` items
not coerced, and a regression guard that model-typed list items **are** still coerced. The first
two fail on current code and pass with the fix; the full `json_utils` suite passes.
