### PR TITLE
feat: add workspace memory to advanced agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.17"
+version = "0.13.18"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -13,7 +13,7 @@ dependencies = [
     "langchain-core>=1.2.27, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",
     "langchain>=1.2.15, <2.0.0",
-    "deepagents>=0.5.3, <0.6.0",
+    "deepagents>=0.5.9, <0.6.0",
     "pydantic-settings>=2.6.0",
     "python-dotenv>=1.0.1",
     "httpx>=0.27.0",

--- a/src/uipath_langchain/agent/advanced/__init__.py
+++ b/src/uipath_langchain/agent/advanced/__init__.py
@@ -6,9 +6,17 @@ from deepagents.backends.protocol import BackendFactory
 
 from .agent import create_advanced_agent, create_advanced_agent_graph
 from .types import AdvancedAgentGraphState
-from .utils import create_state_with_input
+from .utils import (
+    MEMORY_DIR_NAME,
+    MEMORY_INDEX_FILENAME,
+    MEMORY_INDEX_VIRTUAL_PATH,
+    create_state_with_input,
+)
 
 __all__ = [
+    "MEMORY_DIR_NAME",
+    "MEMORY_INDEX_FILENAME",
+    "MEMORY_INDEX_VIRTUAL_PATH",
     "AdvancedAgentGraphState",
     "BackendFactory",
     "BackendProtocol",

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -6,6 +6,7 @@ from typing import Any
 from deepagents import CompiledSubAgent, SubAgent
 from deepagents import create_deep_agent as _create_deep_agent
 from deepagents.backends import BackendProtocol
+from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import BackendFactory
 from langchain.agents.structured_output import ResponseFormat
 from langchain_core.language_models import BaseChatModel
@@ -18,7 +19,11 @@ from pydantic import BaseModel
 from uipath_langchain.agent.react.job_attachments import get_job_attachment_paths
 
 from .types import AdvancedAgentGraphState
-from .utils import create_state_with_input, resolve_input_attachments
+from .utils import (
+    MEMORY_INDEX_VIRTUAL_PATH,
+    create_state_with_input,
+    resolve_input_attachments,
+)
 
 
 def create_advanced_agent(
@@ -28,8 +33,14 @@ def create_advanced_agent(
     subagents: Sequence[SubAgent | CompiledSubAgent] = (),
     backend: BackendProtocol | BackendFactory | None = None,
     response_format: ResponseFormat[Any] | None = None,
+    memory: Sequence[str] = (),
 ) -> CompiledStateGraph[Any, Any, Any, Any]:
-    """Create a deepagents agent with planning, filesystem, and sub-agent tools."""
+    """Create a deepagents agent with planning, filesystem, and sub-agent tools.
+
+    ``memory`` is a list of file paths loaded via deepagents' ``MemoryMiddleware``:
+    each is read from ``backend`` and injected into the system prompt every turn,
+    and the model maintains them with ``edit_file``. Empty disables the middleware.
+    """
     return _create_deep_agent(
         model=model,
         system_prompt=system_prompt,
@@ -37,6 +48,7 @@ def create_advanced_agent(
         subagents=list(subagents),
         backend=backend,
         response_format=response_format,
+        memory=list(memory) or None,
     )
 
 
@@ -53,14 +65,22 @@ def create_advanced_agent_graph(
     """Wrap the advanced agent in a parent graph that maps typed I/O to/from messages.
 
     With a ``FilesystemBackend``, attachment-shaped inputs are downloaded into the
-    workspace and given a ``FilePath`` before the user message is built.
+    workspace and given a ``FilePath`` before the user message is built. A
+    ``FilesystemBackend`` also enables workspace memory: deepagents'
+    ``MemoryMiddleware`` reads ``/memory/MEMORY.md`` from the backend each turn.
+    Memory stays disabled for non-filesystem backends, which carry no workspace.
     """
+    memory_sources = (
+        [MEMORY_INDEX_VIRTUAL_PATH] if isinstance(backend, FilesystemBackend) else []
+    )
+
     inner_graph = create_advanced_agent(
         model=model,
         tools=tools,
         system_prompt=system_prompt,
         backend=backend,
         response_format=response_format,
+        memory=memory_sources,
     )
 
     wrapper_state = create_state_with_input(input_schema)

--- a/src/uipath_langchain/agent/advanced/utils.py
+++ b/src/uipath_langchain/agent/advanced/utils.py
@@ -18,6 +18,18 @@ from .types import AdvancedAgentGraphState
 
 logger = logging.getLogger(__name__)
 
+# --- Workspace memory layout ---
+# Durable memory lives under <workspace>/memory/: MEMORY.md is the always-loaded
+# index, entries live in <workspace>/memory/<name>.md. deepagents' MemoryMiddleware
+# handles loading/injection, but backed by the agent's FilesystemBackend (run-scoped,
+# persisted via WorkspaceHydrator) rather than the cross-run StoreBackend.
+MEMORY_DIR_NAME = "memory"
+MEMORY_INDEX_FILENAME = "MEMORY.md"
+
+# Virtual path handed to MemoryMiddleware as a source; the agent's virtual-mode
+# FilesystemBackend resolves it under the workspace root.
+MEMORY_INDEX_VIRTUAL_PATH = f"/{MEMORY_DIR_NAME}/{MEMORY_INDEX_FILENAME}"
+
 
 def create_state_with_input(
     input_schema: type[BaseModel] | None,

--- a/tests/agent/advanced/test_memory_injection.py
+++ b/tests/agent/advanced/test_memory_injection.py
@@ -1,0 +1,129 @@
+"""Wiring test: the wrapper enables deepagents memory based on the backend.
+
+Phase 1 workspace memory is delegated to deepagents' ``MemoryMiddleware``, which
+``create_deep_agent`` builds when a ``memory=`` source list is supplied. The
+wrapper's responsibility is therefore to pass ``memory=["/memory/MEMORY.md"]``
+through to ``_create_deep_agent`` when (and only when) the backend is a
+``FilesystemBackend`` that carries a durable workspace. The actual loading and
+system-prompt injection are deepagents' concern and covered by their own tests.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from deepagents.backends.filesystem import FilesystemBackend
+from langchain_core.language_models import BaseChatModel
+from pydantic import BaseModel
+
+from uipath_langchain.agent.advanced.agent import (
+    create_advanced_agent_graph,
+)
+from uipath_langchain.agent.advanced.utils import (
+    MEMORY_INDEX_VIRTUAL_PATH,
+)
+
+
+class _Input(BaseModel):
+    """Minimal input schema for the test."""
+
+    task: str
+
+
+class _Output(BaseModel):
+    """Minimal output schema for the test."""
+
+    result: str = ""
+
+
+def _build_user_message(args: dict[str, Any]) -> str:
+    return args.get("task", "")
+
+
+def _memory_kwarg(
+    backend: Any,
+) -> Any:
+    """Build the wrapper graph and return the ``memory`` kwarg handed to deepagents."""
+    with patch(
+        "uipath_langchain.agent.advanced.agent._create_deep_agent",
+        return_value=MagicMock(),
+    ) as mock_create:
+        create_advanced_agent_graph(
+            model=MagicMock(spec=BaseChatModel),
+            tools=[],
+            system_prompt="",
+            backend=backend,
+            response_format=None,
+            input_schema=_Input,
+            output_schema=_Output,
+            build_user_message=_build_user_message,
+        )
+    return mock_create.call_args.kwargs["memory"]
+
+
+class TestWorkspaceMemoryWiring:
+    """The wrapper turns deepagents memory on for filesystem-backed workspaces."""
+
+    def test_enables_memory_for_filesystem_backend(self, tmp_path: Any) -> None:
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        assert _memory_kwarg(backend) == [MEMORY_INDEX_VIRTUAL_PATH]
+
+    def test_disables_memory_for_non_filesystem_backend(self) -> None:
+        # The default in-state backend (None) carries no durable workspace, so
+        # passing memory=None leaves MemoryMiddleware out of the stack entirely.
+        assert _memory_kwarg(None) is None
+
+
+@pytest.mark.asyncio
+class TestWrapperInputUnchanged:
+    """transform_input no longer hand-rolls a memory SystemMessage."""
+
+    async def test_transform_input_emits_only_user_message(self, tmp_path: Any) -> None:
+        # Even with a populated MEMORY.md on disk, the wrapper passes just the user
+        # message; memory injection is now MemoryMiddleware's job inside the inner
+        # agent, not the wrapper's.
+        from langchain_core.messages import HumanMessage
+        from langgraph.graph import END, START, StateGraph
+
+        from uipath_langchain.agent.advanced.types import (
+            AdvancedAgentGraphState,
+        )
+
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        (memory_dir / "MEMORY.md").write_text("- entry: x", encoding="utf-8")
+
+        captured: list[list[Any]] = []
+
+        def _make_inner() -> Any:
+            def _capture(state: AdvancedAgentGraphState) -> dict[str, Any]:
+                captured.append(list(state.messages))
+                return {"structured_response": {"result": "ok"}}
+
+            inner = StateGraph(AdvancedAgentGraphState)
+            inner.add_node("capture", _capture)
+            inner.add_edge(START, "capture")
+            inner.add_edge("capture", END)
+            return inner.compile()
+
+        with patch(
+            "uipath_langchain.agent.advanced.agent._create_deep_agent",
+            return_value=_make_inner(),
+        ):
+            wrapper = create_advanced_agent_graph(
+                model=MagicMock(spec=BaseChatModel),
+                tools=[],
+                system_prompt="",
+                backend=FilesystemBackend(root_dir=tmp_path, virtual_mode=True),
+                response_format=None,
+                input_schema=_Input,
+                output_schema=_Output,
+                build_user_message=_build_user_message,
+            ).compile()
+            await wrapper.ainvoke({"task": "do something"})
+
+        assert len(captured) == 1
+        messages = captured[0]
+        assert len(messages) == 1
+        assert isinstance(messages[0], HumanMessage)
+        assert messages[0].content == "do something"

--- a/uv.lock
+++ b/uv.lock
@@ -4439,7 +4439,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.17"
+version = "0.13.18"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4502,7 +4502,7 @@ dev = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.2.0,<1.0.0" },
     { name = "boto3-stubs", marker = "extra == 'bedrock'", specifier = ">=1.41.4" },
-    { name = "deepagents", specifier = ">=0.5.3,<0.6.0" },
+    { name = "deepagents", specifier = ">=0.5.9,<0.6.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "jsonschema-pydantic-converter", specifier = ">=0.4.0" },


### PR DESCRIPTION
## Summary
- add workspace memory to the advanced agent: a `memory=` parameter on `create_advanced_agent`, and automatic `/memory/MEMORY.md` loading (via deepagents `MemoryMiddleware`) whenever the backend is a `FilesystemBackend`
- export the memory path constants from `uipath_langchain.agent.advanced`

## Why

workspace memory currently lives only in uipath-agents and is missing from the advanced harness that now lives in this package. porting it here lets agents consume it from the correct layer instead of carrying its own copy.