### PR TITLE
fix: bump uipath-dev to >=0.0.82 in dev-console testcase

### DIFF
--- a/testcases/dev-console/pyproject.toml
+++ b/testcases/dev-console/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "langchain-core>=0.3.34",
     "python-dotenv>=1.0.1",
     "uipath-langchain",
-    "uipath-dev>=0.0.12",
+    "uipath-dev>=0.0.82",
     "pydantic>=2.10.6",
     "typing-extensions>=4.12.2",
     "pexpect>=4.9.0",


### PR DESCRIPTION
## Why

The `dev-console` cross-langchain testcase fails dependency resolution on uipath-python PRs ([example](https://github.com/UiPath/uipath-python/actions/runs/28509866863/job/84508210362?pr=1707)): `uipath-langchain>=0.13.16` requires `uipath>=2.12.1` while every `uipath-dev<=0.0.81` pins `uipath<2.12.0`.

[uipath-dev-python#109](https://github.com/UiPath/uipath-dev-python/pull/109) (merged) makes `uipath-dev 0.0.82` compatible with `uipath>=2.12.0, <2.13.0`. This PR raises the testcase floor so the resolver requires the compatible version and fails loudly (rather than with a confusing resolution backtrack) if it's unavailable.

Slack context: https://uipath-product.slack.com/archives/C07BTKVLVC3/p1782902385666139?thread_ts=1782860141.222669&cid=C07BTKVLVC3

⚠️ Note: `uipath-dev 0.0.82` is being released to PyPI now (CD in progress on uipath-dev-python main) — CI on this PR will fail resolution until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)