### PR TITLE
feat(datafabric): add OTEL span instrumentation for SQL query execution

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -241,7 +241,7 @@ agent = create_agent(
 
 ### Escalation action (human-in-the-loop)
 
-`EscalateAction` routes a violation to a **human reviewer** instead of logging or blocking it. On a violation it builds the review payload and calls the documented HITL primitive [`interrupt(CreateEscalation(...))`](https://uipath.github.io/uipath-python/langchain/human_in_the_loop/#3-createescalation) — creating a task in a UiPath **Action App** and **suspending the run** until the reviewer responds. On resume:
+`EscalateAction` routes a violation to a **human reviewer** instead of logging or blocking it. On a violation it builds the review payload and calls the documented HITL primitive [`interrupt(CreateEscalation(...))`](https://uipath.github.io/uipath-python/langchain/human_in_the_loop/#createescalation) — creating a task in a UiPath **Action App** and **suspending the run** until the reviewer responds. On resume:
 
 - **Approve** — if the reviewer edited the content, the edited value is substituted back into the flagged message / tool args / output; otherwise the original is kept. The edit is read from `ReviewedInputs` for a PRE (input) escalation and `ReviewedOutputs` for a POST (output) one.
 - **Reject** — raises `GuardrailBlockException`, terminating the run.

--- a/docs/human_in_the_loop.md
+++ b/docs/human_in_the_loop.md
@@ -1,53 +1,130 @@
 # Human In The Loop
 
 Guide for **Human-In-The-Loop** scenarios within the UiPath-Langchain integration.
-It focuses on the **interrupt(model)** functionality, illustrating its role as a symbolic representation of an agent's
-wait state within the LangGraph framework.
+It focuses on the **interrupt(model)** functionality, which is a symbolic representation of an agent's wait state within the LangGraph framework.
 
-## Models Overview
+Each model below ties the agent's wait state to a specific UiPath operation. You pass the model to `interrupt(...)`, the agent suspends, and it resumes once the operation completes. The models are grouped by the kind of operation they wait on.
 
-### 1. CreateTask
+/// info
+Every model is imported from `uipath.platform.common`, for example `from uipath.platform.common import CreateTask`.
+///
 
-The `CreateTask` model is utilized to create an escalation action within the UiPath Action Center as part of an interrupt context. The action will rely on a previously created UiPath app.
-After addressing the escalation, the current agent will resume execution.
-For more information on UiPath apps, refer to the [UiPath Apps User Guide](https://docs.uipath.com/apps/automation-cloud/latest/user-guide/introduction).
+---
 
-#### Attributes:
+## Action Center tasks
 
--   **app_name** (Optional[str]): The name of the app.
--   **app_folder_path** (Optional[str]): The folder path of the app.
--   **app_key** (Optional[str]): The key of the app.
--   **title** (str): The title of the action to create.
--   **data** (Optional[Dict[str, Any]]): Values that the action will be populated with.
--   **assignee** (Optional[str]): The username or email of the person assigned to handle the escalation.
--   **recipient** (Optional[TaskRecipient]): A structured recipient that assigns the action to a specific user (by email or id) or group (by name or id). Takes precedence over **assignee** when both are set. See [Assigning the action to a user or group](#assigning-the-action-to-a-user-or-group).
+These models drive human review through a UiPath app in Action Center. The agent suspends while a person handles the action, then resumes.
 
-#### Example:
+### CreateTask
+
+Creates an action in Action Center backed by a previously created UiPath app. After the action is addressed, the agent resumes. For more information on UiPath apps, refer to the [UiPath Apps User Guide](https://docs.uipath.com/apps/automation-cloud/latest/user-guide/introduction).
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `title` | `str` | The title of the action to create. |
+| `data` | `dict[str, Any] | None` | Values the action is populated with. |
+| `assignee` | `str | None` | Username or email of the person assigned to handle the action. |
+| `recipient` | `TaskRecipient | None` | Structured recipient targeting a user or group. Takes precedence over `assignee`. See [Assigning the action to a user or group](#assigning-the-action-to-a-user-or-group). |
+| `app_name` | `str | None` | The name of the app. |
+| `app_folder_path` | `str | None` | The folder path of the app. |
+| `app_folder_key` | `str | None` | The folder key of the app. |
+| `app_key` | `str | None` | The key of the app. |
+| `priority` | `str | None` | Priority of the action, for example `Low`, `Medium`, `High`, or `Critical`. |
+| `labels` | `list[str] | None` | Labels to attach to the action. |
+| `is_actionable_message_enabled` | `bool | None` | Whether actionable-message delivery is enabled for the action. |
+| `actionable_message_metadata` | `dict[str, Any] | None` | Metadata for the actionable message. |
+| `source_name` | `str` | The source that created the action. Defaults to `Agent`. |
 
 ```python
 from uipath.platform.common import CreateTask
 task_output = interrupt(CreateTask(app_name="AppName", app_folder_path="MyFolderPath", title="Escalate Issue", data={"key": "value"}, assignee="user@example.com"))
 ```
-/// info
-The return value of the interrupt is the task output — only the data fields written back by the app, not the full task object. If the task did not produce any output, the return value will be the task status, e.g., `{"status": "completed"}`.
 
-The human's decision (which Approve/Reject button was clicked, stored in `task.action`) is **not** included in the return value. To branch on the outcome, either add an explicit output field to the app schema (e.g. a boolean `IsApproved` wired to the buttons), or use [`CreateEscalation`](#3-createescalation) instead, which returns the full task object.
+/// info
+The return value of the interrupt is the task output, meaning only the data fields written back by the app, not the full task object. If the task did not produce any output, the return value is the task status, for example `{"status": "completed"}`.
+
+The human's decision (which Approve/Reject button was clicked, stored in `task.action`) is **not** included in the return value. To branch on the outcome, either add an explicit output field to the app schema (for example a boolean `IsApproved` wired to the buttons), or use [`CreateEscalation`](#createescalation) instead, which returns the full task object.
 ///
 
-For a practical implementation of the `CreateTask` model, refer to the [ticket-classification sample](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/ticket-classification). This sample demonstrates how to create an action with dynamic input.
+For a practical implementation, refer to the [ticket-classification sample](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/ticket-classification), which creates an action with dynamic input.
 
-#### Assigning the action to a user or group
+### WaitTask
 
-`CreateTask` and `CreateEscalation` — together with their wait counterparts [`WaitTask`](#2-waittask) and [`WaitEscalation`](#4-waitescalation) — support two ways to assign the action:
+Waits for a task that has already been created to be handled.
 
--   **assignee** (Optional[str]): The simple shortcut — a single username or email.
--   **recipient** (Optional[TaskRecipient]): A structured recipient that can target a **user** (by email or id) or a **group** (by name or id). When both are provided, **`recipient` takes precedence over `assignee`**.
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `action` | `Task` | The instance of the task to wait for. |
+| `app_folder_path` | `str | None` | The folder path of the app. |
+| `app_folder_key` | `str | None` | The folder key of the app. |
+| `app_name` | `str | None` | The name of the app. |
+| `recipient` | `TaskRecipient | None` | Optionally assign the task to a user or group while waiting. See [Assigning the action to a user or group](#assigning-the-action-to-a-user-or-group). |
+
+```python
+from uipath.platform.common import WaitTask
+task_output = interrupt(WaitTask(action=my_task_instance, app_folder_path="MyFolderPath"))
+```
+
+/// info
+Like `CreateTask`, the return value is the task output only. Use [`WaitEscalation`](#waitescalation) if you need the full task object back, including the selected action.
+///
+
+### CreateEscalation
+
+Creates an Action Center action the same way `CreateTask` does, but on resume the agent receives the **full `Task` object** instead of just `task.data`. Use this when the agent needs to branch on the human's decision (the button the reviewer clicked, stored in `task.action`) rather than only on the data fields written back by the app.
+
+Accepts the same attributes as [`CreateTask`](#createtask), including `assignee` and `recipient`.
+
+```python
+from uipath.platform.common import CreateEscalation
+
+task = interrupt(
+    CreateEscalation(
+        app_name="ApprovalApp",
+        app_folder_path="MyFolderPath",
+        title="Approve expense",
+        data={"amount": 1200},
+        assignee="reviewer@example.com",
+    )
+)
+
+if task.action == "Approve":
+    ...
+else:
+    ...
+```
+
+/// info
+The return value is the full `Task` object (including `task.action`, `task.data`, `task.status`, and so on). If the task is deleted while the agent is suspended, the task object is still returned rather than raising, so the agent can handle the deletion gracefully.
+///
+
+### WaitEscalation
+
+The escalation counterpart of [`WaitTask`](#waittask): wait on an already-created task and receive the full `Task` object on resume.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `action` | `Task` | The instance of the task to wait for. |
+| `app_folder_path` | `str | None` | The folder path of the app. |
+| `recipient` | `TaskRecipient | None` | Optionally assign the task to a user or group while waiting. See [Assigning the action to a user or group](#assigning-the-action-to-a-user-or-group). |
+
+```python
+from uipath.platform.common import WaitEscalation
+task = interrupt(WaitEscalation(action=my_task_instance, app_folder_path="MyFolderPath"))
+```
+
+### Assigning the action to a user or group
+
+`CreateTask` and `CreateEscalation`, together with their wait counterparts [`WaitTask`](#waittask) and [`WaitEscalation`](#waitescalation), support two ways to assign the action:
+
+- **assignee** (`str | None`): The simple shortcut, a single username or email.
+- **recipient** (`TaskRecipient | None`): A structured recipient that can target a **user** (by email or id) or a **group** (by name or id). When both are provided, `recipient` takes precedence over `assignee`.
 
 `TaskRecipient` is imported from `uipath.platform.action_center.tasks` and has the following fields:
 
--   **type** (TaskRecipientType): The kind of recipient (see the table below).
--   **value** (str): The identifier — an email, group name, user id, or group id, matching `type`.
--   **display_name** (Optional[str]): An optional human-readable name. For `USER_ID` and `GROUP_ID` recipients it is resolved automatically from the identity service.
+- **type** (`TaskRecipientType`): The kind of recipient (see the table below).
+- **value** (`str`): The identifier, an email, group name, user id, or group id, matching `type`.
+- **display_name** (`str | None`): An optional human-readable name. For `USER_ID` and `GROUP_ID` recipients it is resolved automatically from the identity service.
 
 | TaskRecipientType | Assigns to | `value` holds |
 | --- | --- | --- |
@@ -55,8 +132,6 @@ For a practical implementation of the `CreateTask` model, refer to the [ticket-c
 | `USER_ID` | a single user, by id | the user id |
 | `GROUP_NAME` | a group, by name | the group name |
 | `GROUP_ID` | a group, by id | the group id |
-
-#### Example:
 
 ```python
 from uipath.platform.common import CreateTask
@@ -85,99 +160,21 @@ task_output = interrupt(
 )
 ```
 
-The same `recipient` field is available on `CreateEscalation`, `WaitTask`, and `WaitEscalation`.
-
 ---
 
-### 2. WaitTask
+## Processes and jobs
 
-The `WaitTask` model is used to wait for a task to be handled. This model is intended for scenarios where the task has already been created.
+These models suspend the agent until another process or job finishes. This enables **Robot/Agent-in-the-loop** scenarios, where one agent's execution is suspended until another robot or agent completes.
 
-#### Attributes:
+### InvokeProcess
 
--   **task** (Task): The instance of the task to wait for.
--   **app_folder_path** (Optional[str]): The folder path of the app.
--   **recipient** (Optional[TaskRecipient]): Optionally assign the task to a user or group while waiting. See [Assigning the action to a user or group](#assigning-the-action-to-a-user-or-group).
+Invokes a process within the UiPath cloud platform. The process can be an API workflow, an Agent, or an RPA automation. When it completes, the agent resumes automatically.
 
-#### Example:
-
-```python
-from uipath.platform.common import WaitTask
-task_output = interrupt(WaitTask(task=my_task_instance, app_folder_path="MyFolderPath"))
-```
-/// info
-Like `CreateTask`, the return value is the task output only. Use [`WaitEscalation`](#4-waitescalation) if you need the full task object back, including the selected action.
-///
-
----
-
-### 3. CreateEscalation
-
-The `CreateEscalation` model creates an Action Center action the same way `CreateTask` does, but when the agent resumes it receives the **full `Task` object** instead of just `task.data`. Use this when the agent needs to branch on the human's decision (the button the reviewer clicked, stored in `task.action`) rather than only on the data fields written back by the app.
-
-Accepts the same attributes as [`CreateTask`](#1-createtask), including `assignee` and `recipient` (see [Assigning the action to a user or group](#assigning-the-action-to-a-user-or-group)).
-
-#### Example:
-
-```python
-from uipath.platform.common import CreateEscalation
-
-task = interrupt(
-    CreateEscalation(
-        app_name="ApprovalApp",
-        app_folder_path="MyFolderPath",
-        title="Approve expense",
-        data={"amount": 1200},
-        assignee="reviewer@example.com",
-    )
-)
-
-if task.action == "Approve":
-    ...
-else:
-    ...
-```
-/// info
-The return value is the full `Task` object (including `task.action`, `task.data`, `task.status`, etc.). If the task is deleted while the agent is suspended, the task object is still returned rather than raising, so the agent can handle the deletion gracefully.
-///
-
----
-
-### 4. WaitEscalation
-
-`WaitEscalation` is the escalation counterpart of [`WaitTask`](#2-waittask): wait on an already-created task and receive the full `Task` object on resume.
-
-#### Attributes:
-
--   **action** (Task): The instance of the task to wait for.
--   **app_folder_path** (Optional[str]): The folder path of the app.
--   **recipient** (Optional[TaskRecipient]): Optionally assign the task to a user or group while waiting. See [Assigning the action to a user or group](#assigning-the-action-to-a-user-or-group).
-
-#### Example:
-
-```python
-from uipath.platform.common import WaitEscalation
-task = interrupt(WaitEscalation(action=my_task_instance, app_folder_path="MyFolderPath"))
-```
-
----
-
-> 💡The UiPath-LangChain SDK also supports **Robot/Agent-in-the-loop** scenarios. In this context, the execution of one agent
-> can be suspended until another robot or agent finishes its execution.
-
-### 5. InvokeProcess
-
-The `InvokeProcess` model is utilized to invoke a process within the UiPath cloud platform.
-This process can be of various types, including API workflows, Agents or RPA automation.
-Upon completion of the invoked process, the current agent will automatically resume execution.
-
-#### Attributes:
-
--   **name** (str): The name of the process to invoke.
--   **process_folder_path** (Optional[str]): The folder path of the process.
--   **input_arguments** (Optional[Dict[str, Any]]): A dictionary containing the input arguments required for the invoked process.
-
-#### Example:
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `name` | `str` | The name of the process to invoke. |
+| `process_folder_path` | `str | None` | The folder path of the process. |
+| `input_arguments` | `dict[str, Any] | None` | Input arguments for the invoked process. |
 
 ```python
 from uipath.platform.common import InvokeProcess
@@ -185,28 +182,25 @@ process_output = interrupt(InvokeProcess(name="MyProcess", process_folder_path="
 ```
 
 /// info
-The return value of the interrupt is the job output. If the job did not produce any output, the return value will be the job state, e.g., `{"state": "successful"}`.
+The return value of the interrupt is the job output. If the job did not produce any output, the return value is the job state, for example `{"state": "successful"}`.
+
+**Raw variant:** `InvokeProcessRaw` accepts the same attributes but returns the raw `Job` object without validating its terminal state. Use it when you want to inspect the job state and handle non-successful jobs yourself instead of having the SDK extract the output or raise.
 ///
 
 /// warning
-An agent can invoke itself if needed, but this must be done with caution. Be mindful that using the same name for invocation may lead to unintentional loops. To prevent recursion issues, implement safeguards like exit conditions.
+An agent can invoke itself if needed, but this must be done with caution. Using the same name for invocation may lead to unintentional loops. To prevent recursion issues, implement safeguards like exit conditions.
 ///
 
-For a practical implementation of the `InvokeProcess` model, refer to the [multi-agent-planner-researcher-coder-distributed sample](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/multi-agent-planner-researcher-coder-distributed). This sample demonstrates how to invoke a process with dynamic input arguments, showcasing the integration of the interrupt functionality within a multi-agent system or a system where an agent integrates with RPA processes and API workflows.
+For a practical implementation, refer to the [multi-agent-planner-researcher-coder-distributed sample](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/multi-agent-planner-researcher-coder-distributed), which invokes a process with dynamic input arguments.
 
----
+### WaitJob
 
-### 6. WaitJob
+Waits for a job to complete. Unlike `InvokeProcess`, which creates the job, this model is for jobs that have already been created.
 
-The `WaitJob` model is used to wait for a job completion. Unlike `InvokeProcess`, which automatically creates a job, this model is intended for scenarios where
-the job has already been created.
-
-#### Attributes:
-
--   **job** (Job): The instance of the job that the agent will wait for. This should be a valid job object that has been previously created.
--   **process_folder_path** (Optional[str]): The folder path of the process.
-
-#### Example:
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `job` | `Job` | The instance of the job to wait for. |
+| `process_folder_path` | `str | None` | The folder path of the process. |
 
 ```python
 from uipath.platform.common import WaitJob
@@ -214,5 +208,283 @@ job_output = interrupt(WaitJob(job=my_job_instance, process_folder_path="MyFolde
 ```
 
 /// info
-The return value of the interrupt is the job output. If the job did not produce any output, the return value will be the job state, e.g., `{"state": "successful"}`.
+The return value of the interrupt is the job output. If the job did not produce any output, the return value is the job state, for example `{"state": "successful"}`.
+
+**Raw variant:** `WaitJobRaw` accepts the same attributes but returns the raw `Job` object without state validation.
+///
+
+---
+
+## Context Grounding (RAG)
+
+These models drive Context Grounding operations: Deep RAG queries, ephemeral indexes, and batch transforms. Each `Create*` model starts an asynchronous operation and suspends the agent; the matching `Wait*` model resumes once the operation completes. Where a `Raw` variant exists, it returns the underlying response without validating its final status, so the agent can inspect the status itself.
+
+### CreateDeepRag
+
+Starts a Deep RAG query against a Context Grounding index and suspends the agent until the query completes.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `name` | `str` | A name for the Deep RAG task. |
+| `prompt` | `str` | The query to run against the index. |
+| `index_name` | `str | None` | The name of the Context Grounding index to query. |
+| `index_id` | `str | None` | The id of the index. Required when `is_ephemeral_index` is `True`. |
+| `glob_pattern` | `str` | Glob filter for which documents to consider. Defaults to `**`. |
+| `citation_mode` | `CitationMode` | `Skip` (default) or `Inline`. |
+| `index_folder_key` | `str | None` | The folder key of the index. |
+| `index_folder_path` | `str | None` | The folder path of the index. |
+| `is_ephemeral_index` | `bool | None` | Set to `True` when querying an ephemeral index (then `index_id` is required). |
+
+```python
+from uipath.platform.common import CreateDeepRag
+result = interrupt(CreateDeepRag(name="research", index_name="MyIndex", prompt="Summarize the contract terms"))
+```
+
+/// info
+The return value is the validated Deep RAG response (the SDK checks the task reached a successful status).
+
+**Raw variant:** `CreateDeepRagRaw` returns the raw Deep RAG response without status validation.
+///
+
+### WaitDeepRag
+
+Waits for an already-created Deep RAG task to complete.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `deep_rag` | `DeepRagCreationResponse` | The Deep RAG creation response to wait on. |
+| `index_folder_path` | `str | None` | The folder path of the index. |
+| `index_folder_key` | `str | None` | The folder key of the index. |
+
+```python
+from uipath.platform.common import WaitDeepRag
+result = interrupt(WaitDeepRag(deep_rag=my_deep_rag_response, index_folder_path="MyFolderPath"))
+```
+
+/// info
+**Raw variant:** `WaitDeepRagRaw` returns the raw Deep RAG response without status validation.
+///
+
+### CreateEphemeralIndex
+
+Creates a short-lived Context Grounding index from attachments and suspends the agent until the index is ready. Ephemeral indexes are typically created on the fly to back a Deep RAG or Batch Transform operation.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `usage` | `EphemeralIndexUsage` | What the index will be used for: `DeepRAG` or `BatchRAG`. |
+| `attachments` | `List[str]` | The attachment ids to index. |
+
+```python
+from uipath.platform.common import CreateEphemeralIndex
+from uipath.platform.context_grounding import EphemeralIndexUsage
+index = interrupt(CreateEphemeralIndex(usage=EphemeralIndexUsage.DEEP_RAG, attachments=["attachment-id-1"]))
+```
+
+/// info
+The return value is the validated index.
+
+**Raw variant:** `CreateEphemeralIndexRaw` returns the raw ephemeral index response without status validation.
+///
+
+### WaitEphemeralIndex
+
+Waits for an already-created ephemeral index to become ready.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `index` | `ContextGroundingIndex` | The index instance to wait on. |
+
+```python
+from uipath.platform.common import WaitEphemeralIndex
+index = interrupt(WaitEphemeralIndex(index=my_index))
+```
+
+/// info
+**Raw variant:** `WaitEphemeralIndexRaw` returns the raw index response without status validation.
+///
+
+### CreateBatchTransform
+
+Starts a Batch Transform (batch RAG) job that applies a prompt across a set of documents and writes structured output columns to a destination, then suspends the agent until the job completes.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `name` | `str` | A name for the batch transform task. |
+| `prompt` | `str` | The prompt applied to each document. |
+| `output_columns` | `List[BatchTransformOutputColumn]` | The structured columns to extract (each with a `name` and `description`). |
+| `destination_path` | `str` | Where the transformed output is written. |
+| `index_name` | `str | None` | The name of the index to use. |
+| `index_id` | `str | None` | The id of the index. Required when `is_ephemeral_index` is `True`. |
+| `storage_bucket_folder_path_prefix` | `str | None` | Storage bucket folder prefix for source documents. |
+| `enable_web_search_grounding` | `bool` | Whether to ground answers with web search. Defaults to `False`. |
+| `index_folder_key` | `str | None` | The folder key of the index. |
+| `index_folder_path` | `str | None` | The folder path of the index. |
+| `is_ephemeral_index` | `bool | None` | Set to `True` when using an ephemeral index (then `index_id` is required). |
+
+```python
+from uipath.platform.common import CreateBatchTransform
+from uipath.platform.context_grounding import BatchTransformOutputColumn
+
+result = interrupt(
+    CreateBatchTransform(
+        name="extract-fields",
+        index_name="MyIndex",
+        prompt="Extract the vendor and total amount",
+        output_columns=[
+            BatchTransformOutputColumn(name="vendor", description="The vendor name"),
+            BatchTransformOutputColumn(name="total", description="The total amount"),
+        ],
+        destination_path="output/results",
+    )
+)
+```
+
+### WaitBatchTransform
+
+Waits for an already-created Batch Transform job to complete.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `batch_transform` | `BatchTransformCreationResponse` | The batch transform creation response to wait on. |
+| `index_folder_path` | `str | None` | The folder path of the index. |
+| `index_folder_key` | `str | None` | The folder key of the index. |
+
+```python
+from uipath.platform.common import WaitBatchTransform
+result = interrupt(WaitBatchTransform(batch_transform=my_batch_transform_response, index_folder_path="MyFolderPath"))
+```
+
+---
+
+## Document Understanding (IXP)
+
+These models extract structured data from documents and, optionally, route the result to a human for validation.
+
+### DocumentExtraction
+
+Starts an IXP extraction over a document and suspends the agent until extraction completes. Provide the document via **exactly one** of `file` or `file_path`.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `project_name` | `str` | The IXP project to run extraction with. |
+| `tag` | `str` | The project tag or version to use. |
+| `file` | `FileContent | None` | The in-memory file content to extract from. |
+| `file_path` | `str | None` | The path to the file to extract from. |
+
+```python
+from uipath.platform.common import DocumentExtraction
+extraction = interrupt(DocumentExtraction(project_name="Invoices", tag="production", file_path="invoice.pdf"))
+```
+
+/// warning
+Provide exactly one of `file` or `file_path`. Supplying both or neither raises a validation error.
+///
+
+### WaitDocumentExtraction
+
+Waits for an already-started document extraction to complete.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `extraction` | `StartExtractionResponse` | The extraction-start response to wait on. |
+
+```python
+from uipath.platform.common import WaitDocumentExtraction
+result = interrupt(WaitDocumentExtraction(extraction=my_extraction_response))
+```
+
+### DocumentExtractionValidation
+
+Routes an extraction result to a human for validation in Action Center, creating a document validation action and suspending the agent until it is handled.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `extraction_response` | `ExtractionResponseIXP` | The extraction result to validate. |
+| `action_title` | `str` | The title of the validation action. |
+| `action_catalog` | `str | None` | The action catalog to use. |
+| `action_priority` | `ActionPriority | None` | `Low`, `Medium`, `High`, or `Critical`. |
+| `action_folder` | `str | None` | The folder for the validation action. |
+| `storage_bucket_name` | `str | None` | The storage bucket used for the document. |
+| `storage_bucket_directory_path` | `str | None` | The directory path within the storage bucket. |
+
+```python
+from uipath.platform.common import DocumentExtractionValidation
+from uipath.platform.documents import ActionPriority
+
+result = interrupt(
+    DocumentExtractionValidation(
+        extraction_response=my_extraction_result,
+        action_title="Validate invoice extraction",
+        action_priority=ActionPriority.HIGH,
+    )
+)
+```
+
+### WaitDocumentExtractionValidation
+
+Waits for an already-created document validation action to be handled.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `extraction_validation` | `StartExtractionValidationResponse` | The validation-start response to wait on. |
+| `task_url` | `str | None` | The URL of the validation task. |
+
+```python
+from uipath.platform.common import WaitDocumentExtractionValidation
+result = interrupt(WaitDocumentExtractionValidation(extraction_validation=my_validation_response))
+```
+
+---
+
+## Integration Services events
+
+### WaitIntegrationEvent
+
+Suspends the agent until a remote event is delivered through Integration Services (for example a Slack message or a Teams reply). The SDK resolves `connection_name` (scoped to `connection_folder_path` when provided) to the underlying connection id and subscribes to the described event via the Connections service.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `connector` | `str` | The connector to subscribe through (for example Slack, Teams). |
+| `connection_name` | `str` | The name of the connection to use. |
+| `connection_folder_path` | `str | None` | The folder path scoping the connection. |
+| `operation` | `str` | The event operation to subscribe to. |
+| `object_name` | `str` | The remote object the event relates to. |
+| `filter_expression` | `str | None` | An optional filter narrowing which events resume the agent. |
+| `parameters` | `dict[str, str] | None` | Additional parameters for the subscription. |
+
+```python
+from uipath.platform.common import WaitIntegrationEvent
+event = interrupt(
+    WaitIntegrationEvent(
+        connector="slack",
+        connection_name="MySlackConnection",
+        operation="new_message",
+        object_name="message",
+    )
+)
+```
+
+For a practical implementation, refer to the [email-triage-agent sample](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/email-triage-agent).
+
+---
+
+## Resuming with a plain value (API trigger)
+
+All the models above are typed interrupts that tie the agent's wait state to a specific UiPath operation. When you call `interrupt(...)` with a value that is **not** one of those models, most commonly a plain string but any JSON-serializable value works, the SDK creates an **API resume trigger**. The agent suspends and waits to be resumed by an explicit external API call rather than by polling a UiPath operation.
+
+When the trigger is created the SDK generates a fresh `inbox_id` and stores the interrupted value as the trigger's request payload. The agent stays suspended until a caller posts a payload to the job's resume inbox, and that payload becomes the return value of the `interrupt(...)` call.
+
+This is the right approach for human-in-the-loop or system-to-system handoffs driven from outside the agent (a custom UI, a webhook, another service) instead of a UiPath task, job, or RAG operation.
+
+While the job is suspended, open its job details page in Orchestrator and expand **Resume conditions**. The **API** condition exposes the resume URL, which you can copy with the button next to it. Post your payload to that URL to resume the job. For the full request shape and authentication, see the [Orchestrator API triggers documentation](https://docs.uipath.com/orchestrator/automation-cloud/latest/user-guide/api-triggers).
+
+```python
+from langgraph.types import interrupt
+
+# Suspend with an arbitrary prompt or payload; the resume value is whatever the caller posts back.
+human_response = interrupt("Please review the draft and reply with your decision.")
+```
+
+/// info
+The interrupt value can be any JSON-serializable object (string, dict, and so on), and the resume value is the payload delivered to the trigger's inbox. There is no status validation, so the agent resumes with exactly what the external caller provides.
 ///

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,19 @@
 [project]
 name = "uipath-langchain"
-version = "0.12.3"
+version = "0.13.19"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.10.79, <2.12.0",
+    "uipath>=2.11.14, <2.13.0",
     "uipath-core>=0.5.20, <0.6.0",
-    "uipath-platform>=0.1.71, <0.2.0",
-    "uipath-runtime>=0.11.0, <0.12.0",
+    "uipath-platform>=0.1.86, <0.2.0",
+    "uipath-runtime>=0.11.4, <0.12.0",
     "langgraph>=1.1.8, <2.0.0",
-    "langchain-core>=1.2.11, <2.0.0",
+    "langchain-core>=1.2.27, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",
-    "langchain>=1.0.0, <2.0.0",
+    "langchain>=1.2.15, <2.0.0",
+    "deepagents>=0.5.9, <0.6.0",
     "pydantic-settings>=2.6.0",
     "python-dotenv>=1.0.1",
     "httpx>=0.27.0",
@@ -23,7 +24,7 @@ dependencies = [
     "langchain-mcp-adapters==0.2.1",
     "pillow>=12.1.1",
     "a2a-sdk>=0.2.0,<1.0.0",
-    "uipath-langchain-client[openai]>=1.14.0,<1.15.0",
+    "uipath-langchain-client[openai]>=1.14.1,<1.15.0",
 ]
 
 classifiers = [
@@ -40,21 +41,21 @@ maintainers = [
 
 [project.optional-dependencies]
 anthropic = [
-    "uipath-langchain-client[anthropic]>=1.14.0,<1.15.0",
+    "uipath-langchain-client[anthropic]>=1.14.1,<1.15.0",
 ]
 vertex = [
-    "uipath-langchain-client[google]>=1.14.0,<1.15.0",
-    "uipath-langchain-client[vertexai]>=1.14.0,<1.15.0",
+    "uipath-langchain-client[google]>=1.14.1,<1.15.0",
+    "uipath-langchain-client[vertexai]>=1.14.1,<1.15.0",
 ]
 bedrock = [
-    "uipath-langchain-client[bedrock]>=1.14.0,<1.15.0",
+    "uipath-langchain-client[bedrock]>=1.14.1,<1.15.0",
     "boto3-stubs>=1.41.4",
 ]
 fireworks = [
-    "uipath-langchain-client[fireworks]>=1.14.0,<1.15.0",
+    "uipath-langchain-client[fireworks]>=1.14.1,<1.15.0",
 ]
 all = [
-    "uipath-langchain-client[all]>=1.14.0,<1.15.0",
+    "uipath-langchain-client[all]>=1.14.1,<1.15.0",
 ]
 
 [project.entry-points."uipath.middlewares"]

--- a/samples/chat-uipath-agent/graph.py
+++ b/samples/chat-uipath-agent/graph.py
@@ -27,5 +27,5 @@ Always maintain an enthusiastic and knowledgeable tone about cinema. Provide acc
 DO NOT do any math calculations unless specifically related to movie statistics or box office figures.
 """
 
-llm = UiPathChatOpenAI(model="gpt-4o-mini-2024-07-18")
+llm = UiPathChatOpenAI(model="gpt-4.1-mini-2025-04-14")
 graph = create_agent(llm, tools=[search_tool], system_prompt=movie_system_prompt)

--- a/samples/email-triage-agent/graph.py
+++ b/samples/email-triage-agent/graph.py
@@ -92,7 +92,7 @@ class GraphState(BaseModel):
     triage_count: int = 0
 
 
-llm = UiPathChat(model="gpt-4o-mini-2024-07-18")
+llm = UiPathChat(model="gpt-4.1-mini-2025-04-14")
 
 
 def _email_str(email: dict[str, Any], *path: str, default: str = "") -> str:

--- a/samples/ticket-classification/main.py
+++ b/samples/ticket-classification/main.py
@@ -78,7 +78,7 @@ def decide_next_node(state: GraphState) -> Literal["classify", "notify_team"]:
 
 async def classify(state: GraphState) -> Command:
     """Classify the support ticket using LLM."""
-    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    llm = ChatOpenAI(model="gpt-4.1-mini-2025-04-14", temperature=0)
 
     if state.get("last_predicted_category", None):
         predicted_category = state["last_predicted_category"]

--- a/src/uipath_langchain/agent/advanced/__init__.py
+++ b/src/uipath_langchain/agent/advanced/__init__.py
@@ -1,0 +1,29 @@
+"""UiPath Advanced agent implementation."""
+
+from deepagents import CompiledSubAgent, SubAgent
+from deepagents.backends import BackendProtocol, FilesystemBackend
+from deepagents.backends.protocol import BackendFactory
+
+from .agent import create_advanced_agent, create_advanced_agent_graph
+from .types import AdvancedAgentGraphState
+from .utils import (
+    MEMORY_DIR_NAME,
+    MEMORY_INDEX_FILENAME,
+    MEMORY_INDEX_VIRTUAL_PATH,
+    create_state_with_input,
+)
+
+__all__ = [
+    "MEMORY_DIR_NAME",
+    "MEMORY_INDEX_FILENAME",
+    "MEMORY_INDEX_VIRTUAL_PATH",
+    "AdvancedAgentGraphState",
+    "BackendFactory",
+    "BackendProtocol",
+    "CompiledSubAgent",
+    "FilesystemBackend",
+    "SubAgent",
+    "create_advanced_agent",
+    "create_advanced_agent_graph",
+    "create_state_with_input",
+]

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -1,0 +1,122 @@
+"""Advanced agent builder."""
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from deepagents import CompiledSubAgent, SubAgent
+from deepagents import create_deep_agent as _create_deep_agent
+from deepagents.backends import BackendProtocol
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.protocol import BackendFactory
+from langchain.agents.structured_output import ResponseFormat
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import BaseTool
+from langgraph.graph import END, START
+from langgraph.graph.state import CompiledStateGraph, StateGraph
+from pydantic import BaseModel
+
+from uipath_langchain.agent.react.job_attachments import get_job_attachment_paths
+
+from .types import AdvancedAgentGraphState
+from .utils import (
+    MEMORY_INDEX_VIRTUAL_PATH,
+    create_state_with_input,
+    resolve_input_attachments,
+)
+
+
+def create_advanced_agent(
+    model: BaseChatModel,
+    system_prompt: str = "",
+    tools: Sequence[BaseTool] = (),
+    subagents: Sequence[SubAgent | CompiledSubAgent] = (),
+    backend: BackendProtocol | BackendFactory | None = None,
+    response_format: ResponseFormat[Any] | None = None,
+    memory: Sequence[str] = (),
+) -> CompiledStateGraph[Any, Any, Any, Any]:
+    """Create a deepagents agent with planning, filesystem, and sub-agent tools.
+
+    ``memory`` is a list of file paths loaded via deepagents' ``MemoryMiddleware``:
+    each is read from ``backend`` and injected into the system prompt every turn,
+    and the model maintains them with ``edit_file``. Empty disables the middleware.
+    """
+    return _create_deep_agent(
+        model=model,
+        system_prompt=system_prompt,
+        tools=list(tools),
+        subagents=list(subagents),
+        backend=backend,
+        response_format=response_format,
+        memory=list(memory) or None,
+    )
+
+
+def create_advanced_agent_graph(
+    model: BaseChatModel,
+    tools: Sequence[BaseTool],
+    system_prompt: str,
+    backend: BackendProtocol | BackendFactory | None,
+    response_format: ResponseFormat[Any] | None,
+    input_schema: type[BaseModel] | None,
+    output_schema: type[BaseModel],
+    build_user_message: Callable[[dict[str, Any]], str],
+) -> StateGraph[Any, Any, Any, Any]:
+    """Wrap the advanced agent in a parent graph that maps typed I/O to/from messages.
+
+    With a ``FilesystemBackend``, attachment-shaped inputs are downloaded into the
+    workspace and given a ``FilePath`` before the user message is built. A
+    ``FilesystemBackend`` also enables workspace memory: deepagents'
+    ``MemoryMiddleware`` reads ``/memory/MEMORY.md`` from the backend each turn.
+    Memory stays disabled for non-filesystem backends, which carry no workspace.
+    """
+    memory_sources = (
+        [MEMORY_INDEX_VIRTUAL_PATH] if isinstance(backend, FilesystemBackend) else []
+    )
+
+    inner_graph = create_advanced_agent(
+        model=model,
+        tools=tools,
+        system_prompt=system_prompt,
+        backend=backend,
+        response_format=response_format,
+        memory=memory_sources,
+    )
+
+    wrapper_state = create_state_with_input(input_schema)
+    internal_fields = set(AdvancedAgentGraphState.model_fields.keys())
+    attachment_paths = (
+        get_job_attachment_paths(input_schema) if input_schema is not None else []
+    )
+
+    async def transform_input_async(state: BaseModel) -> dict[str, Any]:
+        state_data = state.model_dump()
+        input_data = {k: v for k, v in state_data.items() if k not in internal_fields}
+        input_args = (
+            input_schema.model_validate(input_data).model_dump(by_alias=True)
+            if input_schema is not None
+            else {}
+        )
+        if attachment_paths:
+            input_args = await resolve_input_attachments(
+                backend, attachment_paths, input_args
+            )
+        user_text = build_user_message(input_args)
+        return {"messages": [HumanMessage(content=user_text, id="user-input")]}
+
+    def transform_output(state: BaseModel) -> dict[str, Any]:
+        structured = getattr(state, "structured_response", {})
+        return output_schema.model_validate(structured).model_dump()
+
+    wrapper: StateGraph[Any, Any, Any, Any] = StateGraph(
+        wrapper_state, input_schema=input_schema, output_schema=output_schema
+    )
+    wrapper.add_node("transform_input", transform_input_async)
+    wrapper.add_node("advanced_agent", inner_graph)
+    wrapper.add_node("transform_output", transform_output)
+    wrapper.add_edge(START, "transform_input")
+    wrapper.add_edge("transform_input", "advanced_agent")
+    wrapper.add_edge("advanced_agent", "transform_output")
+    wrapper.add_edge("transform_output", END)
+
+    return wrapper

--- a/src/uipath_langchain/agent/advanced/types.py
+++ b/src/uipath_langchain/agent/advanced/types.py
@@ -1,0 +1,14 @@
+"""State types for the advanced agent wrapper graph."""
+
+from typing import Annotated, Any
+
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+from pydantic import BaseModel
+
+
+class AdvancedAgentGraphState(BaseModel):
+    """Graph state for the advanced agent wrapper."""
+
+    messages: Annotated[list[AnyMessage], add_messages] = []
+    structured_response: dict[str, Any] = {}

--- a/src/uipath_langchain/agent/advanced/utils.py
+++ b/src/uipath_langchain/agent/advanced/utils.py
@@ -1,0 +1,110 @@
+"""Advanced agent utilities."""
+
+import asyncio
+import copy
+import logging
+import uuid
+from pathlib import Path
+from typing import Any, NamedTuple, cast
+
+from deepagents.backends import BackendProtocol, FilesystemBackend
+from deepagents.backends.protocol import BackendFactory
+from jsonpath_ng import parse as jsonpath_parse  # type: ignore[import-untyped]
+from pydantic import BaseModel
+from uipath.platform import UiPath
+from uipath.platform.attachments import Attachment
+
+from .types import AdvancedAgentGraphState
+
+logger = logging.getLogger(__name__)
+
+# --- Workspace memory layout ---
+# Durable memory lives under <workspace>/memory/: MEMORY.md is the always-loaded
+# index, entries live in <workspace>/memory/<name>.md. deepagents' MemoryMiddleware
+# handles loading/injection, but backed by the agent's FilesystemBackend (run-scoped,
+# persisted via WorkspaceHydrator) rather than the cross-run StoreBackend.
+MEMORY_DIR_NAME = "memory"
+MEMORY_INDEX_FILENAME = "MEMORY.md"
+
+# Virtual path handed to MemoryMiddleware as a source; the agent's virtual-mode
+# FilesystemBackend resolves it under the workspace root.
+MEMORY_INDEX_VIRTUAL_PATH = f"/{MEMORY_DIR_NAME}/{MEMORY_INDEX_FILENAME}"
+
+
+def create_state_with_input(
+    input_schema: type[BaseModel] | None,
+) -> type[AdvancedAgentGraphState]:
+    """Create combined state by merging AdvancedAgentGraphState with the input schema."""
+    if input_schema is None:
+        return AdvancedAgentGraphState
+    CompleteState = type(
+        "CompleteAdvancedAgentGraphState",
+        (AdvancedAgentGraphState, input_schema),
+        {},
+    )
+    cast(type[BaseModel], CompleteState).model_rebuild()
+    return CompleteState
+
+
+class _AttachmentDownload(NamedTuple):
+    """One input attachment to download and patch back into the args."""
+
+    location: Any
+    attachment_id: uuid.UUID
+    file_name: str
+    ticket: dict[str, Any]
+
+
+async def resolve_input_attachments(
+    backend: BackendProtocol | BackendFactory | None,
+    attachment_paths: list[str],
+    input_args: dict[str, Any],
+) -> dict[str, Any]:
+    """Download attachment-shaped inputs into the backend and add a ``FilePath``.
+
+    Each ticket is streamed to ``<backend.cwd>/<ID>_<name>`` and augmented with a
+    ``FilePath`` so the agent's file tools can open it. FilesystemBackend only.
+    """
+    if not isinstance(backend, FilesystemBackend):
+        raise NotImplementedError(
+            "Advanced agent with input attachments requires a FilesystemBackend, "
+            f"got {type(backend).__name__}"
+        )
+
+    result = copy.deepcopy(input_args)
+    client = UiPath()
+
+    worklist: list[_AttachmentDownload] = []
+    for path_expr in attachment_paths:
+        for match in jsonpath_parse(path_expr).find(result):
+            ticket = match.value
+            if not isinstance(ticket, dict) or "ID" not in ticket:
+                continue
+            att = Attachment.model_validate(ticket, from_attributes=True)
+            worklist.append(
+                _AttachmentDownload(
+                    location=match.full_path,
+                    attachment_id=att.id,
+                    # basename only: full_name is caller-controlled, keep the
+                    # download inside the workspace (no path traversal)
+                    file_name=f"{att.id}_{Path(att.full_name).name}",
+                    ticket=ticket,
+                )
+            )
+
+    logger.info(
+        "Downloading %d input attachment(s) into %s", len(worklist), backend.cwd
+    )
+
+    await asyncio.gather(
+        *(
+            client.attachments.download_async(
+                key=item.attachment_id,
+                destination_path=str(backend.cwd / item.file_name),
+            )
+            for item in worklist
+        )
+    )
+    for item in worklist:
+        item.location.update(result, {**item.ticket, "FilePath": f"/{item.file_name}"})
+    return result

--- a/src/uipath_langchain/agent/exceptions/licensing.py
+++ b/src/uipath_langchain/agent/exceptions/licensing.py
@@ -1,13 +1,9 @@
 """Convert LLM provider HTTP errors into structured AgentRuntimeErrors.
 
-Each LLM provider wraps HTTP errors in a different exception type:
-- OpenAI: openai.PermissionDeniedError  → e.status_code
-- Vertex: google.genai.errors.ClientError → e.code
-- Bedrock: botocore.exceptions.ClientError → e.response dict
-
-This module extracts the HTTP status code from any of these and re-raises
-as an AgentRuntimeError so that upstream error handling (exception mapper,
-CAS bridge) can categorise by status code without provider-specific logic.
+Provider exceptions are first normalized to a common ``ProviderError`` (status_code + detail).
+This module maps that status code to an AgentRuntimeError so
+upstream handling (exception mapper, CAS bridge) can categorise by status code
+without provider-specific logic.
 """
 
 from uipath.runtime.errors import UiPathErrorCategory
@@ -16,39 +12,7 @@ from uipath_langchain.agent.exceptions.exceptions import (
     AgentRuntimeError,
     AgentRuntimeErrorCode,
 )
-
-
-def _extract_status_code(e: BaseException) -> int | None:
-    """Extract HTTP status code from any provider-specific exception.
-
-    Supports OpenAI (status_code), Vertex/google.genai (code), and
-    Bedrock/botocore (response dict). Walks __cause__ chain to handle
-    LangChain wrapper exceptions (e.g. ChatGoogleGenerativeAIError).
-    """
-    # OpenAI: e.status_code
-    sc = getattr(e, "status_code", None)
-    if isinstance(sc, int):
-        return sc
-
-    # Vertex (google.genai.errors.APIError): e.code
-    sc = getattr(e, "code", None)
-    if isinstance(sc, int):
-        return sc
-
-    # Bedrock (botocore.exceptions.ClientError): e.response dict
-    resp = getattr(e, "response", None)
-    if isinstance(resp, dict):
-        sc = resp.get("ResponseMetadata", {}).get("HTTPStatusCode")
-        if isinstance(sc, int):
-            return sc
-
-    # Walk __cause__ chain
-    cause = getattr(e, "__cause__", None)
-    if cause is not None and cause is not e:
-        return _extract_status_code(cause)
-
-    return None
-
+from uipath_langchain.chat.provider_errors import extract_provider_error
 
 # Maps known LLM Gateway status codes to specific error codes.
 # Unknown status codes fall back to HTTP_ERROR.
@@ -60,27 +24,25 @@ _LLM_STATUS_CODE_MAP: dict[int, AgentRuntimeErrorCode] = {
 def raise_for_provider_http_error(e: BaseException) -> None:
     """Re-raise provider-specific HTTP errors as a structured AgentRuntimeError.
 
-    Extracts the HTTP status code from any LLM provider exception and
-    converts it to an AgentRuntimeError with the status code preserved.
-    Known status codes (e.g. 403) get a specific error code so upstream
-    handlers can match on the suffix. Does nothing if no HTTP status code
-    can be extracted.
+    Extracts the HTTP status code and the gateway's ``detail``
+    from any LLM provider exception and converts it to an
+    AgentRuntimeError. Does nothing if no HTTP status code can be extracted.
     """
-    sc = _extract_status_code(e)
-    if sc is None:
+    err = extract_provider_error(e)
+    if err.status_code is None:
         return
 
-    code = _LLM_STATUS_CODE_MAP.get(sc, AgentRuntimeErrorCode.HTTP_ERROR)
-
-    if sc == 403:
-        category = UiPathErrorCategory.DEPLOYMENT
-    else:
-        category = UiPathErrorCategory.UNKNOWN
+    code = _LLM_STATUS_CODE_MAP.get(err.status_code, AgentRuntimeErrorCode.HTTP_ERROR)
+    category = (
+        UiPathErrorCategory.DEPLOYMENT
+        if err.status_code == 403
+        else UiPathErrorCategory.UNKNOWN
+    )
 
     raise AgentRuntimeError(
         code=code,
-        title=f"LLM provider returned HTTP {sc}",
-        detail=str(e),
+        title=f"LLM provider returned HTTP {err.status_code}",
+        detail=err.detail or str(e),
         category=category,
-        status=sc,
+        status=err.status_code,
     ) from e

--- a/src/uipath_langchain/agent/guardrails/actions/escalate_action.py
+++ b/src/uipath_langchain/agent/guardrails/actions/escalate_action.py
@@ -16,7 +16,10 @@ from uipath._utils import UiPathUrl
 from uipath.agent.models.agent import (
     AgentEscalationRecipient,
     AssetRecipient,
+    CustomAssigneesRecipient,
+    RoundRobinRecipient,
     StandardRecipient,
+    WorkloadRecipient,
 )
 from uipath.platform import UiPath
 from uipath.platform.action_center.tasks import Task, TaskRecipient
@@ -31,6 +34,7 @@ from ...exceptions import AgentRuntimeError, AgentRuntimeErrorCode
 from ...messages.message_utils import replace_tool_calls
 from ...react.types import AgentGuardrailsGraphState
 from ...react.utils import extract_current_tool_call_index, find_latest_ai_message
+from ...tools.escalation_recipient import resolve_recipient_value
 from ..types import ExecutionStage
 from ..utils import _extract_tool_args_from_message, get_message_content
 from .base_action import GuardrailAction, GuardrailActionNodes
@@ -114,9 +118,8 @@ class EscalateAction(GuardrailAction):
             if existing_task is not None:
                 return {}
 
-            # Lazy import to avoid circular dependency with escalation_tool
+            # Lazy imports to avoid circular dependencies within the agent package
             from ...react.types import AgentGraphState
-            from ...tools.escalation_tool import resolve_recipient_value
             from ...tools.utils import sanitize_dict_for_serialization
 
             internal_fields = set(AgentGraphState.model_fields.keys())
@@ -139,6 +142,12 @@ class EscalateAction(GuardrailAction):
             elif isinstance(self.recipient, AssetRecipient):
                 metadata["escalation_data"]["assigned_to"] = (
                     task_recipient.value if task_recipient else None
+                )
+            elif isinstance(self.recipient, (WorkloadRecipient, RoundRobinRecipient)):
+                metadata["escalation_data"]["assigned_to"] = self.recipient.display_name
+            elif isinstance(self.recipient, CustomAssigneesRecipient):
+                metadata["escalation_data"]["assigned_to"] = (
+                    self.recipient.display_name or self.recipient.value
                 )
 
             # Validate message count based on execution stage

--- a/src/uipath_langchain/agent/react/agent.py
+++ b/src/uipath_langchain/agent/react/agent.py
@@ -178,18 +178,21 @@ def create_agent(
     tool_node_names = list(tool_nodes_with_guardrails.keys())
 
     if config.is_conversational:
-        route_agent = create_route_agent_conversational()
-        target_node_names = [
+        target_node_names: list[str] = [
             *tool_node_names,
             AgentGraphNode.TERMINATE,
         ]
+        route_agent = create_route_agent_conversational(valid_targets=target_node_names)
     else:
-        route_agent = create_route_agent(config.thinking_messages_limit)
         target_node_names = [
             AgentGraphNode.AGENT,
             *tool_node_names,
             AgentGraphNode.TERMINATE,
         ]
+        route_agent = create_route_agent(
+            valid_targets=target_node_names,
+            thinking_messages_limit=config.thinking_messages_limit,
+        )
 
     builder.add_conditional_edges(
         AgentGraphNode.AGENT,

--- a/src/uipath_langchain/agent/react/router.py
+++ b/src/uipath_langchain/agent/react/router.py
@@ -1,5 +1,6 @@
 """Routing functions for conditional edges in the agent graph."""
 
+from collections.abc import Container
 from typing import Literal
 
 from uipath.runtime.errors import UiPathErrorCategory
@@ -13,12 +14,15 @@ from .utils import (
 )
 
 
-def create_route_agent(thinking_messages_limit: int = 0):
+def create_route_agent(
+    thinking_messages_limit: int = 0,
+    valid_targets: Container[str] | None = None,
+):
     """Create a routing function configured with thinking_messages_limit.
 
     Args:
         thinking_messages_limit: Max consecutive thinking messages before error
-
+        valid_targets: Allowed routing destinations
     Returns:
         Routing function for LangGraph conditional edges
     """
@@ -89,6 +93,17 @@ def create_route_agent(thinking_messages_limit: int = 0):
 
         if current_tool_name in FLOW_CONTROL_TOOLS:
             return AgentGraphNode.TERMINATE
+
+        if valid_targets is not None and current_tool_name not in valid_targets:
+            raise AgentRuntimeError(
+                code=AgentRuntimeErrorCode.ROUTING_ERROR,
+                title="Agent routed to an unknown destination",
+                detail=(
+                    f"The agent attempted to route to '{current_tool_name}', "
+                    "which is not a registered tool or control node."
+                ),
+                category=UiPathErrorCategory.SYSTEM,
+            )
 
         return current_tool_name
 

--- a/src/uipath_langchain/agent/react/router_conversational.py
+++ b/src/uipath_langchain/agent/react/router_conversational.py
@@ -1,6 +1,7 @@
 """Routing functions for conditional edges in the agent graph."""
 
 import logging
+from collections.abc import Container
 from typing import Literal
 
 from uipath.runtime.errors import UiPathErrorCategory
@@ -20,10 +21,12 @@ from .types import AgentGraphNode
 logger = logging.getLogger(__name__)
 
 
-def create_route_agent_conversational():
+def create_route_agent_conversational(valid_targets: Container[str] | None = None):
     """Create a routing function for conversational agents. It routes between agent and tool calls until
     the agent response has no tool calls, then it routes to the USER_MESSAGE_WAIT node which does an interrupt.
 
+    Args:
+        valid_targets: Allowed routing destinations
     Returns:
         Routing function for LangGraph conditional edges
     """
@@ -60,6 +63,17 @@ def create_route_agent_conversational():
 
             current_tool_call = last_message.tool_calls[current_index]
             current_tool_name = current_tool_call["name"]
+
+            if valid_targets is not None and current_tool_name not in valid_targets:
+                raise AgentRuntimeError(
+                    code=AgentRuntimeErrorCode.ROUTING_ERROR,
+                    title="Agent routed to an unknown destination",
+                    detail=(
+                        f"The agent attempted to route to '{current_tool_name}', "
+                        "which is not a registered tool or control node."
+                    ),
+                    category=UiPathErrorCategory.SYSTEM,
+                )
 
             return current_tool_name
         else:

--- a/src/uipath_langchain/agent/tools/a2a/__init__.py
+++ b/src/uipath_langchain/agent/tools/a2a/__init__.py
@@ -1,6 +1,17 @@
 """A2A (Agent-to-Agent) tools."""
 
-from .a2a_tool import (
+import os
+
+# The a2a-sdk auto-instruments its JSON-RPC transport with OpenTelemetry spans
+# (``a2a.client.transports.jsonrpc.JsonRpcTransport.*``). Those internal spans
+# surface as noisy, unparented nodes in the Execution Trace and are not a
+# meaningful representation of the call. Disable that instrumentation before the
+# SDK is imported (it reads this variable at import time), so the single A2A
+# span emitted by ``a2a_tool`` is the only node for the call. ``setdefault``
+# preserves an explicit opt-in when the variable is already set.
+os.environ.setdefault("OTEL_INSTRUMENTATION_A2A_SDK_ENABLED", "false")
+
+from .a2a_tool import (  # noqa: E402
     A2aClient,
     create_a2a_tools_and_clients,
     open_a2a_tools,

--- a/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
+++ b/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
@@ -30,10 +30,13 @@ from a2a.types import (
 from langchain_core.messages import ToolCall, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.types import Command
+from opentelemetry import trace as otel_trace
 from pydantic import BaseModel, Field
 from uipath._utils._ssl_context import get_httpx_client_kwargs
 from uipath.agent.models.agent import AgentA2aResourceConfig
+from uipath.core.tracing.span_utils import UiPathSpanUtils
 
+from uipath_langchain._utils import get_execution_folder_path
 from uipath_langchain.agent.react.types import AgentGraphState
 from uipath_langchain.agent.tools.base_uipath_structured_tool import (
     BaseUiPathStructuredTool,
@@ -65,8 +68,9 @@ class A2aClient:
     pool when done.
     """
 
-    def __init__(self, agent_card: AgentCard) -> None:
+    def __init__(self, agent_card: AgentCard, slug: str) -> None:
         self._agent_card = agent_card
+        self._slug = slug
         self._lock = asyncio.Lock()
         self._client: Client | None = None
         self._http_client: httpx.AsyncClient | None = None
@@ -80,6 +84,16 @@ class A2aClient:
                     from uipath.platform import UiPath
 
                     sdk = UiPath()
+                    folder_path = get_execution_folder_path()
+                    agent = await sdk.remote_a2a.retrieve_async(
+                        slug=self._slug, folder_path=folder_path
+                    )
+                    if not agent.a2a_url:
+                        raise ValueError(
+                            f"Remote A2A agent '{self._slug}' has no a2a_url configured"
+                        )
+                    self._agent_card.url = agent.a2a_url
+
                     client_kwargs = get_httpx_client_kwargs(
                         headers={"Authorization": f"Bearer {sdk._config.secret}"},
                     )
@@ -152,19 +166,16 @@ def _build_description(card: AgentCard) -> str:
                 skill_desc += f": {skill.description}"
             if skill_desc:
                 parts.append(f"Skill: {skill_desc}")
-    return " | ".join(parts) if parts else f"Remote A2A agent at {card.url}"
-
-
-def _resolve_a2a_url(config: AgentA2aResourceConfig) -> str:
-    """Resolve the A2A endpoint URL from the cached agent card."""
-    if config.cached_agent_card and "url" in config.cached_agent_card:
-        return config.cached_agent_card["url"]
-    raise ValueError(f"A2A resource '{config.name}' has no URL in cachedAgentCard")
+    if parts:
+        return " | ".join(parts)
+    # The card URL is resolved lazily at runtime, so it is empty or stale here;
+    # fall back to the agent name rather than exposing an internal/blank URL.
+    return f"Remote A2A agent: {card.name}" if card.name else "Remote A2A agent"
 
 
 async def _send_a2a_message(
     client: Client,
-    a2a_url: str,
+    agent_label: str,
     *,
     message: str,
     task_id: str | None,
@@ -177,10 +188,10 @@ async def _send_a2a_message(
     """
     if task_id or context_id:
         logger.info(
-            "A2A continue task=%s context=%s to %s", task_id, context_id, a2a_url
+            "A2A continue task=%s context=%s to %s", task_id, context_id, agent_label
         )
     else:
-        logger.info("A2A new message to %s", a2a_url)
+        logger.info("A2A new message to %s", agent_label)
 
     a2a_message = Message(
         role=Role.user,
@@ -218,7 +229,7 @@ async def _send_a2a_message(
         return (text or "No response received.", state, new_task_id, new_context_id)
 
     except Exception as e:
-        logger.exception("A2A request to %s failed", a2a_url)
+        logger.exception("A2A request to %s failed", agent_label)
         return (f"Error: {e}", "error", task_id, context_id)
 
 
@@ -234,7 +245,7 @@ def _create_a2a_tool(
     raw_name = agent_card.name or config.name
     tool_name = sanitize_tool_name(raw_name)
     tool_description = _build_description(agent_card)
-    a2a_url = _resolve_a2a_url(config)
+    agent_label = config.slug
 
     metadata = {
         "tool_type": "a2a",
@@ -242,10 +253,50 @@ def _create_a2a_tool(
         "slug": config.slug,
     }
 
+    async def _invoke(
+        *, message: str, task_id: str | None, context_id: str | None
+    ) -> tuple[str, str, str | None, str | None]:
+        """Send one message to the remote agent inside an A2A trace span.
+
+        The span is parented under the active tool-call span (via
+        ``UiPathSpanUtils.get_parent_context``) so the remote call nests under
+        the tool in the Execution Trace, and is marked
+        ``uipath.custom_instrumentation`` so the LLMOps exporter keeps it. The
+        a2a-sdk's own transport spans are disabled in this package's __init__,
+        so this is the single node representing the call.
+        """
+        parent_ctx = UiPathSpanUtils.get_parent_context()
+        tracer = otel_trace.get_tracer(__name__)
+        with tracer.start_as_current_span(raw_name, context=parent_ctx) as span:
+            # "openinference.span.kind" drives the SpanType shown in the UI;
+            # "toolCall" is the recognized type for a tool invocation.
+            span.set_attribute("openinference.span.kind", "toolCall")
+            span.set_attribute("type", "toolCall")
+            span.set_attribute("span_type", "toolCall")
+            span.set_attribute("uipath.custom_instrumentation", True)
+            span.set_attribute("tool_type", "a2a")
+            span.set_attribute("input", message)
+            span.set_attribute("input.value", message)
+
+            client = await a2a_client.get()
+            text, response_state, new_task_id, new_context_id = await _send_a2a_message(
+                client,
+                agent_label,
+                message=message,
+                task_id=task_id,
+                context_id=context_id,
+            )
+
+            span.set_attribute("output", text)
+            span.set_attribute("output.value", text)
+            span.set_attribute("task_state", response_state)
+            if response_state == "error":
+                span.set_status(otel_trace.StatusCode.ERROR, text)
+            return text, response_state, new_task_id, new_context_id
+
     async def _send(*, message: str) -> str:
-        client = await a2a_client.get()
-        text, state, _, _ = await _send_a2a_message(
-            client, a2a_url, message=message, task_id=None, context_id=None
+        text, state, _, _ = await _invoke(
+            message=message, task_id=None, context_id=None
         )
         return _format_response(text, state)
 
@@ -258,10 +309,7 @@ def _create_a2a_tool(
         task_id = prior.get("task_id")
         context_id = prior.get("context_id")
 
-        client = await a2a_client.get()
-        text, task_state, new_task_id, new_context_id = await _send_a2a_message(
-            client,
-            a2a_url,
+        text, task_state, new_task_id, new_context_id = await _invoke(
             message=call["args"]["message"],
             task_id=task_id,
             context_id=context_id,
@@ -341,7 +389,7 @@ def create_a2a_tools_and_clients(
                 default_output_modes=["text/plain"],
             )
 
-        a2a_client = A2aClient(agent_card)
+        a2a_client = A2aClient(agent_card, resource.slug)
         tool = _create_a2a_tool(resource, a2a_client, agent_card)
         tools.append(tool)
         clients.append(a2a_client)

--- a/src/uipath_langchain/agent/tools/datafabric_tool/datafabric_subgraph.py
+++ b/src/uipath_langchain/agent/tools/datafabric_tool/datafabric_subgraph.py
@@ -13,7 +13,8 @@ retry path remains intact.
 
 import asyncio
 import logging
-from typing import Annotated, Any
+from contextlib import contextmanager
+from typing import Annotated, Any, Iterator
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
@@ -30,12 +31,24 @@ from langgraph.graph.message import add_messages
 from langgraph.graph.state import CompiledStateGraph
 from pydantic import BaseModel
 from uipath.platform.entities import EntitiesService, Entity
+from uipath.platform.errors import EnrichedException
+
+try:
+    from uipath.platform.errors import DataFabricError
+except ImportError:
+    DataFabricError = None  # type: ignore[assignment,misc]
 
 from ..datafabric_query_tool import DataFabricQueryTool
 from . import datafabric_prompt_builder
 from .models import DataFabricExecuteSqlInput
 
 logger = logging.getLogger(__name__)
+CATEGORY_MARKER = "(category: "
+
+
+@contextmanager
+def _noop_context() -> Iterator[None]:
+    yield None
 
 
 class DataFabricSubgraphState(BaseModel):
@@ -44,33 +57,124 @@ class DataFabricSubgraphState(BaseModel):
     messages: Annotated[list[AnyMessage], add_messages] = []
     iteration_count: int = 0
     last_tool_success: bool = False
+    last_error_category: str = ""
+    last_error_detail: str = ""
 
 
 class QueryExecutor:
     """Executes SQL queries against Data Fabric."""
 
-    def __init__(self, entities_service: EntitiesService) -> None:
+    def __init__(
+        self, entities_service: EntitiesService, entities: list[Entity]
+    ) -> None:
         self._entities = entities_service
+        native = [e.name for e in entities if not e.external_fields]
+        federated = [e.name for e in entities if e.external_fields]
+        self._entity_attrs: dict[str, str | int] = {
+            "df.entity_count": len(entities),
+            "df.native_entity_count": len(native),
+            "df.federated_entity_count": len(federated),
+            "df.native_entities": ", ".join(native) if native else "",
+            "df.federated_entities": ", ".join(federated) if federated else "",
+        }
 
     async def __call__(self, sql_query: str) -> dict[str, Any]:
         logger.debug("execute_sql called with SQL: %s", sql_query)
+
         try:
-            records = await self._entities.query_entity_records_async(
-                sql_query=sql_query,
+            from opentelemetry import trace as otel_trace
+
+            tracer = otel_trace.get_tracer("uipath_langchain.datafabric")
+        except ImportError:
+            tracer = None
+
+        span_ctx = (
+            tracer.start_as_current_span(
+                "Data Fabric SQL query",
+                attributes={
+                    "openinference.span.kind": "TOOL",
+                    "span_type": "datafabricQuery",
+                    "uipath.custom_instrumentation": True,
+                    "df.sql_query": sql_query,
+                    **self._entity_attrs,
+                },
             )
-            return {
-                "records": records,
-                "total_count": len(records),
-                "sql_query": sql_query,
-            }
-        except Exception as e:
-            logger.error("SQL query failed: %s", e)
-            return {
-                "records": [],
-                "total_count": 0,
-                "error": str(e),
-                "sql_query": sql_query,
-            }
+            if tracer
+            else _noop_context()
+        )
+
+        with span_ctx as span:
+            try:
+                records = await self._entities.query_entity_records_async(
+                    sql_query=sql_query,
+                )
+                if span is not None:
+                    span.set_attribute("df.record_count", len(records))
+                    span.set_attribute("df.success", True)
+                return {
+                    "records": records,
+                    "total_count": len(records),
+                    "sql_query": sql_query,
+                }
+            except Exception as e:
+                return self._handle_query_error(e, span, sql_query)
+
+    def _handle_query_error(
+        self, e: Exception, span: Any, sql_query: str
+    ) -> dict[str, Any]:
+        """Handle a failed SQL query: log, record span attributes, return error dict."""
+        logger.error("SQL query failed: %s", e)
+
+        df_error = None
+        if isinstance(e, EnrichedException) and DataFabricError is not None:
+            df_error = DataFabricError.from_enriched_exception(e)
+
+        if span is not None:
+            self._record_error_span(span, e, df_error)
+
+        return {
+            "records": [],
+            "total_count": 0,
+            "error": self._build_error_detail(e, df_error),
+            "sql_query": sql_query,
+        }
+
+    @staticmethod
+    def _record_error_span(
+        span: Any, e: Exception, df_error: "DataFabricError | None"
+    ) -> None:
+        """Set error attributes on an OTEL span."""
+        span.set_attribute("df.success", False)
+        span.set_attribute("df.error.raw", str(e)[:500])
+        if df_error:
+            if df_error.code:
+                span.set_attribute("df.error.code", df_error.code)
+            if df_error.message:
+                span.set_attribute("df.error.message", df_error.message)
+            if df_error.trace_id:
+                span.set_attribute("df.error.trace_id", df_error.trace_id)
+            span.set_attribute("df.error.category", df_error.category.value)
+
+        from opentelemetry.trace import StatusCode
+
+        span.record_exception(e)
+        span.set_status(StatusCode.ERROR, str(e)[:200])
+
+    @staticmethod
+    def _build_error_detail(exc: Exception, df_error: "DataFabricError | None") -> str:
+        """Build a structured error string for the inner LLM."""
+        if df_error and df_error.code:
+            parts = [f"[{df_error.code}]"]
+            if df_error.category.value != "unknown":
+                parts.append(f"(category: {df_error.category.value})")
+            if df_error.message:
+                parts.append(df_error.message)
+            if df_error.is_retryable:
+                parts.append("— This error is transient, retry the same query.")
+            elif df_error.is_bad_sql:
+                parts.append("— Fix the SQL syntax and retry.")
+            return " ".join(parts)
+        return str(exc)
 
 
 class DataFabricGraph:
@@ -130,16 +234,33 @@ class DataFabricGraph:
         results = await asyncio.gather(
             *[self._execute_tool_call(tc) for tc in last.tool_calls]
         )
-        tool_messages = [msg for msg, _ in results]
-        all_succeeded = bool(results) and all(success for _, success in results)
+        tool_messages = [msg for msg, _, _, _ in results]
+        all_succeeded = bool(results) and all(ok for _, ok, _, _ in results)
+
+        # Capture last error info from the most recent failed call
+        last_category = ""
+        last_detail = ""
+        for _, ok, cat, detail in reversed(results):
+            if not ok and detail:
+                last_category = cat
+                last_detail = detail
+                break
+
         return {
             "messages": tool_messages,
             "iteration_count": state.iteration_count + len(last.tool_calls),
             "last_tool_success": all_succeeded,
+            "last_error_category": last_category or state.last_error_category,
+            "last_error_detail": last_detail or state.last_error_detail,
         }
 
-    async def _execute_tool_call(self, tool_call: ToolCall) -> tuple[ToolMessage, bool]:
-        """Execute a single tool call and report whether it succeeded."""
+    async def _execute_tool_call(
+        self, tool_call: ToolCall
+    ) -> tuple[ToolMessage, bool, str, str]:
+        """Execute a single tool call and report whether it succeeded.
+
+        Returns (message, succeeded, error_category, error_detail).
+        """
         args = tool_call.get("args", {})
         try:
             result = await self._execute_sql_tool.ainvoke(args)
@@ -150,11 +271,18 @@ class DataFabricGraph:
                 "error": str(e),
                 "sql_query": args.get("sql_query", ""),
             }
+        error_str = result.get("error", "") if isinstance(result, dict) else ""
         succeeded = (
             isinstance(result, dict)
-            and not result.get("error")
+            and not error_str
             and result.get("total_count", 0) > 0
         )
+        # Extract category from structured error like "[SQL_VALIDATION] (category: bad_sql) ..."
+        error_category = ""
+        if error_str and CATEGORY_MARKER in error_str:
+            start = error_str.index(CATEGORY_MARKER) + len(CATEGORY_MARKER)
+            end = error_str.index(")", start)
+            error_category = error_str[start:end]
         return (
             ToolMessage(
                 content=str(result),
@@ -162,21 +290,22 @@ class DataFabricGraph:
                 name="execute_sql",
             ),
             succeeded,
+            error_category,
+            error_str,
         )
 
     async def termination_node(self, state: DataFabricSubgraphState) -> dict[str, Any]:
         """Produce a clear message when max iterations is reached."""
-        return {
-            "messages": [
-                AIMessage(
-                    content=(
-                        "I was unable to resolve the query after "
-                        f"{state.iteration_count} SQL attempts. "
-                        "Please try rephrasing the question or narrowing the scope."
-                    )
-                )
-            ]
-        }
+        parts = [
+            f"I was unable to resolve the query after "
+            f"{state.iteration_count} SQL attempts.",
+        ]
+        if state.last_error_category:
+            parts.append(f"Last error category: {state.last_error_category}.")
+        if state.last_error_detail:
+            parts.append(f"Last error: {state.last_error_detail[:300]}")
+        parts.append("Please try rephrasing the question or narrowing the scope.")
+        return {"messages": [AIMessage(content=" ".join(parts))]}
 
     def router(self, state: DataFabricSubgraphState) -> str:
         """Route from ``inner_llm`` to tool, termination, or END."""
@@ -214,7 +343,7 @@ class DataFabricGraph:
                 "tables and columns. Retry with a corrected query on errors."
             ),
             args_schema=DataFabricExecuteSqlInput,
-            coroutine=QueryExecutor(entities_service),
+            coroutine=QueryExecutor(entities_service, entities),
             metadata={"tool_type": "datafabric_sql"},
         )
 

--- a/src/uipath_langchain/agent/tools/escalation_memory.py
+++ b/src/uipath_langchain/agent/tools/escalation_memory.py
@@ -573,9 +573,9 @@ async def _ingest_escalation_memory(
     trace_id: str,
     user_id: str | None = None,
     folder_path: str | None = None,
+    memory_space_name: str | None = None,
 ) -> None:
     """Persist a resolved escalation outcome into memory."""
-    set_span_attribute("fromMemory", False)
     normalized_user_id = _normalize_user_id(user_id)
     if user_id is not None and normalized_user_id is None:
         logger.info(
@@ -584,32 +584,77 @@ async def _ingest_escalation_memory(
         )
 
     try:
-        request = EscalationMemoryIngestRequest(
-            span_id=parent_span_id,
-            trace_id=trace_id,
-            answer=answer,
-            attributes=attributes,
-            user_id=normalized_user_id,
+        # Keep the OTel import local to match the lookup path and keep this
+        # module importable in runtimes where tracing is not installed.
+        from opentelemetry import trace as otel_trace
+
+        tracer = otel_trace.get_tracer("uipath_langchain.memory")
+    except ImportError:
+        tracer = None
+        otel_trace = None  # type: ignore[assignment]
+
+    # Span attribute keys match what the LlmOpsHttpExporter and Studio UI expect;
+    # "openinference.span.kind" sets the SpanType.
+    ingest_span_ctx = (
+        tracer.start_as_current_span(
+            "Save escalation memory",
+            attributes={
+                "openinference.span.kind": "agentMemoryWrite",
+                "type": "agentMemoryWrite",
+                "span_type": "agentMemoryWrite",
+                "uipath.custom_instrumentation": True,
+                "memorySpaceName": memory_space_name or "",
+                "memorySpaceId": memory_space_id,
+                "strategy": ESCALATION_MEMORY_STRATEGY,
+            },
         )
-        sdk = UiPath()
-        await sdk.memory.escalation_ingest_async(
-            memory_space_id=memory_space_id,
-            request=request,
-            folder_path=folder_path,
-        )
-        set_span_attribute("savedToMemory", True)
-        logger.info(
-            "Ingested escalation outcome into memory space '%s'", memory_space_id
-        )
-    except Exception as error:
-        set_span_attribute("savedToMemory", False)
-        set_current_span_error(error)
-        logger.warning(
-            "Failed to ingest escalation outcome into memory space '%s': %s",
-            memory_space_id,
-            error,
-            exc_info=True,
-        )
+        if tracer
+        else _noop_context()
+    )
+
+    with ingest_span_ctx as ingest_span:
+        if ingest_span and hasattr(ingest_span, "set_attribute"):
+            ingest_span.set_attribute("fromMemory", False)
+        try:
+            request = EscalationMemoryIngestRequest(
+                span_id=parent_span_id,
+                trace_id=trace_id,
+                answer=answer,
+                attributes=attributes,
+                user_id=normalized_user_id,
+            )
+            # Record what was saved as a JSON string; the exporter parses it
+            # back to an object and the Studio UI reads "request" to display
+            # the persisted memory item. Mirrors the lookup span's "request".
+            if ingest_span and hasattr(ingest_span, "set_attribute"):
+                ingest_span.set_attribute(
+                    "request",
+                    _json_dumps(request.model_dump(by_alias=True, exclude_none=True)),
+                )
+            sdk = UiPath()
+            await sdk.memory.escalation_ingest_async(
+                memory_space_id=memory_space_id,
+                request=request,
+                folder_path=folder_path,
+            )
+            if ingest_span and hasattr(ingest_span, "set_attribute"):
+                ingest_span.set_attribute("savedToMemory", True)
+            logger.info(
+                "Ingested escalation outcome into memory space '%s'", memory_space_id
+            )
+        except Exception as error:
+            if ingest_span and hasattr(ingest_span, "set_attribute"):
+                ingest_span.set_attribute("savedToMemory", False)
+            if otel_trace and ingest_span and hasattr(ingest_span, "set_status"):
+                ingest_span.set_status(otel_trace.StatusCode.ERROR, repr(error))
+            if ingest_span and hasattr(ingest_span, "record_exception"):
+                ingest_span.record_exception(error)
+            logger.warning(
+                "Failed to ingest escalation outcome into memory space '%s': %s",
+                memory_space_id,
+                error,
+                exc_info=True,
+            )
 
 
 def _build_search_fields(

--- a/src/uipath_langchain/agent/tools/escalation_recipient.py
+++ b/src/uipath_langchain/agent/tools/escalation_recipient.py
@@ -1,0 +1,192 @@
+"""Escalation recipient resolution.
+
+Turns a channel's design-time recipient configuration — or an agent-inferred
+("LLM inferred") value supplied at runtime — into a concrete ``TaskRecipient``
+for Action Center assignment.
+"""
+
+import logging
+import re
+from typing import Any
+
+from uipath.agent.models.agent import (
+    AgentEscalationRecipient,
+    AgentEscalationRecipientType,
+    ArgumentEmailRecipient,
+    ArgumentGroupNameRecipient,
+    AssetRecipient,
+    CustomAssigneesRecipient,
+    RoundRobinRecipient,
+    StandardRecipient,
+    WorkloadRecipient,
+)
+from uipath.agent.utils.text_tokens import safe_get_nested
+from uipath.platform import UiPath
+from uipath.platform.action_center.tasks import TaskRecipient, TaskRecipientType
+from uipath.platform.common import UiPathConfig
+
+from uipath_langchain._utils import get_execution_folder_path
+
+from .escalation_memory import _get_user_email
+
+_logger = logging.getLogger(__name__)
+
+
+# Reserved input-schema field that carries the agent-inferred ("Custom") recipient.
+RESERVED_RECIPIENT_FIELD = "dynamic__escalationRecipient"
+
+MAX_RECIPIENTS = 50
+MAX_EMAIL_LENGTH = 254
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s.]+(?:\.[^@\s.]+)+$")
+
+
+async def _resolve_asset(asset_name: str, folder_path: str | None) -> str | None:
+    """Retrieve asset value."""
+    try:
+        client = UiPath()
+        result = await client.assets.retrieve_async(
+            name=asset_name, folder_path=folder_path
+        )
+
+        if not result or not result.value:
+            raise ValueError(f"Asset '{asset_name}' has no value configured.")
+
+        return result.value
+    except Exception as e:
+        raise ValueError(
+            f"Failed to resolve asset '{asset_name}' in folder '{folder_path}': {str(e)}"
+        ) from e
+
+
+async def _filter_to_directory_users(emails: list[str]) -> list[str]:
+    """Return only the emails that resolve to a real user in the tenant directory."""
+    org_id = UiPathConfig.organization_id
+    if not org_id:
+        return []
+    client = UiPath()
+    valid: list[str] = []
+    for email in emails:
+        try:
+            response = await client.api_client.request_async(
+                "GET",
+                f"/identity_/api/Directory/Search/{org_id}",
+                scoped="org",
+                params={
+                    "startsWith": email,
+                    "sourceFilter": ["directoryUsers", "localUsers"],
+                },
+            )
+            if any(
+                _get_user_email(entry) == email for entry in (response.json() or [])
+            ):
+                valid.append(email)
+            else:
+                _logger.warning(
+                    "LLM recipient '%s' did not match a tenant directory user; dropping",
+                    email,
+                )
+        except Exception:
+            _logger.warning(
+                "Directory lookup failed for LLM recipient '%s'; dropping",
+                email,
+                exc_info=True,
+            )
+    return valid
+
+
+async def _build_llm_recipient(raw: Any) -> TaskRecipient | None:
+    """Validate an LLM-supplied recipient value and shape it into a TaskRecipient."""
+    if isinstance(raw, str):
+        candidates = [s.strip() for s in raw.split(",")]
+    elif isinstance(raw, list):
+        candidates = [str(s).strip() for s in raw]
+    else:
+        return None
+
+    emails = [
+        c for c in candidates if c and len(c) <= MAX_EMAIL_LENGTH and _EMAIL_RE.match(c)
+    ][:MAX_RECIPIENTS]
+    if not emails:
+        _logger.warning(
+            "LLM recipient produced no valid email values; leaving task unassigned"
+        )
+        return None
+
+    valid = await _filter_to_directory_users(emails)
+    if not valid:
+        _logger.warning(
+            "LLM recipient values did not resolve to tenant users; "
+            "leaving task unassigned"
+        )
+        return None
+
+    return TaskRecipient(
+        value=valid[0],
+        values=valid,
+        type=TaskRecipientType.WORKLOAD,
+        displayName=", ".join(valid),
+    )
+
+
+async def resolve_recipient_value(
+    recipient: AgentEscalationRecipient,
+    input_args: dict[str, Any] | None = None,
+) -> TaskRecipient | None:
+    """Resolve recipient value based on recipient type."""
+    if isinstance(recipient, AssetRecipient):
+        value = await _resolve_asset(recipient.asset_name, get_execution_folder_path())
+        type = None
+        if recipient.type == AgentEscalationRecipientType.ASSET_USER_EMAIL:
+            type = TaskRecipientType.EMAIL
+        elif recipient.type == AgentEscalationRecipientType.ASSET_GROUP_NAME:
+            type = TaskRecipientType.GROUP_NAME
+        return TaskRecipient(value=value, type=type, displayName=value)
+
+    if isinstance(recipient, ArgumentEmailRecipient):
+        value = safe_get_nested(input_args or {}, recipient.argument_path)
+        if value is None:
+            raise ValueError(
+                f"Argument '{recipient.argument_path}' has no value in agent input."
+            )
+        return TaskRecipient(
+            value=value, type=TaskRecipientType.EMAIL, displayName=value
+        )
+
+    if isinstance(recipient, ArgumentGroupNameRecipient):
+        value = safe_get_nested(input_args or {}, recipient.argument_path)
+        if value is None:
+            raise ValueError(
+                f"Argument '{recipient.argument_path}' has no value in agent input."
+            )
+        return TaskRecipient(
+            value=value, type=TaskRecipientType.GROUP_NAME, displayName=value
+        )
+
+    if isinstance(recipient, WorkloadRecipient):
+        # Action Center expects the group NAME in assigneeNamesOrEmails;
+        # `value` on the agent model is the group identifier, `display_name` is the name.
+        return TaskRecipient(
+            value=recipient.display_name,
+            type=TaskRecipientType.WORKLOAD,
+            displayName=recipient.display_name,
+        )
+
+    if isinstance(recipient, RoundRobinRecipient):
+        return TaskRecipient(
+            value=recipient.display_name,
+            type=TaskRecipientType.ROUND_ROBIN,
+            displayName=recipient.display_name,
+        )
+
+    if isinstance(recipient, CustomAssigneesRecipient):
+        return None
+
+    if isinstance(recipient, StandardRecipient):
+        type = TaskRecipientType(recipient.type)
+        if recipient.type == AgentEscalationRecipientType.USER_EMAIL:
+            type = TaskRecipientType.EMAIL
+        return TaskRecipient(
+            value=recipient.value, type=type, displayName=recipient.value
+        )
+
+    return None

--- a/src/uipath_langchain/agent/tools/escalation_tool.py
+++ b/src/uipath_langchain/agent/tools/escalation_tool.py
@@ -11,21 +11,14 @@ from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel
 from uipath.agent.models.agent import (
     AgentEscalationChannel,
-    AgentEscalationRecipient,
-    AgentEscalationRecipientType,
     AgentEscalationResourceConfig,
     AgentQuickFormEscalationChannel,
-    ArgumentEmailRecipient,
-    ArgumentGroupNameRecipient,
-    AssetRecipient,
     EscalationChannel,
     LowCodeAgentDefinition,
-    StandardRecipient,
 )
-from uipath.agent.utils.text_tokens import safe_get_nested
 from uipath.eval.mocks import mockable
 from uipath.platform import UiPath
-from uipath.platform.action_center.tasks import Task, TaskRecipient, TaskRecipientType
+from uipath.platform.action_center.tasks import Task, TaskRecipient
 from uipath.platform.common import WaitEscalation
 from uipath.runtime.errors import UiPathErrorCategory
 
@@ -56,6 +49,11 @@ from .escalation_memory import (
     _ingest_escalation_memory,
     _resolve_user_id,
 )
+from .escalation_recipient import (
+    RESERVED_RECIPIENT_FIELD,
+    _build_llm_recipient,
+    resolve_recipient_value,
+)
 from .tool_node import ToolWrapperReturnType
 from .utils import (
     resolve_task_title,
@@ -71,69 +69,6 @@ class EscalationAction(str, Enum):
 
     CONTINUE = "continue"
     END = "end"
-
-
-async def resolve_recipient_value(
-    recipient: AgentEscalationRecipient,
-    input_args: dict[str, Any] | None = None,
-) -> TaskRecipient | None:
-    """Resolve recipient value based on recipient type."""
-    if isinstance(recipient, AssetRecipient):
-        value = await resolve_asset(recipient.asset_name, get_execution_folder_path())
-        type = None
-        if recipient.type == AgentEscalationRecipientType.ASSET_USER_EMAIL:
-            type = TaskRecipientType.EMAIL
-        elif recipient.type == AgentEscalationRecipientType.ASSET_GROUP_NAME:
-            type = TaskRecipientType.GROUP_NAME
-        return TaskRecipient(value=value, type=type, displayName=value)
-
-    if isinstance(recipient, ArgumentEmailRecipient):
-        value = safe_get_nested(input_args or {}, recipient.argument_path)
-        if value is None:
-            raise ValueError(
-                f"Argument '{recipient.argument_path}' has no value in agent input."
-            )
-        return TaskRecipient(
-            value=value, type=TaskRecipientType.EMAIL, displayName=value
-        )
-
-    if isinstance(recipient, ArgumentGroupNameRecipient):
-        value = safe_get_nested(input_args or {}, recipient.argument_path)
-        if value is None:
-            raise ValueError(
-                f"Argument '{recipient.argument_path}' has no value in agent input."
-            )
-        return TaskRecipient(
-            value=value, type=TaskRecipientType.GROUP_NAME, displayName=value
-        )
-
-    if isinstance(recipient, StandardRecipient):
-        type = TaskRecipientType(recipient.type)
-        if recipient.type == AgentEscalationRecipientType.USER_EMAIL:
-            type = TaskRecipientType.EMAIL
-        return TaskRecipient(
-            value=recipient.value, type=type, displayName=recipient.value
-        )
-
-    return None
-
-
-async def resolve_asset(asset_name: str, folder_path: str | None) -> str | None:
-    """Retrieve asset value."""
-    try:
-        client = UiPath()
-        result = await client.assets.retrieve_async(
-            name=asset_name, folder_path=folder_path
-        )
-
-        if not result or not result.value:
-            raise ValueError(f"Asset '{asset_name}' has no value configured.")
-
-        return result.value
-    except Exception as e:
-        raise ValueError(
-            f"Failed to resolve asset '{asset_name}' in folder '{folder_path}': {str(e)}"
-        ) from e
 
 
 def _parse_task_data(
@@ -354,20 +289,30 @@ def create_escalation_tool(
         agent_input: dict[str, Any] = (
             tool.metadata.get("agent_input") if tool.metadata else None
         ) or {}
-        recipient: TaskRecipient | None = (
-            await resolve_recipient_value(channel.recipients[0], input_args=agent_input)
-            if channel.recipients
-            else None
-        )
         folder_path = get_execution_folder_path()
+
+        serialized_data = input_model.model_validate(kwargs).model_dump(mode="json")
+
+        llm_recipient_raw = serialized_data.pop(RESERVED_RECIPIENT_FIELD, None)
+        if llm_recipient_raw is not None:
+            recipient: TaskRecipient | None = await _build_llm_recipient(
+                llm_recipient_raw
+            )
+        else:
+            recipient = (
+                await resolve_recipient_value(
+                    channel.recipients[0],
+                    input_args=agent_input,
+                )
+                if channel.recipients
+                else None
+            )
 
         task_title = "Escalation Task"
         if tool.metadata is not None:
             # Recipient requires runtime resolution, store in metadata after resolving
             tool.metadata["recipient"] = recipient
             task_title = tool.metadata.get("task_title") or task_title
-
-        serialized_data = input_model.model_validate(kwargs).model_dump(mode="json")
 
         # --- Escalation memory: check cache before creating HITL task ---
         if _memory_space_id:
@@ -489,6 +434,7 @@ def create_escalation_tool(
                 trace_id=trace_id,
                 user_id=user_id,
                 folder_path=_memory_folder_path or folder_path,
+                memory_space_name=_memory_space_name,
             )
             if user_id is None:
                 _escalation_logger.info(
@@ -547,9 +493,11 @@ def create_escalation_tool(
             "assigned_to": result.get("assigned_to"),
         }
 
+    description = resource.description
+
     tool = StructuredToolWithArgumentProperties(
         name=tool_name,
-        description=resource.description,
+        description=description,
         args_schema=input_model,
         output_type=output_model,
         coroutine=escalation_tool_fn,

--- a/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
@@ -15,6 +15,7 @@ from langchain_core.messages import (
 )
 from langchain_core.runnables.config import RunnableConfig, var_child_runnable_config
 from langchain_core.tools import StructuredTool
+from langgraph.constants import TAG_NOSTREAM
 from opentelemetry import trace as otel_trace
 from uipath.agent.models.agent import (
     AgentInternalToolResourceConfig,
@@ -136,6 +137,15 @@ def _llm_call_attachments_payload(files: list[FileInfo]) -> str | None:
             )
         )
     return json.dumps([att.model_dump(by_alias=True) for att in attachments])
+
+
+def _config_without_streaming(config: RunnableConfig | None) -> RunnableConfig:
+    """Tag config with TAG_NOSTREAM so LangGraph's StreamMessagesHandler skips
+    this LLM call — prevents its response from leaking into the conversation
+    stream as a visible content part."""
+    new_config = cast(RunnableConfig, dict(config) if config else {})
+    new_config["tags"] = [*(new_config.get("tags") or []), TAG_NOSTREAM]
+    return new_config
 
 
 def _config_with_llm_call_attachments(
@@ -327,6 +337,7 @@ def create_analyze_file_tool(
             cast(AnyMessage, human_message_with_files),
         ]
         config = var_child_runnable_config.get(None)
+        config = _config_without_streaming(config)
         config = _config_with_llm_call_attachments(config, files)
         result = await non_streaming_llm.ainvoke(messages, config=config)
 

--- a/src/uipath_langchain/agent/tools/mcp/claude.md
+++ b/src/uipath_langchain/agent/tools/mcp/claude.md
@@ -257,6 +257,46 @@ finally:
 
 Creates tools for a single MCP resource config using an existing McpClient.
 
+The discovery mode comes from `config.tools_configuration.discovery_mode`, defaulting
+to cached when `tools_configuration` is unset.
+
+**Cached mode + self-healing schema (`refresh_schema_before_call`):** `CachedToolsConfig`
+carries a `refresh_schema_before_call` flag (default `True`). When set, each tool's
+`tool_fn` calls `mcpClient.list_tools()` before `call_tool()` and compares
+the live input schema with the cached one (`_refresh_tool_schema` + `_breaking_schema_change`):
+
+- **No breaking change** (identical, or only additive/cosmetic): the call proceeds
+  against the cached schema as normal.
+- **Breaking change** (a newly required param, a dropped/renamed cached param, or a
+  type change on a shared param): the tool is **not** executed. The cached snapshot
+  (`mcp_tool`) and the model-facing `args_schema` are updated in place to the live
+  schema, and `tool_fn` returns a retry instruction (`_schema_change_message`, which
+  lists each refreshed param with its type and optionality). The ReAct loop re-binds
+  tools on the next LLM turn (`llm_node.py` binds fresh every step),
+  so the model re-issues the call against the live schema and it succeeds on retry.
+- **Tool removed** (no longer in the live `list_tools()`): the tool is **not** executed;
+  `tool_fn` returns a message (`_tool_removed_message`) telling the model the tool is
+  gone, so it stops calling it instead of retrying a doomed call.
+
+The tool wrapper reference needed to mutate `args_schema` is passed to `build_mcp_tool`
+via a small `tool_holder` dict filled right after the tool is constructed. This keeps
+the whole mechanism inside the MCP tool (the tool does not import or know about the
+ReAct loop). `list_tools()` is **not** called at tool-creation time for cached mode.
+The flag is read directly from the cached `discovery_mode.refresh_schema_before_call`
+field (default `True`).
+
+`McpClient.list_tools()` caches its result in memory, so the live list is fetched
+**once per run** and reused; `dispose()` clears the cache, so a resumed run (fresh
+client) fetches it again. The self-heal is evaluated against a tool list refreshed once
+at the start of each run (and each resume), so a schema change that lands mid-run is
+picked up on the next run or resume. `force_refresh=True` bypasses the cache for a live
+re-query.
+
+**Limitation:** tools with static argument bindings (non-empty `argument_properties`)
+are re-bound each turn from a cached copy in `StaticArgsHandler`, so the `args_schema`
+mutation may not reach the model; those tools fall back to the server's validation
+error instead of self-healing.
+
 #### `open_mcp_tools(config)` → Context Manager
 
 Async context manager that wraps `create_mcp_tools_and_clients()` with automatic

--- a/src/uipath_langchain/agent/tools/mcp/mcp_client.py
+++ b/src/uipath_langchain/agent/tools/mcp/mcp_client.py
@@ -104,6 +104,12 @@ class McpClient(UiPathDisposableProtocol):
         # Lock for both client initialization and session reinitialization
         self._lock = asyncio.Lock()
 
+        # Tool list cached in memory and fetched once per client lifetime, with its own
+        # lock so a concurrent first call does not deadlock against ``_lock`` (held by
+        # session initialization inside ``_execute_with_retry``).
+        self._tools_lock = asyncio.Lock()
+        self._tools_cache: ListToolsResult | None = None
+
         # Client state (created once, reused across session reinitializations)
         self._http_client: httpx.AsyncClient | None = None
         self._read_stream: (
@@ -340,12 +346,28 @@ class McpClient(UiPathDisposableProtocol):
 
         raise RuntimeError("Exited retry loop unexpectedly")
 
-    async def list_tools(self) -> ListToolsResult:
-        """List available tools from the MCP server."""
-        return await self._execute_with_retry(
-            lambda session: session.list_tools(),
-            "list_tools",
-        )
+    async def list_tools(self, *, force_refresh: bool = False) -> ListToolsResult:
+        """List available tools from the MCP server.
+
+        The result is cached in memory on the first successful call and reused for the
+        lifetime of this client. ``dispose()`` clears the cache, so a fresh client
+        fetches the list again on its next call. Pass ``force_refresh=True`` to re-query
+        the server and refresh the cache.
+
+        Args:
+            force_refresh: When True, re-query the server and refresh the cache.
+        """
+        if not force_refresh and self._tools_cache is not None:
+            return self._tools_cache
+        async with self._tools_lock:
+            if not force_refresh and self._tools_cache is not None:
+                return self._tools_cache
+            result = await self._execute_with_retry(
+                lambda session: session.list_tools(),
+                "list_tools",
+            )
+            self._tools_cache = result
+            return result
 
     async def call_tool(
         self,
@@ -374,19 +396,23 @@ class McpClient(UiPathDisposableProtocol):
         After calling dispose(), the client can be reused - a new call_tool()
         will reinitialize everything.
         """
-        async with self._lock:
-            if self._stack is not None:
-                try:
-                    await self._stack.__aexit__(None, None, None)
-                except Exception as e:
-                    logger.debug(f"Error during cleanup: {e}")
-                finally:
-                    self._stack = None
-                    self._session = None
-                    self._http_client = None
-                    self._read_stream = None
-                    self._write_stream = None
-                    self._session_info = None
-                    self._client_initialized = False
+        # Acquire _tools_lock before _lock (the same order list_tools uses) so the tool
+        # cache is cleared atomically with respect to an in-flight list_tools().
+        async with self._tools_lock:
+            self._tools_cache = None
+            async with self._lock:
+                if self._stack is not None:
+                    try:
+                        await self._stack.__aexit__(None, None, None)
+                    except Exception as e:
+                        logger.debug(f"Error during cleanup: {e}")
+                    finally:
+                        self._stack = None
+                        self._session = None
+                        self._http_client = None
+                        self._read_stream = None
+                        self._write_stream = None
+                        self._session_info = None
+                        self._client_initialized = False
 
-            logger.info("MCP client disposed")
+                logger.info("MCP client disposed")

--- a/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
+++ b/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
@@ -21,6 +21,134 @@ from .mcp_client import McpClient, SessionInfoFactory
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+def _breaking_schema_change(cached: dict[str, Any], live: dict[str, Any]) -> bool:
+    """Whether the live input schema differs from the cached one in a way that would
+    break a call the model built from the cached schema.
+
+    Treated as breaking (the model cannot produce a valid call without seeing the new
+    schema): a newly required parameter, a cached parameter the server dropped or
+    renamed, or a type change on a shared parameter. Purely additive or cosmetic
+    changes (new optional params, reworded descriptions) are not breaking, so the call
+    proceeds against the cached schema.
+    """
+    cached_props = cached.get("properties") or {}
+    live_props = live.get("properties") or {}
+    cached_required = set(cached.get("required") or [])
+    live_required = set(live.get("required") or [])
+
+    if live_required - cached_required:
+        return True
+    if set(cached_props) - set(live_props):
+        return True
+    for name in set(cached_props) & set(live_props):
+        if (cached_props.get(name) or {}).get("type") != (
+            live_props.get(name) or {}
+        ).get("type"):
+            return True
+    return False
+
+
+def _describe_param(name: str, spec: Any, required: bool) -> str:
+    """Format a parameter for the schema-change message, e.g. ``city (string, optional)``.
+
+    Falls back to just the name (optionally with ``(optional)``) when the param has no
+    simple JSON-schema ``type`` (unions, ``$ref``, etc.), to avoid a misleading hint.
+    """
+    type_hint = spec.get("type") if isinstance(spec, dict) else None
+    attrs: list[str] = [type_hint] if isinstance(type_hint, str) else []
+    if not required:
+        attrs.append("optional")
+    return f"{name} ({', '.join(attrs)})" if attrs else name
+
+
+def _schema_change_message(name: str, schema: dict[str, Any]) -> str:
+    """Instruction returned to the model when a cached tool's schema changed, telling
+    it to re-issue the call against the refreshed schema."""
+    props = schema.get("properties") or {}
+    required = set(schema.get("required") or [])
+    if props:
+        params = ", ".join(_describe_param(p, props[p], p in required) for p in props)
+    else:
+        params = "no parameters"
+    return (
+        f"The schema for tool '{name}' changed on the MCP server, so the tool was not "
+        f"executed. Its parameters have been refreshed to: {params}. "
+        f"Call '{name}' again using these parameters."
+    )
+
+
+def _tool_removed_message(name: str) -> str:
+    """Instruction returned to the model when a cached tool is no longer exposed by the
+    MCP server, telling it to stop calling that tool."""
+    return (
+        f"The tool '{name}' is no longer available on the MCP server, so it was not "
+        f"executed. Do not call '{name}' again; use a different tool or tell the user "
+        f"it is unavailable."
+    )
+
+
+async def _refresh_tool_schema(
+    mcp_tool: AgentMcpTool,
+    mcpClient: McpClient,
+    tool_holder: dict[str, BaseTool] | None = None,
+) -> str | None:
+    """Fetch the live tool schema before invoking a cached tool and self-heal on drift.
+
+    Lists the tools from the server (the McpClient caches this list for the lifetime of
+    the run) and compares the live input schema with the cached one. If the change would
+    break a call built from the cached schema, the cached
+    snapshot and the schema the model is bound to are updated to the live schema and a
+    retry instruction is returned; the caller must then NOT run the stale call. The
+    ReAct loop re-binds tools on the next LLM turn, so the model re-issues the call
+    against the refreshed schema.
+
+    Returns None to let the call proceed against the cached schema when there is no
+    breaking change, or, as a non-fatal fallback, when the live schema cannot be
+    fetched. When the tool is missing from the live list (removed or renamed), returns
+    a message telling the model the tool is gone so it does not retry a doomed call.
+
+    Note: tools that carry static argument bindings (non-empty argument_properties) are
+    re-bound each turn from a cached copy, so the rebind may not reach the model; such
+    tools fall back to the server's own validation error rather than self-healing.
+    """
+    try:
+        result = await mcpClient.list_tools()
+    except Exception as exc:  # noqa: BLE001 - refresh is best effort
+        logger.warning(
+            f"Could not refresh schema for tool '{mcp_tool.name}' before call; "
+            f"using cached schema. Error: {exc}"
+        )
+        return None
+
+    fresh = next((t for t in result.tools if t.name == mcp_tool.name), None)
+    if fresh is None:
+        logger.warning(
+            f"Tool '{mcp_tool.name}' is no longer exposed by the MCP server; "
+            f"the model will be told to stop calling it"
+        )
+        return _tool_removed_message(mcp_tool.name)
+
+    if not _breaking_schema_change(mcp_tool.input_schema, fresh.inputSchema):
+        return None
+
+    logger.warning(
+        f"MCP tool '{mcp_tool.name}' schema changed on the server since design time; "
+        f"refreshing the bound schema and asking the model to retry"
+    )
+    # Heal: update the cached baseline and the schema the model is bound to, so the
+    # next LLM turn re-binds the live schema and the model can build a valid call.
+    mcp_tool.input_schema = fresh.inputSchema
+    mcp_tool.output_schema = fresh.outputSchema
+    if fresh.description:
+        mcp_tool.description = fresh.description
+    tool = tool_holder.get("tool") if tool_holder else None
+    if tool is not None:
+        tool.args_schema = fresh.inputSchema
+        if fresh.description:
+            tool.description = fresh.description
+    return _schema_change_message(mcp_tool.name, fresh.inputSchema)
+
+
 @asynccontextmanager
 async def open_mcp_tools(
     config: list[AgentMcpResourceConfig],
@@ -57,9 +185,15 @@ async def create_mcp_tools(
         List of BaseTool instances, one for each tool in the config.
         Returns empty list if config.is_enabled is False.
 
-    Behavior depends on config.tools_configuration.discovery_mode:
-        - Cached (default when unset): Uses the tools and schemas saved in
-          config.available_tools.
+    Behavior depends on config.tools_configuration.discovery_mode (defaults to
+    Cached when tools_configuration is unset):
+        - Cached: Uses the tools and schemas saved in config.available_tools. When
+          the cached config has refresh_schema_before_call=True (the default), the
+          live tool schema is fetched (once per run, cached on the McpClient) and
+          compared with the design-time snapshot before a tool invocation; if it
+          changed in a breaking way, the bound schema is refreshed and the model is
+          asked to retry the call against the live schema (self-healing). A resumed run
+          uses a fresh client, which fetches the live list again.
         - Dynamic with allow_all=True: Lists all tools from the MCP
           server via mcpClient, ignoring config.available_tools as a source
           of truth.
@@ -77,9 +211,14 @@ async def create_mcp_tools(
         if config.tools_configuration is not None
         else CachedToolsConfig()
     )
+    refresh_schema_before_call = (
+        isinstance(discovery_mode, CachedToolsConfig)
+        and discovery_mode.refresh_schema_before_call
+    )
     logger.info(
         f"Loading MCP tools for server '{config.slug}' "
-        f"(discovery_mode={discovery_mode.type})"
+        f"(discovery_mode={discovery_mode.type}, "
+        f"refresh_schema_before_call={refresh_schema_before_call})"
     )
 
     config_tools_by_name = {t.name: t for t in config.available_tools}
@@ -129,26 +268,49 @@ async def create_mcp_tools(
 
     tools: list[BaseTool] = []
     for mcp_tool in mcp_tools:
-        tools.append(
-            StructuredToolWithArgumentProperties(
-                name=sanitize_tool_name(mcp_tool.name),
-                description=mcp_tool.description,
-                args_schema=mcp_tool.input_schema,
-                coroutine=build_mcp_tool(mcp_tool, mcpClient),
-                output_type=Any,
-                metadata={
-                    "tool_type": "mcp",
-                    "display_name": mcp_tool.name,
-                    "folder_path": config.folder_path,
-                    "slug": config.slug,
-                },
-                argument_properties=mcp_tool.argument_properties,
-            )
+        # The holder gives the tool's coroutine a reference back to the tool wrapper so
+        # it can refresh its own args_schema on schema drift (see _refresh_tool_schema).
+        tool_holder: dict[str, BaseTool] = {}
+        structured_tool = StructuredToolWithArgumentProperties(
+            name=sanitize_tool_name(mcp_tool.name),
+            description=mcp_tool.description,
+            args_schema=mcp_tool.input_schema,
+            coroutine=build_mcp_tool(
+                mcp_tool, mcpClient, refresh_schema_before_call, tool_holder
+            ),
+            output_type=Any,
+            metadata={
+                "tool_type": "mcp",
+                "display_name": mcp_tool.name,
+                "folder_path": config.folder_path,
+                "slug": config.slug,
+            },
+            argument_properties=mcp_tool.argument_properties,
         )
+        tool_holder["tool"] = structured_tool
+        tools.append(structured_tool)
     return tools
 
 
-def build_mcp_tool(mcp_tool: AgentMcpTool, mcpClient: McpClient) -> Any:
+def _normalize_tool_result(result: Any) -> Any:
+    """Normalize an MCP ``call_tool`` result into JSON-serializable content."""
+    content = result.content if hasattr(result, "content") else result
+    if isinstance(content, list):
+        return [
+            item.model_dump(exclude_none=True) if hasattr(item, "model_dump") else item
+            for item in content
+        ]
+    if hasattr(content, "model_dump"):
+        return content.model_dump(exclude_none=True)
+    return content
+
+
+def build_mcp_tool(
+    mcp_tool: AgentMcpTool,
+    mcpClient: McpClient,
+    refresh_schema_before_call: bool = False,
+    tool_holder: dict[str, BaseTool] | None = None,
+) -> Any:
     output_schema: Any
     if mcp_tool.output_schema:
         output_schema = mcp_tool.output_schema
@@ -164,22 +326,22 @@ def build_mcp_tool(mcp_tool: AgentMcpTool, mcpClient: McpClient) -> Any:
     async def tool_fn(**kwargs: Any) -> Any:
         """Execute MCP tool call with ephemeral session.
 
+        When ``refresh_schema_before_call`` is set (cached discovery mode), the live
+        tool schema is checked first against the McpClient's cached tool list (fetched
+        once per run). If it changed in a breaking way, the tool is not executed: the
+        bound schema is refreshed and a retry instruction is returned so the model
+        re-issues the call against the live schema on the next turn.
+
         If a session disconnect error occurs (e.g., 404 or session terminated),
         the tool will retry once by re-initializing the session.
         """
+        if refresh_schema_before_call:
+            retry_message = await _refresh_tool_schema(mcp_tool, mcpClient, tool_holder)
+            if retry_message is not None:
+                return retry_message
         result = await mcpClient.call_tool(mcp_tool.name, arguments=kwargs)
         logger.info(f"Tool call successful for {mcp_tool.name}")
-        content = result.content if hasattr(result, "content") else result
-        if isinstance(content, list):
-            return [
-                item.model_dump(exclude_none=True)
-                if hasattr(item, "model_dump")
-                else item
-                for item in content
-            ]
-        if hasattr(content, "model_dump"):
-            return content.model_dump(exclude_none=True)
-        return content
+        return _normalize_tool_result(result)
 
     return tool_fn
 

--- a/src/uipath_langchain/agent/tools/static_args.py
+++ b/src/uipath_langchain/agent/tools/static_args.py
@@ -6,6 +6,7 @@ import re
 from typing import Any, Iterator, Mapping, Sequence, TypeVar
 
 from jsonpath_ng import parse  # type: ignore[import-untyped]
+from jsonpath_ng.exceptions import JsonPathParserError  # type: ignore[import-untyped]
 from langchain_core.messages import ToolCall
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel
@@ -57,6 +58,7 @@ _SENSITIVE_ITEM_PLACEHOLDER = "<hidden>"
 def _resolve_argument_properties(
     argument_properties: Mapping[str, AgentToolArgumentProperties],
     agent_input: dict[str, Any],
+    tool_name: str | None = None,
 ) -> dict[str, ToolStaticArgument]:
     """Resolves the different variants of argument properties to static arguments."""
 
@@ -73,7 +75,21 @@ def _resolve_argument_properties(
                     is_sensitive=props.is_sensitive,
                 )
             case AgentToolArgumentArgumentProperties():
-                agent_argument = parse(props.argument_path).find(agent_input)
+                try:
+                    argument_expr = parse(props.argument_path)
+                except JsonPathParserError as e:
+                    tool_ref = f" of tool '{tool_name}'" if tool_name else ""
+                    raise AgentRuntimeError(
+                        code=AgentRuntimeErrorCode.INVALID_STATIC_ARGUMENT,
+                        title="Malformed argument path in tool configuration",
+                        detail=(
+                            f"The argument binding '{json_path}'{tool_ref} has a "
+                            f"malformed JSONPath expression {props.argument_path!r}: {e} "
+                            "Fix the argument path in the agent configuration."
+                        ),
+                        category=UiPathErrorCategory.SYSTEM,
+                    ) from e
+                agent_argument = argument_expr.find(agent_input)
                 if not agent_argument:
                     return None
                 else:
@@ -312,7 +328,7 @@ class StaticArgsHandler:
                 and tool.argument_properties
             ):
                 static_args = _resolve_argument_properties(
-                    tool.argument_properties, agent_input
+                    tool.argument_properties, agent_input, tool_name=tool.name
                 )
                 modified_tool, applied_paths = _apply_static_arguments_to_schema(
                     tool, static_args

--- a/src/uipath_langchain/chat/provider_errors.py
+++ b/src/uipath_langchain/chat/provider_errors.py
@@ -1,0 +1,95 @@
+"""Normalize LLM provider HTTP errors into a common shape.
+
+Providers behind the LLM Gateway each raise a different exception type, but all
+carry the same gateway body (``{status, detail, ...}``); only the attribute that
+holds it differs. LangChain may wrap the SDK error, so the useful fields can sit
+a few links down the ``__cause__`` chain — always together, on one link.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ProviderError:
+    """Normalized provider HTTP error: status code + user-facing detail."""
+
+    status_code: int | None = None
+    detail: str | None = None
+
+    def __bool__(self) -> bool:
+        """Truthy once we have a status code — the signal that a provider matched."""
+        return self.status_code is not None
+
+
+def _int(value: object) -> int | None:
+    """The value if it is an int (a real HTTP status), else None.
+
+    Guards against matching unrelated exceptions that happen to carry a
+    ``code``/``status_code`` attribute that isn't an HTTP status.
+    """
+    return value if isinstance(value, int) else None
+
+
+def _detail(body: object) -> str | None:
+    """The gateway ``detail`` message from a parsed body dict, if present."""
+    if isinstance(body, dict):
+        return body.get("detail")
+
+    return None
+
+
+# One extractor per provider: read that SDK's status code and detail out of the exception, if present
+# Returns an empty (falsy) ProviderError when ``e`` isn't that provider's error type
+
+
+def _from_openai(e: BaseException) -> ProviderError:
+    """OpenAI / Anthropic: ``e.status_code`` + ``e.body``."""
+    return ProviderError(
+        _int(getattr(e, "status_code", None)), _detail(getattr(e, "body", None))
+    )
+
+
+def _from_vertex(e: BaseException) -> ProviderError:
+    """Vertex / google.genai ``APIError``."""
+    return ProviderError(
+        _int(getattr(e, "code", None)), _detail(getattr(e, "details", None))
+    )
+
+
+def _from_bedrock(e: BaseException) -> ProviderError:
+    """Bedrock — same ``e.status_code`` + ``e.body`` shape as OpenAI.
+
+    Bedrock requests go through the uipath-client ``WrappedBotoClient`` shim
+    rather than boto3. On a gateway HTTP error its ``raise_for_status`` raises a
+    ``UiPathPermissionDeniedError`` (a ``UiPathAPIError`` / ``httpx.HTTPStatusError``
+    subclass) that exposes the OpenAI-style ``.status_code`` and ``.body``.
+    """
+    return ProviderError(
+        _int(getattr(e, "status_code", None)), _detail(getattr(e, "body", None))
+    )
+
+
+def _from_botocore(e: BaseException) -> ProviderError:
+    """Bedrock via legacy direct boto3 (``use_new_llm_clients=False``): a
+    ``botocore.exceptions.ClientError`` carrying everything in ``e.response``."""
+    resp = getattr(e, "response", None)
+    if not isinstance(resp, dict):
+        return ProviderError()
+    return ProviderError(
+        _int(resp.get("ResponseMetadata", {}).get("HTTPStatusCode")),
+        _detail(resp.get("Error")),
+    )
+
+
+_PROVIDERS = (_from_openai, _from_vertex, _from_bedrock, _from_botocore)
+
+
+def extract_provider_error(e: BaseException | None) -> ProviderError:
+    """Return the first provider that matches ``e`` or any of its ``__cause__`` links."""
+    if e is None:
+        return ProviderError()
+    for extract in _PROVIDERS:
+        error = extract(e)
+        if error:
+            return error
+    return extract_provider_error(e.__cause__)

--- a/src/uipath_langchain/guardrails/middlewares/_base.py
+++ b/src/uipath_langchain/guardrails/middlewares/_base.py
@@ -278,7 +278,7 @@ class BuiltInGuardrailMiddlewareMixin:
             return await middleware_instance._run_tool_guardrail(request, handler)
 
         _wrap_tool_call_func.__name__ = f"{guardrail_name}_wrap_tool_call"
-        return wrap_tool_call(_wrap_tool_call_func)  # type: ignore[call-overload]
+        return wrap_tool_call(_wrap_tool_call_func)
 
     def _build_message_hooks(
         self,

--- a/src/uipath_langchain/guardrails/middlewares/deterministic.py
+++ b/src/uipath_langchain/guardrails/middlewares/deterministic.py
@@ -212,7 +212,7 @@ class UiPathDeterministicGuardrailMiddleware:
             return tool_result
 
         _wrap_tool_call_func.__name__ = f"{guardrail_name}_wrap_tool_call"
-        _wrap_tool_call = wrap_tool_call(_wrap_tool_call_func)  # type: ignore[call-overload]
+        _wrap_tool_call = wrap_tool_call(_wrap_tool_call_func)
         instances.append(_wrap_tool_call)
 
         return instances

--- a/tests/agent/advanced/__init__.py
+++ b/tests/agent/advanced/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the advanced agent harness."""

--- a/tests/agent/advanced/test_create_advanced_agent.py
+++ b/tests/agent/advanced/test_create_advanced_agent.py
@@ -1,0 +1,71 @@
+"""Tests for create_advanced_agent."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.tools import tool
+from langgraph.graph.state import CompiledStateGraph
+from langgraph.prebuilt import ToolNode
+
+from uipath_langchain.agent.advanced.agent import create_advanced_agent
+
+
+def _make_mock_model() -> MagicMock:
+    """Create a mock model with the attributes the upstream code reads."""
+    model = MagicMock(spec=BaseChatModel)
+    # upstream reads model.profile for summarization defaults
+    model.profile = None
+    return model
+
+
+@tool
+def _sample_tool(query: str) -> str:
+    """A sample tool for testing."""
+    return query
+
+
+class TestCreateAdvancedAgent:
+    """Test the create_advanced_agent function."""
+
+    @pytest.fixture
+    def mock_model(self) -> MagicMock:
+        return _make_mock_model()
+
+    def test_advanced_agent_with_tools(self, mock_model: MagicMock) -> None:
+        """Custom tool is registered alongside built-in advanced agent tools."""
+        result = create_advanced_agent(
+            mock_model, system_prompt="test", tools=[_sample_tool]
+        )
+        assert isinstance(result, CompiledStateGraph)
+        tools_node = result.nodes["tools"].bound
+        assert isinstance(tools_node, ToolNode)
+        tool_names = set(tools_node.tools_by_name.keys())
+        assert "_sample_tool" in tool_names
+
+    def test_advanced_agent_without_tools(self, mock_model: MagicMock) -> None:
+        """Built-in advanced agent tools are present even with no custom tools."""
+        result = create_advanced_agent(mock_model, system_prompt="test", tools=[])
+        assert isinstance(result, CompiledStateGraph)
+        tools_node = result.nodes["tools"].bound
+        assert isinstance(tools_node, ToolNode)
+        tool_names = set(tools_node.tools_by_name.keys())
+        assert "write_todos" in tool_names
+
+    def test_advanced_agent_converts_sequences_to_lists(
+        self, mock_model: MagicMock
+    ) -> None:
+        """Tuples for tools and subagents are converted to lists."""
+        with patch(
+            "uipath_langchain.agent.advanced.agent._create_deep_agent"
+        ) as mock_upstream:
+            mock_upstream.return_value = MagicMock(spec=CompiledStateGraph)
+            create_advanced_agent(
+                mock_model,
+                system_prompt="test",
+                tools=(_sample_tool,),
+                subagents=(),
+            )
+            _, kwargs = mock_upstream.call_args
+            assert isinstance(kwargs["tools"], list)
+            assert isinstance(kwargs["subagents"], list)

--- a/tests/agent/advanced/test_create_advanced_agent_graph.py
+++ b/tests/agent/advanced/test_create_advanced_agent_graph.py
@@ -1,0 +1,126 @@
+"""Tests for the create_advanced_agent_graph wrapper builder."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+from pydantic import BaseModel, ConfigDict, Field
+
+from uipath_langchain.agent.advanced.agent import create_advanced_agent_graph
+from uipath_langchain.agent.advanced.types import AdvancedAgentGraphState
+from uipath_langchain.agent.advanced.utils import create_state_with_input
+
+
+class _Output(BaseModel):
+    result: str = ""
+
+
+class _Input(BaseModel):
+    book: dict[str, Any] = {}
+    question: str = ""
+
+
+class _AliasedInput(BaseModel):
+    model_config = ConfigDict(validate_by_alias=True, validate_by_name=True)
+
+    schema_: str = Field(alias="schema")
+    question: str = ""
+
+
+def _mock_model() -> MagicMock:
+    model = MagicMock(spec=BaseChatModel)
+    model.profile = None
+    return model
+
+
+def _build(**overrides: Any) -> Any:
+    kwargs: dict[str, Any] = dict(
+        model=_mock_model(),
+        tools=[],
+        system_prompt="sys",
+        backend=None,
+        response_format=None,
+        input_schema=None,
+        output_schema=_Output,
+        build_user_message=lambda args: "hello",
+    )
+    kwargs.update(overrides)
+    return create_advanced_agent_graph(**kwargs)
+
+
+def test_wrapper_graph_has_io_nodes() -> None:
+    """The wrapper wires transform_input -> advanced_agent -> transform_output."""
+    graph = _build()
+    assert {"transform_input", "advanced_agent", "transform_output"} <= set(graph.nodes)
+
+
+@pytest.mark.asyncio
+async def test_transform_input_without_schema_builds_single_user_message() -> None:
+    """With no input schema, the built message comes straight from build_user_message."""
+    graph = _build(build_user_message=lambda args: "hi there")
+    out = await graph.nodes["transform_input"].runnable.ainvoke(
+        AdvancedAgentGraphState()
+    )
+    message = out["messages"][0]
+    assert isinstance(message, HumanMessage)
+    assert message.content == "hi there"
+    assert message.id == "user-input"
+
+
+@pytest.mark.asyncio
+async def test_transform_input_resolves_attachments_when_present() -> None:
+    """With an input schema and attachment paths, input attachments are resolved first."""
+    with (
+        patch(
+            "uipath_langchain.agent.advanced.agent.get_job_attachment_paths",
+            return_value=["$.book"],
+        ),
+        patch(
+            "uipath_langchain.agent.advanced.agent.resolve_input_attachments",
+            new_callable=AsyncMock,
+        ) as mock_resolve,
+    ):
+        mock_resolve.return_value = {"book": {"FilePath": "/x"}, "question": "q"}
+        graph = _build(
+            input_schema=_Input,
+            build_user_message=lambda args: f"msg:{args['question']}",
+        )
+        state_cls = create_state_with_input(_Input)
+        state = state_cls(book={"ID": "1"}, question="q")
+        out = await graph.nodes["transform_input"].runnable.ainvoke(state)
+
+    mock_resolve.assert_awaited_once()
+    assert out["messages"][0].content == "msg:q"
+
+
+@pytest.mark.asyncio
+async def test_transform_input_passes_alias_keyed_args_to_message_builder() -> None:
+    """Input args use JSON/schema field names, including aliases."""
+    captured_args: dict[str, Any] = {}
+
+    def build_user_message(args: dict[str, Any]) -> str:
+        captured_args.update(args)
+        return f"schema:{args['schema']}"
+
+    graph = _build(
+        input_schema=_AliasedInput,
+        build_user_message=build_user_message,
+    )
+    state_cls = create_state_with_input(_AliasedInput)
+    state = state_cls(schema="invoice", question="q")
+
+    out = await graph.nodes["transform_input"].runnable.ainvoke(state)
+
+    assert captured_args == {"schema": "invoice", "question": "q"}
+    assert out["messages"][0].content == "schema:invoice"
+
+
+def test_transform_output_validates_structured_response() -> None:
+    """transform_output coerces the agent's structured_response into the output schema."""
+    graph = _build()
+    out = graph.nodes["transform_output"].runnable.invoke(
+        AdvancedAgentGraphState(structured_response={"result": "done"})
+    )
+    assert out == {"result": "done"}

--- a/tests/agent/advanced/test_memory_injection.py
+++ b/tests/agent/advanced/test_memory_injection.py
@@ -1,0 +1,129 @@
+"""Wiring test: the wrapper enables deepagents memory based on the backend.
+
+Phase 1 workspace memory is delegated to deepagents' ``MemoryMiddleware``, which
+``create_deep_agent`` builds when a ``memory=`` source list is supplied. The
+wrapper's responsibility is therefore to pass ``memory=["/memory/MEMORY.md"]``
+through to ``_create_deep_agent`` when (and only when) the backend is a
+``FilesystemBackend`` that carries a durable workspace. The actual loading and
+system-prompt injection are deepagents' concern and covered by their own tests.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from deepagents.backends.filesystem import FilesystemBackend
+from langchain_core.language_models import BaseChatModel
+from pydantic import BaseModel
+
+from uipath_langchain.agent.advanced.agent import (
+    create_advanced_agent_graph,
+)
+from uipath_langchain.agent.advanced.utils import (
+    MEMORY_INDEX_VIRTUAL_PATH,
+)
+
+
+class _Input(BaseModel):
+    """Minimal input schema for the test."""
+
+    task: str
+
+
+class _Output(BaseModel):
+    """Minimal output schema for the test."""
+
+    result: str = ""
+
+
+def _build_user_message(args: dict[str, Any]) -> str:
+    return args.get("task", "")
+
+
+def _memory_kwarg(
+    backend: Any,
+) -> Any:
+    """Build the wrapper graph and return the ``memory`` kwarg handed to deepagents."""
+    with patch(
+        "uipath_langchain.agent.advanced.agent._create_deep_agent",
+        return_value=MagicMock(),
+    ) as mock_create:
+        create_advanced_agent_graph(
+            model=MagicMock(spec=BaseChatModel),
+            tools=[],
+            system_prompt="",
+            backend=backend,
+            response_format=None,
+            input_schema=_Input,
+            output_schema=_Output,
+            build_user_message=_build_user_message,
+        )
+    return mock_create.call_args.kwargs["memory"]
+
+
+class TestWorkspaceMemoryWiring:
+    """The wrapper turns deepagents memory on for filesystem-backed workspaces."""
+
+    def test_enables_memory_for_filesystem_backend(self, tmp_path: Any) -> None:
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        assert _memory_kwarg(backend) == [MEMORY_INDEX_VIRTUAL_PATH]
+
+    def test_disables_memory_for_non_filesystem_backend(self) -> None:
+        # The default in-state backend (None) carries no durable workspace, so
+        # passing memory=None leaves MemoryMiddleware out of the stack entirely.
+        assert _memory_kwarg(None) is None
+
+
+@pytest.mark.asyncio
+class TestWrapperInputUnchanged:
+    """transform_input no longer hand-rolls a memory SystemMessage."""
+
+    async def test_transform_input_emits_only_user_message(self, tmp_path: Any) -> None:
+        # Even with a populated MEMORY.md on disk, the wrapper passes just the user
+        # message; memory injection is now MemoryMiddleware's job inside the inner
+        # agent, not the wrapper's.
+        from langchain_core.messages import HumanMessage
+        from langgraph.graph import END, START, StateGraph
+
+        from uipath_langchain.agent.advanced.types import (
+            AdvancedAgentGraphState,
+        )
+
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        (memory_dir / "MEMORY.md").write_text("- entry: x", encoding="utf-8")
+
+        captured: list[list[Any]] = []
+
+        def _make_inner() -> Any:
+            def _capture(state: AdvancedAgentGraphState) -> dict[str, Any]:
+                captured.append(list(state.messages))
+                return {"structured_response": {"result": "ok"}}
+
+            inner = StateGraph(AdvancedAgentGraphState)
+            inner.add_node("capture", _capture)
+            inner.add_edge(START, "capture")
+            inner.add_edge("capture", END)
+            return inner.compile()
+
+        with patch(
+            "uipath_langchain.agent.advanced.agent._create_deep_agent",
+            return_value=_make_inner(),
+        ):
+            wrapper = create_advanced_agent_graph(
+                model=MagicMock(spec=BaseChatModel),
+                tools=[],
+                system_prompt="",
+                backend=FilesystemBackend(root_dir=tmp_path, virtual_mode=True),
+                response_format=None,
+                input_schema=_Input,
+                output_schema=_Output,
+                build_user_message=_build_user_message,
+            ).compile()
+            await wrapper.ainvoke({"task": "do something"})
+
+        assert len(captured) == 1
+        messages = captured[0]
+        assert len(messages) == 1
+        assert isinstance(messages[0], HumanMessage)
+        assert messages[0].content == "do something"

--- a/tests/agent/advanced/test_utils.py
+++ b/tests/agent/advanced/test_utils.py
@@ -1,0 +1,130 @@
+"""Tests for advanced agent utilities."""
+
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from deepagents.backends import FilesystemBackend
+from pydantic import BaseModel
+
+from uipath_langchain.agent.advanced.types import AdvancedAgentGraphState
+from uipath_langchain.agent.advanced.utils import (
+    create_state_with_input,
+    resolve_input_attachments,
+)
+
+
+class _InputSchema(BaseModel):
+    question: str = ""
+
+
+def test_create_state_returns_base_state_when_schema_is_none() -> None:
+    """With no input schema, returns the bare AdvancedAgentGraphState."""
+    assert create_state_with_input(None) is AdvancedAgentGraphState
+
+
+def test_create_state_merges_schema_with_state() -> None:
+    """Merged state carries both the base state fields and the input schema fields."""
+    merged = create_state_with_input(_InputSchema)
+    assert "messages" in merged.model_fields
+    assert "structured_response" in merged.model_fields
+    assert "question" in merged.model_fields
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_attachments_downloads_and_adds_filepath(
+    tmp_path: Path,
+) -> None:
+    """Happy path: download each ticket and augment it with a FilePath."""
+    backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+    attachment_id = uuid.uuid4()
+    input_args = {
+        "book": {
+            "ID": str(attachment_id),
+            "FullName": "novel.txt",
+            "MimeType": "text/plain",
+        },
+        "question": "summarize",
+    }
+
+    mock_client = MagicMock()
+    mock_client.attachments.download_async = AsyncMock()
+    with patch(
+        "uipath_langchain.agent.advanced.utils.UiPath",
+        return_value=mock_client,
+    ):
+        result = await resolve_input_attachments(backend, ["$.book"], input_args)
+
+    mock_client.attachments.download_async.assert_awaited_once()
+    call_kwargs = mock_client.attachments.download_async.call_args.kwargs
+    assert call_kwargs["key"] == attachment_id
+    expected_name = f"{attachment_id}_novel.txt"
+    assert call_kwargs["destination_path"] == str(backend.cwd / expected_name)
+    assert result["book"] == {
+        "ID": str(attachment_id),
+        "FullName": "novel.txt",
+        "MimeType": "text/plain",
+        "FilePath": f"/{expected_name}",
+    }
+    assert result["question"] == "summarize"
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_attachments_skips_non_ticket_matches(
+    tmp_path: Path,
+) -> None:
+    """A path match that isn't an attachment ticket is skipped, not downloaded."""
+    backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+    input_args: dict[str, Any] = {"book": "not-a-ticket"}
+
+    mock_client = MagicMock()
+    mock_client.attachments.download_async = AsyncMock()
+    with patch(
+        "uipath_langchain.agent.advanced.utils.UiPath",
+        return_value=mock_client,
+    ):
+        result = await resolve_input_attachments(backend, ["$.book"], input_args)
+
+    mock_client.attachments.download_async.assert_not_awaited()
+    assert result == {"book": "not-a-ticket"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_attachments_sanitizes_traversal_in_name(
+    tmp_path: Path,
+) -> None:
+    """A traversal-laden FullName is reduced to its basename, staying in the workspace."""
+    backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+    attachment_id = uuid.uuid4()
+    input_args: dict[str, Any] = {
+        "book": {
+            "ID": str(attachment_id),
+            "FullName": "../../../etc/passwd",
+            "MimeType": "text/plain",
+        }
+    }
+
+    mock_client = MagicMock()
+    mock_client.attachments.download_async = AsyncMock()
+    with patch(
+        "uipath_langchain.agent.advanced.utils.UiPath",
+        return_value=mock_client,
+    ):
+        result = await resolve_input_attachments(backend, ["$.book"], input_args)
+
+    expected_name = f"{attachment_id}_passwd"
+    dest = mock_client.attachments.download_async.call_args.kwargs["destination_path"]
+    assert dest == str(backend.cwd / expected_name)
+    assert result["book"]["FilePath"] == f"/{expected_name}"
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_attachments_raises_for_non_filesystem_backend() -> None:
+    """A backend that isn't FilesystemBackend surfaces a loud NotImplementedError."""
+    input_args: dict[str, Any] = {
+        "book": {"ID": str(uuid.uuid4()), "FullName": "book.txt"}
+    }
+    with pytest.raises(NotImplementedError, match="FilesystemBackend"):
+        await resolve_input_attachments(None, ["$.book"], input_args)

--- a/tests/agent/guardrails/actions/test_escalate_action.py
+++ b/tests/agent/guardrails/actions/test_escalate_action.py
@@ -12,7 +12,10 @@ from langgraph.types import Command
 from uipath.agent.models.agent import (
     AgentEscalationRecipientType,
     AssetRecipient,
+    CustomAssigneesRecipient,
+    RoundRobinRecipient,
     StandardRecipient,
+    WorkloadRecipient,
 )
 from uipath.platform.action_center.tasks import Task, TaskRecipient, TaskRecipientType
 from uipath.platform.guardrails import GuardrailScope
@@ -249,7 +252,9 @@ class TestEscalateAction:
     )
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_node_sends_correct_data(
         self,
         mock_resolve_recipient,
@@ -327,7 +332,9 @@ class TestEscalateAction:
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_node_post_agent_with_agent_result(
         self,
         mock_resolve_recipient,
@@ -401,7 +408,9 @@ class TestEscalateAction:
             GuardrailScope.TOOL,
         ],
     )
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_node_post_execution_single_message_raises_error(
         self, mock_resolve_recipient, scope: GuardrailScope
     ):
@@ -434,7 +443,9 @@ class TestEscalateAction:
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_node_tool_pre_execution_extracts_tool_args(
         self,
         mock_resolve_recipient,
@@ -494,7 +505,9 @@ class TestEscalateAction:
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_node_tool_post_execution_extracts_tool_content(
         self,
         mock_resolve_recipient,
@@ -556,7 +569,9 @@ class TestEscalateAction:
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_node_post_execution_ai_message_with_tool_calls(
         self,
         mock_resolve_recipient,
@@ -1727,7 +1742,9 @@ class TestEscalateAction:
     )
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_resolves_recipient_correctly(
         self,
         mock_resolve_recipient,
@@ -1769,7 +1786,9 @@ class TestEscalateAction:
         assert call_kwargs["recipient"] == expected_value
 
     @pytest.mark.asyncio
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_with_asset_recipient_resolution_failure(
         self, mock_resolve_recipient
     ) -> None:
@@ -1847,7 +1866,9 @@ class TestEscalateActionMetadata:
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.interrupt")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_standard_recipient_assigned_to_uses_value(
         self, mock_resolve_recipient, mock_interrupt, mock_uipath_class, mock_config
     ):
@@ -1889,7 +1910,9 @@ class TestEscalateActionMetadata:
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.interrupt")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_standard_recipient_assigned_to_uses_display_name(
         self, mock_resolve_recipient, mock_interrupt, mock_uipath_class, mock_config
     ):
@@ -1931,7 +1954,9 @@ class TestEscalateActionMetadata:
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.interrupt")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_asset_recipient_assigned_to_uses_resolved_value(
         self, mock_resolve_recipient, mock_interrupt, mock_uipath_class, mock_config
     ):
@@ -1971,9 +1996,177 @@ class TestEscalateActionMetadata:
         assert metadata["escalation_data"]["assigned_to"] == "resolved@example.com"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "recipient_factory,expected_assigned_to",
+        [
+            (
+                lambda: WorkloadRecipient(
+                    type=AgentEscalationRecipientType.WORKLOAD,
+                    value="wl-1",
+                    display_name="Workload A",
+                ),
+                "Workload A",
+            ),
+            (
+                lambda: RoundRobinRecipient(
+                    type=AgentEscalationRecipientType.ROUND_ROBIN,
+                    value="rr-1",
+                    display_name="RoundRobin A",
+                ),
+                "RoundRobin A",
+            ),
+        ],
+    )
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
     @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value")
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.interrupt")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
+    async def test_workload_and_roundrobin_assigned_to_uses_display_name(
+        self,
+        mock_resolve_recipient,
+        mock_interrupt,
+        mock_uipath_class,
+        mock_config,
+        recipient_factory,
+        expected_assigned_to,
+    ):
+        """Workload and RoundRobin recipients surface display_name as `assigned_to`."""
+        mock_resolve_recipient.return_value = TaskRecipient(
+            value="resolved@example.com", type=TaskRecipientType.EMAIL
+        )
+        mock_config.base_url = None
+        mock_config.tenant_name = "TestTenant"
+
+        mock_task = _make_mock_task(recipient=MOCK_TASK_RECIPIENT)
+        mock_client = MagicMock()
+        mock_client.tasks.create_async = AsyncMock(return_value=mock_task)
+        mock_uipath_class.return_value = mock_client
+
+        action = EscalateAction(
+            app_name="TestApp",
+            app_folder_path="TestFolder",
+            version=1,
+            recipient=recipient_factory(),
+        )
+        guardrail = _make_default_guardrail()
+
+        _, create_task_fn, _, _ = _get_action_nodes(
+            action, guardrail, GuardrailScope.LLM, ExecutionStage.PRE_EXECUTION
+        )
+
+        state = AgentGuardrailsGraphState(
+            messages=[HumanMessage(content="Test message")],
+        )
+
+        await create_task_fn(state)
+
+        metadata = getattr(create_task_fn, "__metadata__", None)
+        assert metadata is not None
+        assert metadata["escalation_data"]["assigned_to"] == expected_assigned_to
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.interrupt")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
+    async def test_custom_assignees_assigned_to_uses_display_name(
+        self, mock_resolve_recipient, mock_interrupt, mock_uipath_class, mock_config
+    ):
+        """CustomAssignees with display_name uses it as `assigned_to`."""
+        mock_resolve_recipient.return_value = TaskRecipient(
+            value="resolved@example.com", type=TaskRecipientType.EMAIL
+        )
+        mock_config.base_url = None
+        mock_config.tenant_name = "TestTenant"
+
+        mock_task = _make_mock_task(recipient=MOCK_TASK_RECIPIENT)
+        mock_client = MagicMock()
+        mock_client.tasks.create_async = AsyncMock(return_value=mock_task)
+        mock_uipath_class.return_value = mock_client
+
+        action = EscalateAction(
+            app_name="TestApp",
+            app_folder_path="TestFolder",
+            version=1,
+            recipient=CustomAssigneesRecipient(
+                type=AgentEscalationRecipientType.CUSTOM_ASSIGNEES,
+                value="alice@example.com",
+                display_name="Alice",
+            ),
+        )
+        guardrail = _make_default_guardrail()
+
+        _, create_task_fn, _, _ = _get_action_nodes(
+            action, guardrail, GuardrailScope.LLM, ExecutionStage.PRE_EXECUTION
+        )
+
+        state = AgentGuardrailsGraphState(
+            messages=[HumanMessage(content="Test message")],
+        )
+
+        await create_task_fn(state)
+
+        metadata = getattr(create_task_fn, "__metadata__", None)
+        assert metadata is not None
+        assert metadata["escalation_data"]["assigned_to"] == "Alice"
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.interrupt")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
+    async def test_custom_assignees_assigned_to_falls_back_to_value(
+        self, mock_resolve_recipient, mock_interrupt, mock_uipath_class, mock_config
+    ):
+        """CustomAssignees without display_name falls back to value as `assigned_to`."""
+        mock_resolve_recipient.return_value = TaskRecipient(
+            value="resolved@example.com", type=TaskRecipientType.EMAIL
+        )
+        mock_config.base_url = None
+        mock_config.tenant_name = "TestTenant"
+
+        mock_task = _make_mock_task(recipient=MOCK_TASK_RECIPIENT)
+        mock_client = MagicMock()
+        mock_client.tasks.create_async = AsyncMock(return_value=mock_task)
+        mock_uipath_class.return_value = mock_client
+
+        action = EscalateAction(
+            app_name="TestApp",
+            app_folder_path="TestFolder",
+            version=1,
+            recipient=CustomAssigneesRecipient(
+                type=AgentEscalationRecipientType.CUSTOM_ASSIGNEES,
+                value="bob@example.com",
+            ),
+        )
+        guardrail = _make_default_guardrail()
+
+        _, create_task_fn, _, _ = _get_action_nodes(
+            action, guardrail, GuardrailScope.LLM, ExecutionStage.PRE_EXECUTION
+        )
+
+        state = AgentGuardrailsGraphState(
+            messages=[HumanMessage(content="Test message")],
+        )
+
+        await create_task_fn(state)
+
+        metadata = getattr(create_task_fn, "__metadata__", None)
+        assert metadata is not None
+        assert metadata["escalation_data"]["assigned_to"] == "bob@example.com"
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPathConfig")
+    @patch("uipath_langchain.agent.guardrails.actions.escalate_action.UiPath")
+    @patch(
+        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value"
+    )
     async def test_create_task_node_sets_metadata_node_type(
         self, mock_resolve_recipient, mock_uipath_class, mock_config
     ):

--- a/tests/agent/messages/test_message_utils.py
+++ b/tests/agent/messages/test_message_utils.py
@@ -13,7 +13,13 @@ from langgraph.graph.message import add_messages
 
 from uipath_langchain.agent.messages.message_utils import replace_tool_calls
 
-MessageItem = Union[BaseMessage, list[str], tuple[str, str], str, dict[str, Any]]
+MessageItem = Union[
+    BaseMessage,
+    list[str],
+    tuple[str, Union[str, list[Union[str, dict[str, Any]]]]],
+    str,
+    dict[str, Any],
+]
 
 
 class TestReplaceToolCalls:

--- a/tests/agent/react/test_router.py
+++ b/tests/agent/react/test_router.py
@@ -6,13 +6,14 @@ import pytest
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
 from pydantic import BaseModel
 from uipath.agent.react import END_EXECUTION_TOOL
+from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
     AgentRuntimeErrorCode,
 )
 from uipath_langchain.agent.react.router import create_route_agent
-from uipath_langchain.agent.react.types import AgentGraphNode
+from uipath_langchain.agent.react.types import AgentGraphNode, AgentGraphState
 
 
 class MockInnerState(BaseModel):
@@ -31,17 +32,27 @@ class MockAgentGraphState(BaseModel):
 
 # Module-level fixtures available to all test classes
 
+# Routing targets used across the test states (tools + control nodes).
+_VALID_TARGETS: list[str] = [
+    AgentGraphNode.AGENT,
+    AgentGraphNode.TERMINATE,
+    "search_tool",
+    "calculator_tool",
+    "weather_tool",
+    "test_tool",
+]
+
 
 @pytest.fixture
 def route_function_no_limit():
     """Fixture for routing function with no thinking messages limit."""
-    return create_route_agent(thinking_messages_limit=0)
+    return create_route_agent(valid_targets=_VALID_TARGETS, thinking_messages_limit=0)
 
 
 @pytest.fixture
 def route_function_with_limit():
     """Fixture for routing function with thinking messages limit of 2."""
-    return create_route_agent(thinking_messages_limit=2)
+    return create_route_agent(valid_targets=_VALID_TARGETS, thinking_messages_limit=2)
 
 
 @pytest.fixture
@@ -217,7 +228,9 @@ class TestRouteAgentThinkingMessages:
 
     def test_thinking_messages_limit_zero_forbids_thinking(self):
         """Should not allow any thinking messages when limit is 0."""
-        route_func = create_route_agent(thinking_messages_limit=0)
+        route_func = create_route_agent(
+            valid_targets=_VALID_TARGETS, thinking_messages_limit=0
+        )
         ai_message = AIMessage(content="thinking")
         state = MockAgentGraphState(
             messages=[HumanMessage(content="query"), ai_message]
@@ -232,7 +245,9 @@ class TestRouteAgentThinkingMessages:
 
     def test_thinking_messages_after_tool_execution_resets_count(self):
         """Should reset thinking count after tool execution."""
-        route_func = create_route_agent(thinking_messages_limit=1)
+        route_func = create_route_agent(
+            valid_targets=_VALID_TARGETS, thinking_messages_limit=1
+        )
         messages = [
             HumanMessage(content="query"),
             AIMessage(
@@ -286,3 +301,56 @@ class TestRouteAgentErrorHandling:
         assert exc_info.value.error_info.code == AgentRuntimeError.full_code(
             AgentRuntimeErrorCode.ROUTING_ERROR
         )
+
+
+class TestRouteAgentTargetValidation:
+    """Test guarding of router return values against valid graph targets."""
+
+    def test_unknown_target_raises_routing_error(self):
+        """Should raise ROUTING_ERROR (SYSTEM) when the routed tool is unwired."""
+        route_func = create_route_agent(
+            valid_targets=[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE, "real_tool"],
+            thinking_messages_limit=0,
+        )
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "context", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            route_func(state)
+
+        assert exc_info.value.error_info.code == AgentRuntimeError.full_code(
+            AgentRuntimeErrorCode.ROUTING_ERROR
+        )
+        assert exc_info.value.error_info.category == UiPathErrorCategory.SYSTEM
+
+    def test_known_target_returns_tool_name(self):
+        """Should return the tool name when it is in the valid target set."""
+        route_func = create_route_agent(
+            valid_targets=[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE, "real_tool"],
+            thinking_messages_limit=0,
+        )
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "real_tool", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        assert route_func(state) == "real_tool"
+
+    def test_default_valid_targets_skips_guard(self):
+        """Should skip the destination guard when valid_targets is left unset.
+
+        Backwards-compatible contract: callers predating valid_targets must keep
+        the old unguarded behavior, returning any routed tool name as-is.
+        """
+        route_func = create_route_agent(thinking_messages_limit=0)
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "unwired_tool", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        assert route_func(state) == "unwired_tool"

--- a/tests/agent/react/test_router_conversational.py
+++ b/tests/agent/react/test_router_conversational.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from pydantic import BaseModel
+from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
@@ -13,7 +14,7 @@ from uipath_langchain.agent.exceptions import (
 from uipath_langchain.agent.react.router_conversational import (
     create_route_agent_conversational,
 )
-from uipath_langchain.agent.react.types import AgentGraphNode
+from uipath_langchain.agent.react.types import AgentGraphNode, AgentGraphState
 
 
 class MockInnerState(BaseModel):
@@ -30,13 +31,26 @@ class MockAgentGraphState(BaseModel):
     inner_state: MockInnerState = MockInnerState()
 
 
+# Routing targets used across the test states (tools + control nodes).
+_VALID_TARGETS: list[str] = [
+    AgentGraphNode.AGENT,
+    AgentGraphNode.TERMINATE,
+    "search_tool",
+    "calculator_tool",
+    "weather_tool",
+    "first_tool",
+    "second_tool",
+    "third_tool",
+]
+
+
 class TestCreateRouteAgentConversational:
     """Test cases for create_route_agent_conversational function."""
 
     @pytest.fixture
     def route_function(self):
         """Fixture for the conversational routing function."""
-        return create_route_agent_conversational()
+        return create_route_agent_conversational(valid_targets=_VALID_TARGETS)
 
     @pytest.fixture
     def state_with_single_tool_call(self):
@@ -220,13 +234,64 @@ class TestRouteAgentConversationalFactory:
 
     def test_returns_callable(self):
         """Should return a callable routing function."""
-        result = create_route_agent_conversational()
+        result = create_route_agent_conversational(valid_targets=_VALID_TARGETS)
 
         assert callable(result)
 
     def test_each_call_returns_new_function(self):
         """Should return a new function instance each time."""
-        func1 = create_route_agent_conversational()
-        func2 = create_route_agent_conversational()
+        func1 = create_route_agent_conversational(valid_targets=_VALID_TARGETS)
+        func2 = create_route_agent_conversational(valid_targets=_VALID_TARGETS)
 
         assert func1 is not func2
+
+
+class TestRouteAgentConversationalTargetValidation:
+    """Test guarding of router return values against valid graph targets."""
+
+    def test_unknown_target_raises_routing_error(self):
+        """Should raise ROUTING_ERROR (SYSTEM) when the routed tool is unwired."""
+        route_func = create_route_agent_conversational(
+            valid_targets=[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE, "real_tool"],
+        )
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "context", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            route_func(state)
+
+        assert exc_info.value.error_info.code == AgentRuntimeError.full_code(
+            AgentRuntimeErrorCode.ROUTING_ERROR
+        )
+        assert exc_info.value.error_info.category == UiPathErrorCategory.SYSTEM
+
+    def test_known_target_returns_tool_name(self):
+        """Should return the tool name when it is in the valid target set."""
+        route_func = create_route_agent_conversational(
+            valid_targets=[AgentGraphNode.AGENT, AgentGraphNode.TERMINATE, "real_tool"],
+        )
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "real_tool", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        assert route_func(state) == "real_tool"
+
+    def test_default_valid_targets_skips_guard(self):
+        """Should skip the destination guard when valid_targets is left unset.
+
+        Backwards-compatible contract: callers predating valid_targets must keep
+        the old unguarded behavior, returning any routed tool name as-is.
+        """
+        route_func = create_route_agent_conversational()
+        ai_message = AIMessage(
+            content="routing",
+            tool_calls=[{"name": "unwired_tool", "args": {}, "id": "call_1"}],
+        )
+        state = AgentGraphState(messages=[HumanMessage(content="query"), ai_message])
+
+        assert route_func(state) == "unwired_tool"

--- a/tests/agent/tools/internal_tools/test_analyze_files_tool.py
+++ b/tests/agent/tools/internal_tools/test_analyze_files_tool.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables.config import RunnableConfig
+from langgraph.constants import TAG_NOSTREAM
 from pydantic import BaseModel, ConfigDict, Field
 from uipath.agent.models.agent import (
     AgentInternalAnalyzeFilesToolProperties,
@@ -26,6 +27,7 @@ from uipath_langchain.agent.tools.internal_tools.analyze_files_tool import (
     ANALYZE_FILES_SYSTEM_MESSAGE,
     LLM_CALL_ATTACHMENTS_METADATA_KEY,
     _config_with_llm_call_attachments,
+    _config_without_streaming,
     _is_pii_scope_for_files,
     _resolve_job_attachment_arguments,
     create_analyze_file_tool,
@@ -1015,6 +1017,31 @@ class TestIsPiiScopeForFiles:
         )
 
 
+class TestConfigWithoutStreaming:
+    """Tests for _config_without_streaming — ensures TAG_NOSTREAM is injected."""
+
+    def test_adds_nostream_tag_to_empty_config(self) -> None:
+        result = _config_without_streaming(None)
+        assert TAG_NOSTREAM in result["tags"]
+
+    def test_adds_nostream_tag_to_existing_config(self) -> None:
+        config: RunnableConfig = {"tags": ["existing_tag"]}
+        result = _config_without_streaming(config)
+        assert "existing_tag" in result["tags"]
+        assert TAG_NOSTREAM in result["tags"]
+
+    def test_preserves_other_config_keys(self) -> None:
+        config: RunnableConfig = {"metadata": {"key": "value"}, "tags": ["t"]}
+        result = _config_without_streaming(config)
+        assert result["metadata"] == {"key": "value"}
+        assert TAG_NOSTREAM in result["tags"]
+
+    def test_handles_config_without_tags(self) -> None:
+        config: RunnableConfig = {"metadata": {"key": "value"}}
+        result = _config_without_streaming(config)
+        assert result["tags"] == [TAG_NOSTREAM]
+
+
 class TestConfigWithLlmCallAttachments:
     """The attachments payload travels to the llmCall span via langchain config metadata."""
 
@@ -1153,3 +1180,7 @@ class TestAnalyzeFileToolPassesAttachmentsViaConfig:
         attachments = json.loads(payload)
         assert attachments[0]["id"] == att_id
         assert attachments[0]["fileName"] == "doc.pdf"
+
+        # Verify TAG_NOSTREAM is set to prevent the internal LLM response
+        # from leaking into the conversation stream as a content part.
+        assert TAG_NOSTREAM in config_arg["tags"]

--- a/tests/agent/tools/test_a2a_tool.py
+++ b/tests/agent/tools/test_a2a_tool.py
@@ -1,0 +1,383 @@
+"""Tests for A2A tool creation and URL resolution.
+
+The proxy URL is resolved lazily at runtime by retrieving the remote agent
+through the binding-aware SDK (``remote_a2a.retrieve_async``), mirroring how
+MCP servers are resolved — not from a field baked into the resource config.
+"""
+
+import os
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from a2a.client import Client
+from a2a.types import AgentCard, Message, Part, Role, TextPart
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+from uipath.agent.models.agent import AgentA2aResourceConfig
+
+import uipath_langchain.agent.tools.a2a.a2a_tool as a2a_tool
+from uipath_langchain.agent.react.types import AgentGraphState
+from uipath_langchain.agent.tools.a2a.a2a_tool import (
+    A2aClient,
+    A2aStructuredToolWithWrapper,
+    _build_description,
+    _send_a2a_message,
+    create_a2a_tools_and_clients,
+)
+
+PROXY_URL = (
+    "https://cloud.uipath.com/org/tenant/agenthub_/a2a/remote/folder/remote-agent-slug"
+)
+CACHED_URL = "https://internal.example.com/agents/remote-agent"
+
+
+def _make_resource(
+    *,
+    cached_agent_card: dict[str, Any] | None = None,
+    is_enabled: bool = True,
+) -> AgentA2aResourceConfig:
+    """Build an A2A resource config for tests."""
+    return AgentA2aResourceConfig(
+        id="resource-id",
+        name="remote-agent",
+        description="A remote A2A agent",
+        is_enabled=is_enabled,
+        slug="remote-agent-slug",
+        folder_path="Shared",
+        cached_agent_card=cached_agent_card,
+    )
+
+
+def _cached_card() -> dict[str, Any]:
+    return {
+        "url": CACHED_URL,
+        "name": "Remote Agent",
+        "description": "cached",
+        "version": "1.0.0",
+        "skills": [],
+        "capabilities": {},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+    }
+
+
+def test_create_tools_builds_one_client_per_enabled_resource() -> None:
+    resource = _make_resource(cached_agent_card=_cached_card())
+
+    tools, clients = create_a2a_tools_and_clients([resource])
+
+    assert len(tools) == 1
+    assert len(clients) == 1
+    # The client carries the slug used to resolve the proxy URL at runtime.
+    assert clients[0]._slug == "remote-agent-slug"
+    # The card is built from the cached card; the URL is not yet resolved.
+    assert clients[0]._agent_card.name == "Remote Agent"
+
+
+def test_create_tools_builds_default_card_without_cached_card() -> None:
+    resource = _make_resource(cached_agent_card=None)
+
+    tools, clients = create_a2a_tools_and_clients([resource])
+
+    assert len(tools) == 1
+    assert clients[0]._slug == "remote-agent-slug"
+    assert clients[0]._agent_card.name == "remote-agent"
+
+
+def test_create_tools_skips_disabled_resource() -> None:
+    resource = _make_resource(is_enabled=False)
+
+    tools, clients = create_a2a_tools_and_clients([resource])
+
+    assert tools == []
+    assert clients == []
+
+
+class _FakeRemoteA2aService:
+    def __init__(self, a2a_url: str | None) -> None:
+        self._a2a_url = a2a_url
+        self.calls: list[tuple[str, str | None]] = []
+
+    async def retrieve_async(self, *, slug: str, folder_path: str | None):
+        self.calls.append((slug, folder_path))
+        return SimpleNamespace(a2a_url=self._a2a_url)
+
+
+class _FakeSdk:
+    def __init__(self, a2a_url: str | None) -> None:
+        self.remote_a2a = _FakeRemoteA2aService(a2a_url)
+        self._config = SimpleNamespace(secret="token")
+
+
+def _patch_runtime(monkeypatch: pytest.MonkeyPatch, sdk: _FakeSdk) -> dict[str, Any]:
+    """Patch the SDK, folder-path resolver, and A2A client factory."""
+    import uipath.platform as uipath_platform
+    from a2a.client import ClientFactory
+
+    monkeypatch.setattr(uipath_platform, "UiPath", lambda: sdk)
+    monkeypatch.setattr(a2a_tool, "get_execution_folder_path", lambda: "Shared")
+
+    connected = SimpleNamespace(value="connected")
+
+    async def _fake_connect(agent_card, *, client_config):
+        return connected
+
+    monkeypatch.setattr(ClientFactory, "connect", staticmethod(_fake_connect))
+    return {"connected": connected}
+
+
+async def test_client_resolves_proxy_url_via_retrieve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk = _FakeSdk(a2a_url=PROXY_URL)
+    handles = _patch_runtime(monkeypatch, sdk)
+
+    card = AgentCard(
+        url=CACHED_URL,
+        name="Remote Agent",
+        description="cached",
+        version="1.0.0",
+        skills=[],
+        capabilities={},
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+    )
+    client = A2aClient(card, slug="remote-agent-slug")
+
+    result = await client.get()
+
+    assert result is handles["connected"]
+    # URL resolved from the retrieved agent's a2a_url, not the cached card URL.
+    assert card.url == PROXY_URL
+    assert sdk.remote_a2a.calls == [("remote-agent-slug", "Shared")]
+
+    await client.dispose()
+
+
+async def test_client_raises_when_agent_has_no_proxy_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk = _FakeSdk(a2a_url=None)
+    _patch_runtime(monkeypatch, sdk)
+
+    card = AgentCard(
+        url="",
+        name="Remote Agent",
+        description="",
+        version="1.0.0",
+        skills=[],
+        capabilities={},
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+    )
+    client = A2aClient(card, slug="remote-agent-slug")
+
+    with pytest.raises(ValueError, match="has no a2a_url"):
+        await client.get()
+
+
+def _agent_message(text: str, context_id: str | None = None) -> Message:
+    return Message(
+        role=Role.agent,
+        parts=[Part(root=TextPart(text=text))],
+        message_id="msg-1",
+        context_id=context_id,
+    )
+
+
+class _FakeA2aClient:
+    """Minimal stand-in for the a2a Client whose send_message yields events."""
+
+    def __init__(self, events: list[object]) -> None:
+        self._events = events
+        self.sent: list[Message] = []
+
+    async def send_message(self, message: Message):
+        self.sent.append(message)
+        for event in self._events:
+            yield event
+
+
+class _RaisingA2aClient:
+    async def send_message(self, message: Message):
+        raise RuntimeError("boom")
+        yield  # pragma: no cover - marks this as an async generator
+
+
+def test_build_description_falls_back_to_name() -> None:
+    card = AgentCard(
+        url="",
+        name="Finance Agent",
+        description="",
+        version="1.0.0",
+        skills=[],
+        capabilities={},
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+    )
+    assert _build_description(card) == "Remote A2A agent: Finance Agent"
+
+
+def test_build_description_generic_when_no_name() -> None:
+    card = AgentCard(
+        url="",
+        name="",
+        description="",
+        version="1.0.0",
+        skills=[],
+        capabilities={},
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+    )
+    assert _build_description(card) == "Remote A2A agent"
+
+
+async def test_send_a2a_message_returns_text() -> None:
+    client = _FakeA2aClient([_agent_message("pong", context_id="ctx-1")])
+    text, state, task_id, context_id = await _send_a2a_message(
+        cast(Client, client),
+        "finance-agent",
+        message="ping",
+        task_id=None,
+        context_id=None,
+    )
+    assert text == "pong"
+    assert state == "completed"
+    assert context_id == "ctx-1"
+
+
+async def test_send_a2a_message_continues_existing_task() -> None:
+    client = _FakeA2aClient([_agent_message("again", context_id="ctx-2")])
+    text, _, _, context_id = await _send_a2a_message(
+        cast(Client, client),
+        "finance-agent",
+        message="more",
+        task_id="task-1",
+        context_id="ctx-2",
+    )
+    assert text == "again"
+    assert context_id == "ctx-2"
+    # The continued message carries the prior task/context ids.
+    assert client.sent[0].task_id == "task-1"
+
+
+async def test_send_a2a_message_handles_error() -> None:
+    text, state, _, _ = await _send_a2a_message(
+        cast(Client, _RaisingA2aClient()),
+        "finance-agent",
+        message="ping",
+        task_id=None,
+        context_id=None,
+    )
+    assert state == "error"
+    assert "boom" in text
+
+
+async def test_tool_send_coroutine_sends_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resource = _make_resource(cached_agent_card=_cached_card())
+    tools, clients = create_a2a_tools_and_clients([resource])
+    fake = _FakeA2aClient([_agent_message("pong", context_id="ctx-1")])
+
+    async def _get():
+        return fake
+
+    monkeypatch.setattr(clients[0], "get", _get)
+
+    result = await tools[0].ainvoke({"message": "ping"})
+    assert "pong" in result
+
+
+async def test_tool_wrapper_persists_conversation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resource = _make_resource(cached_agent_card=_cached_card())
+    tools, clients = create_a2a_tools_and_clients([resource])
+    tool = cast(A2aStructuredToolWithWrapper, tools[0])
+    fake = _FakeA2aClient([_agent_message("pong", context_id="ctx-9")])
+
+    async def _get():
+        return fake
+
+    monkeypatch.setattr(clients[0], "get", _get)
+    wrapper: Any = tool.awrapper
+    assert wrapper is not None
+
+    call = {"name": tool.name, "args": {"message": "ping"}, "id": "call-1"}
+    command = await wrapper(tool, call, AgentGraphState())
+
+    stored = command.update["inner_state"]["tools_storage"][tool.name]
+    assert stored["context_id"] == "ctx-9"
+    assert "pong" in command.update["messages"][0].content
+
+
+def test_a2a_sdk_telemetry_suppressed_by_default() -> None:
+    """Importing the a2a package disables the a2a-sdk's own OTel transport spans.
+
+    The package __init__ runs (via the module imports above) before the a2a-sdk
+    is imported and sets the suppression default.
+    """
+    assert os.environ.get("OTEL_INSTRUMENTATION_A2A_SDK_ENABLED") == "false"
+
+
+async def test_tool_invocation_emits_custom_a2a_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invoking the tool emits one custom-instrumentation A2A span carrying the
+    toolCall kind and the message/response."""
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(otel_trace, "get_tracer", provider.get_tracer)
+
+    resource = _make_resource(cached_agent_card=_cached_card())
+    tools, clients = create_a2a_tools_and_clients([resource])
+    fake = _FakeA2aClient([_agent_message("pong", context_id="ctx-1")])
+
+    async def _get():
+        return fake
+
+    monkeypatch.setattr(clients[0], "get", _get)
+
+    result = await tools[0].ainvoke({"message": "ping"})
+    assert "pong" in result
+
+    a2a_spans = [s for s in exporter.get_finished_spans() if s.name == "Remote Agent"]
+    assert len(a2a_spans) == 1
+    attrs = a2a_spans[0].attributes or {}
+    assert attrs["uipath.custom_instrumentation"] is True
+    assert attrs["openinference.span.kind"] == "toolCall"
+    assert attrs["tool_type"] == "a2a"
+    assert attrs["input.value"] == "ping"
+    assert attrs["output.value"] == "pong"
+
+
+async def test_tool_invocation_marks_span_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed remote call sets the A2A span status to ERROR."""
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(otel_trace, "get_tracer", provider.get_tracer)
+
+    resource = _make_resource(cached_agent_card=_cached_card())
+    tools, clients = create_a2a_tools_and_clients([resource])
+
+    async def _get():
+        return _RaisingA2aClient()
+
+    monkeypatch.setattr(clients[0], "get", _get)
+
+    await tools[0].ainvoke({"message": "ping"})
+
+    a2a_spans = [s for s in exporter.get_finished_spans() if s.name == "Remote Agent"]
+    assert len(a2a_spans) == 1
+    assert a2a_spans[0].status.status_code == StatusCode.ERROR

--- a/tests/agent/tools/test_client_side_tool_validation.py
+++ b/tests/agent/tools/test_client_side_tool_validation.py
@@ -1,5 +1,9 @@
 """Tests for client-side tool filtering logic."""
 
+import asyncio
+from collections.abc import Awaitable
+from typing import Any
+
 from uipath_langchain.agent.tools.client_side_tool import (
     ClientSideToolInfo,
     apply_tool_filter,
@@ -22,6 +26,19 @@ AGENT_TOOLS: dict[str, ClientSideToolInfo] = {
         "output_schema": None,
     },
 }
+
+
+def _run_sync(awaitable: Awaitable[Any]) -> Any:
+    """Run a coroutine on a fresh event loop.
+
+    Avoids asyncio.get_event_loop() raising 'no current event loop' once an
+    earlier pytest-asyncio test has closed the thread's loop.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(awaitable)
+    finally:
+        loop.close()
 
 
 class TestApplyToolFilter:
@@ -100,12 +117,8 @@ class TestToolNotAvailableEnforcement:
 
             tool = create_client_side_tool(resource)
 
-            import asyncio
-
             assert tool.coroutine is not None
-            result = asyncio.get_event_loop().run_until_complete(
-                tool.coroutine(tool_call_id="tc-1", query="test")
-            )
+            result = _run_sync(tool.coroutine(tool_call_id="tc-1", query="test"))
 
             assert result.status == "error"
             assert "not available" in result.content
@@ -145,12 +158,8 @@ class TestToolNotAvailableEnforcement:
                 ),
             ):
                 tool = create_client_side_tool(resource)
-                import asyncio
-
                 assert tool.coroutine is not None
-                result = asyncio.get_event_loop().run_until_complete(
-                    tool.coroutine(tool_call_id="tc-1", query="test")
-                )
+                result = _run_sync(tool.coroutine(tool_call_id="tc-1", query="test"))
                 if hasattr(result, "status"):
                     assert result.status != "error"
         finally:
@@ -190,12 +199,8 @@ class TestToolNotAvailableEnforcement:
             ):
                 tool = create_client_side_tool(resource)
 
-                import asyncio
-
                 assert tool.coroutine is not None
-                result = asyncio.get_event_loop().run_until_complete(
-                    tool.coroutine(tool_call_id="tc-1", q="test")
-                )
+                result = _run_sync(tool.coroutine(tool_call_id="tc-1", q="test"))
                 if hasattr(result, "status"):
                     assert result.status != "error"
         finally:

--- a/tests/agent/tools/test_datafabric_subgraph.py
+++ b/tests/agent/tools/test_datafabric_subgraph.py
@@ -1,0 +1,698 @@
+"""Tests for the Data Fabric sub-graph module."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.constants import END
+from uipath.platform.entities import Entity
+from uipath.platform.errors import EnrichedException
+
+from uipath_langchain.agent.tools.datafabric_tool.datafabric_subgraph import (
+    CATEGORY_MARKER,
+    DataFabricGraph,
+    DataFabricSubgraphState,
+    QueryExecutor,
+    _noop_context,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeCategory(Enum):
+    BAD_SQL = "bad_sql"
+    RETRYABLE = "retryable"
+    UNKNOWN = "unknown"
+    INFRASTRUCTURE = "infrastructure"
+
+
+@dataclass(frozen=True)
+class _FakeDataFabricError:
+    code: str | None
+    message: str | None
+    trace_id: str | None
+    category: _FakeCategory
+    is_retryable: bool = False
+    is_bad_sql: bool = False
+
+
+def _make_entity(name: str, external_fields: list[str] | None = None) -> Entity:
+    """Create a minimal Entity for testing."""
+    e = MagicMock(spec=Entity)
+    e.name = name
+    e.external_fields = external_fields
+    return e
+
+
+def _make_entities_service(
+    records: list[dict[str, Any]] | None = None,
+    error: Exception | None = None,
+) -> MagicMock:
+    svc = MagicMock()
+    if error:
+        svc.query_entity_records_async = AsyncMock(side_effect=error)
+    else:
+        svc.query_entity_records_async = AsyncMock(return_value=records or [])
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# _noop_context
+# ---------------------------------------------------------------------------
+
+
+def test_noop_context_yields_none() -> None:
+    with _noop_context() as val:
+        assert val is None
+
+
+# ---------------------------------------------------------------------------
+# DataFabricSubgraphState
+# ---------------------------------------------------------------------------
+
+
+def test_state_defaults() -> None:
+    state = DataFabricSubgraphState()
+    assert state.messages == []
+    assert state.iteration_count == 0
+    assert state.last_tool_success is False
+    assert state.last_error_category == ""
+    assert state.last_error_detail == ""
+
+
+# ---------------------------------------------------------------------------
+# QueryExecutor.__init__  — entity attribute computation
+# ---------------------------------------------------------------------------
+
+
+def test_query_executor_entity_attrs_native_only() -> None:
+    entities = [_make_entity("Orders"), _make_entity("Products")]
+    svc = _make_entities_service()
+    qe = QueryExecutor(svc, entities)
+    assert qe._entity_attrs["df.entity_count"] == 2
+    assert qe._entity_attrs["df.native_entity_count"] == 2
+    assert qe._entity_attrs["df.federated_entity_count"] == 0
+    assert "Orders" in str(qe._entity_attrs["df.native_entities"])
+    assert qe._entity_attrs["df.federated_entities"] == ""
+
+
+def test_query_executor_entity_attrs_mixed() -> None:
+    entities = [
+        _make_entity("Orders"),
+        _make_entity("ExtTable", external_fields=["col1"]),
+    ]
+    svc = _make_entities_service()
+    qe = QueryExecutor(svc, entities)
+    assert qe._entity_attrs["df.native_entity_count"] == 1
+    assert qe._entity_attrs["df.federated_entity_count"] == 1
+    assert "ExtTable" in str(qe._entity_attrs["df.federated_entities"])
+
+
+# ---------------------------------------------------------------------------
+# QueryExecutor.__call__  — success path (no OTEL)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_executor_success_no_otel() -> None:
+    records = [{"id": 1}, {"id": 2}]
+    svc = _make_entities_service(records=records)
+    qe = QueryExecutor(svc, [_make_entity("T")])
+
+    with patch.dict(
+        "sys.modules", {"opentelemetry": None, "opentelemetry.trace": None}
+    ):
+        result = await qe("SELECT * FROM T")
+
+    assert result["records"] == records
+    assert result["total_count"] == 2
+    assert result["sql_query"] == "SELECT * FROM T"
+    assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# QueryExecutor.__call__  — success path with OTEL span
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_executor_success_with_span() -> None:
+    records = [{"id": 1}]
+    svc = _make_entities_service(records=records)
+    qe = QueryExecutor(svc, [_make_entity("T")])
+
+    mock_span = MagicMock()
+    mock_tracer = MagicMock()
+    mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(
+        return_value=mock_span
+    )
+    mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(
+        return_value=False
+    )
+
+    with patch("opentelemetry.trace.get_tracer", return_value=mock_tracer):
+        result = await qe("SELECT 1")
+
+    assert result["total_count"] == 1
+    set_attr_calls = {
+        call.args[0]: call.args[1] for call in mock_span.set_attribute.call_args_list
+    }
+    assert set_attr_calls["df.record_count"] == 1
+    assert set_attr_calls["df.success"] is True
+
+
+# ---------------------------------------------------------------------------
+# QueryExecutor.__call__  — error path (no OTEL, plain exception)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_executor_error_no_otel() -> None:
+    svc = _make_entities_service(error=RuntimeError("connection timeout"))
+    qe = QueryExecutor(svc, [_make_entity("T")])
+
+    with patch.dict(
+        "sys.modules", {"opentelemetry": None, "opentelemetry.trace": None}
+    ):
+        result = await qe("SELECT * FROM T")
+
+    assert result["records"] == []
+    assert result["total_count"] == 0
+    assert "connection timeout" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# QueryExecutor.__call__  — error path with EnrichedException + DataFabricError
+# ---------------------------------------------------------------------------
+
+
+def _make_enriched_exception(msg: str = "enriched error") -> EnrichedException:
+    """Create an EnrichedException with mocked httpx internals."""
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.content = msg.encode("utf-8")
+    mock_request = MagicMock()
+    mock_request.url = "https://datafabric_.example.com/query"
+    mock_request.method = "POST"
+    mock_error = MagicMock()
+    mock_error.response = mock_response
+    mock_error.request = mock_request
+    return EnrichedException(mock_error)
+
+
+@pytest.mark.asyncio
+async def test_query_executor_error_with_datafabric_error() -> None:
+    enriched = _make_enriched_exception()
+
+    svc = _make_entities_service(error=enriched)
+    qe = QueryExecutor(svc, [_make_entity("T")])
+
+    fake_df_error = _FakeDataFabricError(
+        code="SQL_VALIDATION",
+        message="Invalid column reference",
+        trace_id="abc123",
+        category=_FakeCategory.BAD_SQL,
+        is_bad_sql=True,
+    )
+
+    with (
+        patch.dict("sys.modules", {"opentelemetry": None, "opentelemetry.trace": None}),
+        patch(
+            "uipath_langchain.agent.tools.datafabric_tool.datafabric_subgraph.DataFabricError"
+        ) as mock_dfe_cls,
+    ):
+        mock_dfe_cls.from_enriched_exception.return_value = fake_df_error
+        result = await qe("SELECT bad_col FROM T")
+
+    assert result["records"] == []
+    assert "[SQL_VALIDATION]" in result["error"]
+    assert "Fix the SQL syntax" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# QueryExecutor._build_error_detail
+# ---------------------------------------------------------------------------
+
+
+def test_build_error_detail_no_df_error() -> None:
+    detail = QueryExecutor._build_error_detail(RuntimeError("boom"), None)
+    assert detail == "boom"
+
+
+def test_build_error_detail_with_code_and_bad_sql() -> None:
+    df_err = _FakeDataFabricError(
+        code="SQL_VALIDATION",
+        message="Invalid column",
+        trace_id=None,
+        category=_FakeCategory.BAD_SQL,
+        is_bad_sql=True,
+    )
+    detail = QueryExecutor._build_error_detail(RuntimeError("x"), df_err)  # type: ignore[arg-type]
+    assert "[SQL_VALIDATION]" in detail
+    assert "(category: bad_sql)" in detail
+    assert "Invalid column" in detail
+    assert "Fix the SQL syntax" in detail
+
+
+def test_build_error_detail_retryable() -> None:
+    df_err = _FakeDataFabricError(
+        code="TIMEOUT",
+        message="Request timed out",
+        trace_id="t1",
+        category=_FakeCategory.RETRYABLE,
+        is_retryable=True,
+    )
+    detail = QueryExecutor._build_error_detail(RuntimeError("x"), df_err)  # type: ignore[arg-type]
+    assert "[TIMEOUT]" in detail
+    assert "transient" in detail
+
+
+def test_build_error_detail_unknown_category() -> None:
+    df_err = _FakeDataFabricError(
+        code="SOMETHING",
+        message="msg",
+        trace_id=None,
+        category=_FakeCategory.UNKNOWN,
+    )
+    detail = QueryExecutor._build_error_detail(RuntimeError("x"), df_err)  # type: ignore[arg-type]
+    assert "[SOMETHING]" in detail
+    # "unknown" category should NOT appear
+    assert "(category:" not in detail
+
+
+def test_build_error_detail_no_code() -> None:
+    df_err = _FakeDataFabricError(
+        code=None,
+        message="msg",
+        trace_id=None,
+        category=_FakeCategory.UNKNOWN,
+    )
+    # Falls through to str(exc)
+    detail = QueryExecutor._build_error_detail(RuntimeError("fallback"), df_err)  # type: ignore[arg-type]
+    assert detail == "fallback"
+
+
+def test_build_error_detail_no_message() -> None:
+    df_err = _FakeDataFabricError(
+        code="ERR",
+        message=None,
+        trace_id=None,
+        category=_FakeCategory.INFRASTRUCTURE,
+    )
+    detail = QueryExecutor._build_error_detail(RuntimeError("x"), df_err)  # type: ignore[arg-type]
+    assert "[ERR]" in detail
+    assert "(category: infrastructure)" in detail
+
+
+# ---------------------------------------------------------------------------
+# DataFabricGraph — routing
+# ---------------------------------------------------------------------------
+
+
+def _make_graph() -> DataFabricGraph:
+    """Create a DataFabricGraph with a mocked LLM."""
+    llm = MagicMock(spec=["model_copy"])
+    bound = MagicMock()
+    copy = MagicMock()
+    copy.bind_tools = MagicMock(return_value=bound)
+    llm.model_copy.return_value = copy
+
+    entities = [_make_entity("Orders")]
+    svc = _make_entities_service()
+
+    with patch(
+        "uipath_langchain.agent.tools.datafabric_tool.datafabric_subgraph.datafabric_prompt_builder"
+    ) as mock_pb:
+        mock_pb.build.return_value = "system prompt"
+        graph = DataFabricGraph(llm, entities, svc, max_iterations=3)
+    return graph
+
+
+def test_router_to_tool() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(
+        messages=[
+            AIMessage(
+                content="", tool_calls=[{"id": "1", "name": "execute_sql", "args": {}}]
+            )
+        ],
+        iteration_count=0,
+    )
+    assert graph.router(state) == "inner_tool"
+
+
+def test_router_to_termination() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(
+        messages=[
+            AIMessage(
+                content="", tool_calls=[{"id": "1", "name": "execute_sql", "args": {}}]
+            )
+        ],
+        iteration_count=3,  # at max
+    )
+    assert graph.router(state) == "termination"
+
+
+def test_router_to_end_no_tool_calls() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(
+        messages=[AIMessage(content="final answer")],
+    )
+    assert graph.router(state) == END
+
+
+def test_router_to_end_empty_messages() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(messages=[])
+    assert graph.router(state) == END
+
+
+def test_router_to_end_human_message() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(
+        messages=[HumanMessage(content="hello")],
+    )
+    assert graph.router(state) == END
+
+
+# ---------------------------------------------------------------------------
+# DataFabricGraph — tool_router
+# ---------------------------------------------------------------------------
+
+
+def test_tool_router_success_ends() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(last_tool_success=True)
+    assert graph.tool_router(state) == END
+
+
+def test_tool_router_failure_retries() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(last_tool_success=False)
+    assert graph.tool_router(state) == "inner_llm"
+
+
+# ---------------------------------------------------------------------------
+# DataFabricGraph — termination_node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_termination_node_basic() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(iteration_count=5)
+    result = await graph.termination_node(state)
+    msg = result["messages"][0]
+    assert isinstance(msg, AIMessage)
+    assert "5 SQL attempts" in msg.content
+    assert "rephrasing" in msg.content
+
+
+@pytest.mark.asyncio
+async def test_termination_node_with_error_info() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(
+        iteration_count=3,
+        last_error_category="bad_sql",
+        last_error_detail="Invalid column 'foo'",
+    )
+    result = await graph.termination_node(state)
+    msg = result["messages"][0]
+    assert "bad_sql" in msg.content
+    assert "Invalid column 'foo'" in msg.content
+
+
+# ---------------------------------------------------------------------------
+# DataFabricGraph — tool_node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_node_no_tool_calls() -> None:
+    graph = _make_graph()
+    state = DataFabricSubgraphState(
+        messages=[HumanMessage(content="hi")],
+        iteration_count=2,
+    )
+    result = await graph.tool_node(state)
+    assert result["iteration_count"] == 2
+    assert "messages" not in result
+
+
+@pytest.mark.asyncio
+async def test_tool_node_success() -> None:
+    graph = _make_graph()
+    # Mock the execute_sql_tool to return a success result
+    graph._execute_sql_tool = MagicMock()
+    graph._execute_sql_tool.ainvoke = AsyncMock(
+        return_value={"records": [{"id": 1}], "total_count": 1, "sql_query": "SELECT 1"}
+    )
+
+    state = DataFabricSubgraphState(
+        messages=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "tc1",
+                        "name": "execute_sql",
+                        "args": {"sql_query": "SELECT 1"},
+                    }
+                ],
+            )
+        ],
+        iteration_count=0,
+    )
+    result = await graph.tool_node(state)
+    assert result["last_tool_success"] is True
+    assert result["iteration_count"] == 1
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], ToolMessage)
+
+
+@pytest.mark.asyncio
+async def test_tool_node_failure_extracts_category() -> None:
+    graph = _make_graph()
+    graph._execute_sql_tool = MagicMock()
+    graph._execute_sql_tool.ainvoke = AsyncMock(
+        return_value={
+            "records": [],
+            "total_count": 0,
+            "error": "[SQL_VALIDATION] (category: bad_sql) Invalid column",
+            "sql_query": "SELECT bad",
+        }
+    )
+
+    state = DataFabricSubgraphState(
+        messages=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "tc1",
+                        "name": "execute_sql",
+                        "args": {"sql_query": "SELECT bad"},
+                    }
+                ],
+            )
+        ],
+    )
+    result = await graph.tool_node(state)
+    assert result["last_tool_success"] is False
+    assert result["last_error_category"] == "bad_sql"
+    assert "SQL_VALIDATION" in result["last_error_detail"]
+
+
+@pytest.mark.asyncio
+async def test_tool_node_value_error() -> None:
+    graph = _make_graph()
+    graph._execute_sql_tool = MagicMock()
+    graph._execute_sql_tool.ainvoke = AsyncMock(side_effect=ValueError("bad input"))
+
+    state = DataFabricSubgraphState(
+        messages=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"id": "tc1", "name": "execute_sql", "args": {"sql_query": "X"}}
+                ],
+            )
+        ],
+    )
+    result = await graph.tool_node(state)
+    assert result["last_tool_success"] is False
+    assert "bad input" in result["last_error_detail"]
+
+
+@pytest.mark.asyncio
+async def test_tool_node_preserves_prior_error_on_no_new_error() -> None:
+    graph = _make_graph()
+    graph._execute_sql_tool = MagicMock()
+    # Return empty records with no error — not a success (total_count=0) but no error string
+    graph._execute_sql_tool.ainvoke = AsyncMock(
+        return_value={"records": [], "total_count": 0, "sql_query": "SELECT 1"}
+    )
+
+    state = DataFabricSubgraphState(
+        messages=[
+            AIMessage(
+                content="",
+                tool_calls=[{"id": "tc1", "name": "execute_sql", "args": {}}],
+            )
+        ],
+        last_error_category="prior_cat",
+        last_error_detail="prior detail",
+    )
+    result = await graph.tool_node(state)
+    # No new error, so prior values should be preserved
+    assert result["last_error_category"] == "prior_cat"
+    assert result["last_error_detail"] == "prior detail"
+
+
+# ---------------------------------------------------------------------------
+# DataFabricGraph.create
+# ---------------------------------------------------------------------------
+
+
+def test_create_returns_compiled_graph() -> None:
+    llm = MagicMock(spec=["model_copy"])
+    bound = MagicMock()
+    copy = MagicMock()
+    copy.bind_tools = MagicMock(return_value=bound)
+    llm.model_copy.return_value = copy
+
+    with patch(
+        "uipath_langchain.agent.tools.datafabric_tool.datafabric_subgraph.datafabric_prompt_builder"
+    ) as mock_pb:
+        mock_pb.build.return_value = "prompt"
+        compiled = DataFabricGraph.create(
+            llm, [_make_entity("T")], _make_entities_service()
+        )
+
+    assert compiled is not None
+
+
+# ---------------------------------------------------------------------------
+# CATEGORY_MARKER extraction
+# ---------------------------------------------------------------------------
+
+
+def test_category_marker_extraction() -> None:
+    error_str = "[SQL_VALIDATION] (category: bad_sql) Invalid column"
+    start = error_str.index(CATEGORY_MARKER) + len(CATEGORY_MARKER)
+    end = error_str.index(")", start)
+    assert error_str[start:end] == "bad_sql"
+
+
+def test_category_marker_not_present() -> None:
+    error_str = "some generic error"
+    assert CATEGORY_MARKER not in error_str
+
+
+# ---------------------------------------------------------------------------
+# QueryExecutor — error path with OTEL span active
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_executor_error_with_span_sets_attributes() -> None:
+    """Error path when an OTEL span is active — verifies span attributes are set."""
+    enriched = _make_enriched_exception("sql error")
+
+    svc = _make_entities_service(error=enriched)
+    qe = QueryExecutor(svc, [_make_entity("T")])
+
+    fake_df_error = _FakeDataFabricError(
+        code="SQL_VALIDATION",
+        message="bad column",
+        trace_id="trace-1",
+        category=_FakeCategory.BAD_SQL,
+        is_bad_sql=True,
+    )
+
+    mock_span = MagicMock()
+    mock_tracer = MagicMock()
+    mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(
+        return_value=mock_span
+    )
+    mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(
+        return_value=False
+    )
+
+    with (
+        patch("opentelemetry.trace.get_tracer", return_value=mock_tracer),
+        patch(
+            "uipath_langchain.agent.tools.datafabric_tool.datafabric_subgraph.DataFabricError"
+        ) as mock_dfe_cls,
+    ):
+        mock_dfe_cls.from_enriched_exception.return_value = fake_df_error
+        result = await qe("SELECT bad")
+
+    assert result["records"] == []
+    # Verify span attributes were set
+    set_attr_calls = {
+        call.args[0]: call.args[1] for call in mock_span.set_attribute.call_args_list
+    }
+    assert set_attr_calls["df.success"] is False
+    assert set_attr_calls["df.error.code"] == "SQL_VALIDATION"
+    assert set_attr_calls["df.error.message"] == "bad column"
+    assert set_attr_calls["df.error.trace_id"] == "trace-1"
+    assert set_attr_calls["df.error.category"] == "bad_sql"
+    mock_span.record_exception.assert_called_once()
+    mock_span.set_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_query_executor_error_with_span_no_df_error() -> None:
+    """Error path with OTEL span but a plain (non-EnrichedException) error."""
+    svc = _make_entities_service(error=RuntimeError("timeout"))
+    qe = QueryExecutor(svc, [_make_entity("T")])
+
+    mock_span = MagicMock()
+    mock_tracer = MagicMock()
+    mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(
+        return_value=mock_span
+    )
+    mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(
+        return_value=False
+    )
+
+    with patch("opentelemetry.trace.get_tracer", return_value=mock_tracer):
+        result = await qe("SELECT 1")
+
+    assert result["error"] == "timeout"
+    set_attr_calls = {
+        call.args[0]: call.args[1] for call in mock_span.set_attribute.call_args_list
+    }
+    assert set_attr_calls["df.success"] is False
+    assert "timeout" in set_attr_calls["df.error.raw"]
+    # No df_error attributes should be set
+    assert "df.error.code" not in set_attr_calls
+
+
+# ---------------------------------------------------------------------------
+# DataFabricGraph — llm_node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_llm_node_invokes_inner_llm() -> None:
+    graph = _make_graph()
+    mock_response = AIMessage(content="I'll query the database")
+    graph._inner_llm = MagicMock()
+    graph._inner_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+    state = DataFabricSubgraphState(messages=[HumanMessage(content="How many orders?")])
+    result = await graph.llm_node(state)
+    assert result["messages"] == [mock_response]
+    # Verify system message was prepended
+    call_args = graph._inner_llm.ainvoke.call_args[0][0]
+    assert call_args[0] == graph._system_message
+    assert call_args[1].content == "How many orders?"

--- a/tests/agent/tools/test_escalation_memory.py
+++ b/tests/agent/tools/test_escalation_memory.py
@@ -311,6 +311,17 @@ class TestGetEscalationMemorySpaceId:
 
         assert result is None
 
+    def test_folder_path_returns_none_when_memory_disabled(self) -> None:
+        # No properties.memory.isEnabled and no isAgentMemoryEnabled -> disabled.
+        resource = _memory_resource()
+
+        assert _get_escalation_memory_folder_path(resource) is None
+
+    def test_space_name_returns_none_when_memory_disabled(self) -> None:
+        resource = _memory_resource()
+
+        assert _get_escalation_memory_space_name(resource) is None
+
 
 class TestGetMemorySpaceFolderOverride:
     def test_returns_none_without_matching_override(self) -> None:
@@ -1066,6 +1077,127 @@ class TestIngestEscalationMemory:
             trace_id="def456",
             user_id="reviewer@example.com",
         )
+
+    @pytest.mark.asyncio
+    async def test_adds_memory_write_span(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from opentelemetry import trace
+
+        from uipath_langchain.agent.tools import escalation_memory
+
+        fake_tracer = _FakeTracer()
+        tracer_names: list[str] = []
+
+        def get_tracer(name: str) -> _FakeTracer:
+            tracer_names.append(name)
+            return fake_tracer
+
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_ingest_async = AsyncMock()
+        monkeypatch.setattr(trace, "get_tracer", get_tracer)
+        monkeypatch.setattr(
+            escalation_memory, "UiPath", MagicMock(return_value=mock_sdk)
+        )
+
+        await _ingest_escalation_memory(
+            "space-123",
+            answer='{"approved": true}',
+            attributes='{"input": "test"}',
+            parent_span_id="abc123",
+            trace_id="def456",
+            user_id=USER_GUID,
+            memory_space_name="MemorySpace",
+        )
+
+        assert tracer_names == ["uipath_langchain.memory"]
+        assert [span.name for span in fake_tracer.spans] == ["Save escalation memory"]
+        (write_span,) = fake_tracer.spans
+        assert write_span.attributes["openinference.span.kind"] == "agentMemoryWrite"
+        assert write_span.attributes["type"] == "agentMemoryWrite"
+        assert write_span.attributes["span_type"] == "agentMemoryWrite"
+        assert write_span.attributes["uipath.custom_instrumentation"] is True
+        assert write_span.attributes["memorySpaceName"] == "MemorySpace"
+        assert write_span.attributes["memorySpaceId"] == "space-123"
+        assert write_span.attributes["strategy"] == ESCALATION_MEMORY_STRATEGY
+        assert write_span.attributes["fromMemory"] is False
+        assert write_span.attributes["savedToMemory"] is True
+        # "request" captures what was saved as a JSON string the exporter
+        # parses back into an object for the Studio UI.
+        saved_request = write_span.attributes["request"]
+        assert isinstance(saved_request, str)
+        saved = json.loads(saved_request)
+        assert saved["answer"] == '{"approved": true}'
+        assert saved["attributes"] == '{"input": "test"}'
+
+    @pytest.mark.asyncio
+    async def test_sets_memory_write_span_to_error_on_ingest_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from opentelemetry import trace
+
+        from uipath_langchain.agent.tools import escalation_memory
+
+        fake_tracer = _FakeTracer()
+        monkeypatch.setattr(trace, "get_tracer", lambda _name: fake_tracer)
+        error = Exception("fail")
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_ingest_async = AsyncMock(side_effect=error)
+        monkeypatch.setattr(
+            escalation_memory, "UiPath", MagicMock(return_value=mock_sdk)
+        )
+
+        # Should swallow the error so a failed ingest never breaks the run.
+        await _ingest_escalation_memory(
+            "space-123",
+            answer="yes",
+            attributes="{}",
+            parent_span_id="abc123",
+            trace_id="def456",
+        )
+
+        (write_span,) = fake_tracer.spans
+        assert write_span.attributes["savedToMemory"] is False
+        assert write_span.recorded_errors == [error]
+        assert write_span.statuses
+
+    @pytest.mark.asyncio
+    async def test_ingest_succeeds_without_opentelemetry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from uipath_langchain.agent.tools import escalation_memory
+
+        original_import = builtins.__import__
+
+        def import_without_otel(
+            name: str,
+            globals: dict[str, Any] | None = None,
+            locals: dict[str, Any] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> Any:
+            if name == "opentelemetry":
+                raise ImportError("opentelemetry unavailable")
+            return original_import(name, globals, locals, fromlist, level)
+
+        mock_sdk = MagicMock()
+        mock_sdk.memory.escalation_ingest_async = AsyncMock()
+        monkeypatch.setattr(builtins, "__import__", import_without_otel)
+        monkeypatch.setattr(
+            escalation_memory, "UiPath", MagicMock(return_value=mock_sdk)
+        )
+
+        # The ingest must still run when tracing is unavailable (no-op span).
+        await _ingest_escalation_memory(
+            "space-123",
+            answer='{"approved": true}',
+            attributes='{"input": "test"}',
+            parent_span_id="abc123",
+            trace_id="def456",
+            user_id=USER_GUID,
+        )
+
+        mock_sdk.memory.escalation_ingest_async.assert_called_once()
 
 
 class TestEscalationMemoryUtilities:

--- a/tests/agent/tools/test_escalation_recipient.py
+++ b/tests/agent/tools/test_escalation_recipient.py
@@ -1,0 +1,404 @@
+"""Tests for escalation_recipient.py recipient resolution."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from uipath.agent.models.agent import (
+    AgentEscalationRecipientType,
+    ArgumentEmailRecipient,
+    ArgumentGroupNameRecipient,
+    AssetRecipient,
+    CustomAssigneesRecipient,
+    RoundRobinRecipient,
+    StandardRecipient,
+    WorkloadRecipient,
+)
+from uipath.platform.action_center.tasks import TaskRecipient, TaskRecipientType
+
+from uipath_langchain.agent.tools.escalation_memory import _get_user_email
+from uipath_langchain.agent.tools.escalation_recipient import (
+    _build_llm_recipient,
+    _resolve_asset,
+    resolve_recipient_value,
+)
+
+
+class TestResolveAsset:
+    """Test the resolve_asset function."""
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.tools.escalation_recipient.UiPath")
+    async def test_resolve_asset_success(self, mock_uipath_class):
+        """Test successful asset retrieval."""
+        mock_client = MagicMock()
+        mock_uipath_class.return_value = mock_client
+        mock_result = MagicMock()
+        mock_result.value = "test@example.com"
+        mock_client.assets.retrieve_async = AsyncMock(return_value=mock_result)
+
+        result = await _resolve_asset("email_asset", "/Test/Folder")
+
+        assert result == "test@example.com"
+        mock_client.assets.retrieve_async.assert_called_once_with(
+            name="email_asset", folder_path="/Test/Folder"
+        )
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.tools.escalation_recipient.UiPath")
+    async def test_resolve_asset_no_value(self, mock_uipath_class):
+        """Test asset with no value raises ValueError."""
+        mock_client = MagicMock()
+        mock_uipath_class.return_value = mock_client
+        mock_result = MagicMock()
+        mock_result.value = None
+        mock_client.assets.retrieve_async = AsyncMock(return_value=mock_result)
+
+        with pytest.raises(ValueError) as exc_info:
+            await _resolve_asset("empty_asset", "/Test/Folder")
+
+        assert "Asset 'empty_asset' has no value configured" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.tools.escalation_recipient.UiPath")
+    async def test_resolve_asset_not_found(self, mock_uipath_class):
+        """Test asset not found raises ValueError."""
+        mock_client = MagicMock()
+        mock_uipath_class.return_value = mock_client
+        mock_client.assets.retrieve_async = AsyncMock(return_value=None)
+
+        with pytest.raises(ValueError) as exc_info:
+            await _resolve_asset("missing_asset", "/Test/Folder")
+
+        assert "Asset 'missing_asset' has no value configured" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.tools.escalation_recipient.UiPath")
+    async def test_resolve_asset_retrieval_exception(self, mock_uipath_class):
+        """Test exception during asset retrieval raises ValueError with context."""
+        mock_client = MagicMock()
+        mock_uipath_class.return_value = mock_client
+        mock_client.assets.retrieve_async = AsyncMock(
+            side_effect=Exception("Connection error")
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            await _resolve_asset("problem_asset", "/Test/Folder")
+
+        assert (
+            "Failed to resolve asset 'problem_asset' in folder '/Test/Folder'"
+            in str(exc_info.value)
+        )
+        assert "Connection error" in str(exc_info.value)
+
+
+class TestResolveRecipientValue:
+    """Test the resolve_recipient_value function."""
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Test/Folder"})
+    @patch("uipath_langchain.agent.tools.escalation_recipient._resolve_asset")
+    async def test_resolve_recipient_asset_user_email(self, mock_resolve_asset):
+        """Test ASSET_USER_EMAIL type calls resolve_asset."""
+        mock_resolve_asset.return_value = "resolved@example.com"
+
+        recipient = AssetRecipient(
+            type=AgentEscalationRecipientType.ASSET_USER_EMAIL,
+            asset_name="email_asset",
+            folder_path="/Test/Folder",
+        )
+
+        result = await resolve_recipient_value(recipient)
+
+        assert result == TaskRecipient(
+            value="resolved@example.com",
+            type=TaskRecipientType.EMAIL,
+            displayName="resolved@example.com",
+        )
+        mock_resolve_asset.assert_called_once_with("email_asset", "/Test/Folder")
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Test/Folder"})
+    @patch("uipath_langchain.agent.tools.escalation_recipient._resolve_asset")
+    async def test_resolve_recipient_asset_group_name(self, mock_resolve_asset):
+        """Test ASSET_GROUP_NAME type calls resolve_asset."""
+        mock_resolve_asset.return_value = "ResolvedGroup"
+
+        recipient = AssetRecipient(
+            type=AgentEscalationRecipientType.ASSET_GROUP_NAME,
+            asset_name="group_asset",
+            folder_path="/Test/Folder",
+        )
+
+        result = await resolve_recipient_value(recipient)
+
+        assert result == TaskRecipient(
+            value="ResolvedGroup",
+            type=TaskRecipientType.GROUP_NAME,
+            displayName="ResolvedGroup",
+        )
+        mock_resolve_asset.assert_called_once_with("group_asset", "/Test/Folder")
+
+    @pytest.mark.asyncio
+    async def test_resolve_recipient_user_email(self):
+        """Test USER_EMAIL type returns value directly."""
+        recipient = StandardRecipient(
+            type=AgentEscalationRecipientType.USER_EMAIL,
+            value="direct@example.com",
+        )
+
+        result = await resolve_recipient_value(recipient)
+
+        assert result == TaskRecipient(
+            value="direct@example.com",
+            type=TaskRecipientType.EMAIL,
+            displayName="direct@example.com",
+        )
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.tools.escalation_recipient._resolve_asset")
+    async def test_resolve_recipient_propagates_error_when_asset_resolution_fails(
+        self, mock_resolve_asset
+    ):
+        """Test AssetRecipient when asset resolution fails."""
+        mock_resolve_asset.side_effect = ValueError("Asset not found")
+
+        recipient = AssetRecipient(
+            type=AgentEscalationRecipientType.ASSET_USER_EMAIL,
+            asset_name="nonexistent",
+            folder_path="Shared",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            await resolve_recipient_value(recipient)
+
+        assert "Asset not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_resolve_recipient_no_value(self):
+        """Test recipient without value attribute returns None."""
+        recipient = MagicMock()
+        recipient.type = AgentEscalationRecipientType.USER_EMAIL
+        del recipient.value  # Simulate no value attribute
+
+        result = await resolve_recipient_value(recipient)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_recipient_workload(self):
+        """WorkloadRecipient resolves to TaskRecipient with WORKLOAD type using displayName."""
+        recipient = WorkloadRecipient(
+            type=AgentEscalationRecipientType.WORKLOAD,
+            value="group-id-1",
+            display_name="Support Team",
+        )
+
+        result = await resolve_recipient_value(recipient)
+
+        assert result == TaskRecipient(
+            value="Support Team",
+            type=TaskRecipientType.WORKLOAD,
+            displayName="Support Team",
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_recipient_round_robin(self):
+        """RoundRobinRecipient resolves to TaskRecipient with ROUND_ROBIN type."""
+        recipient = RoundRobinRecipient(
+            type=AgentEscalationRecipientType.ROUND_ROBIN,
+            value="group-id-1",
+            display_name="Support Team",
+        )
+
+        result = await resolve_recipient_value(recipient)
+
+        assert result == TaskRecipient(
+            value="Support Team",
+            type=TaskRecipientType.ROUND_ROBIN,
+            displayName="Support Team",
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_recipient_custom_assignees_returns_none(self):
+        """A CustomAssigneesRecipient resolves to None at the design-time resolver."""
+        recipient = CustomAssigneesRecipient(
+            type=AgentEscalationRecipientType.CUSTOM_ASSIGNEES,
+            value="alice@example.com",
+            displayName="Alice",
+        )
+
+        result = await resolve_recipient_value(recipient)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_recipient_custom_assignees_empty_value_returns_none(self):
+        """Empty-value CustomAssignees sentinel resolves to None."""
+        recipient = CustomAssigneesRecipient(
+            type=AgentEscalationRecipientType.CUSTOM_ASSIGNEES,
+            value="",
+        )
+
+        result = await resolve_recipient_value(recipient)
+
+        assert result is None
+
+
+class TestArgumentRecipientResolutionMissing:
+    """Argument-name recipients raise loudly when the named input is missing."""
+
+    @pytest.mark.asyncio
+    async def test_argument_email_raises_when_input_missing(self):
+        recipient = ArgumentEmailRecipient(
+            type=AgentEscalationRecipientType.ARGUMENT_EMAIL,
+            argument_path="user.email",
+        )
+        with pytest.raises(ValueError, match="no value in agent input"):
+            await resolve_recipient_value(recipient, input_args={})
+
+    @pytest.mark.asyncio
+    async def test_argument_group_name_raises_when_input_missing(self):
+        recipient = ArgumentGroupNameRecipient(
+            type=AgentEscalationRecipientType.ARGUMENT_GROUP_NAME,
+            argument_path="group.name",
+        )
+        with pytest.raises(ValueError, match="no value in agent input"):
+            await resolve_recipient_value(recipient, input_args={})
+
+    @pytest.mark.asyncio
+    async def test_argument_email_resolves_value_from_input(self):
+        recipient = ArgumentEmailRecipient(
+            type=AgentEscalationRecipientType.ARGUMENT_EMAIL,
+            argument_path="approver.email",
+        )
+        result = await resolve_recipient_value(
+            recipient,
+            input_args={"approver": {"email": "boss@example.com"}},
+        )
+        assert result is not None
+        assert result.value == "boss@example.com"
+        assert result.type == TaskRecipientType.EMAIL
+
+    @pytest.mark.asyncio
+    async def test_argument_group_name_resolves_value_from_input(self):
+        recipient = ArgumentGroupNameRecipient(
+            type=AgentEscalationRecipientType.ARGUMENT_GROUP_NAME,
+            argument_path="dept.team",
+        )
+        result = await resolve_recipient_value(
+            recipient,
+            input_args={"dept": {"team": "Finance"}},
+        )
+        assert result is not None
+        assert result.value == "Finance"
+        assert result.type == TaskRecipientType.GROUP_NAME
+
+
+class TestBuildLlmRecipient:
+    """Tests for the agent-inferred ("LLM inferred") recipient builder."""
+
+    @pytest.mark.asyncio
+    @patch(
+        "uipath_langchain.agent.tools.escalation_recipient._filter_to_directory_users"
+    )
+    async def test_comma_separated_string_sets_display_name(self, mock_filter):
+        """Comma-separated emails resolve to a Workload assignment with a joined display_name."""
+        mock_filter.return_value = ["a@x.com", "b@x.com"]
+
+        result = await _build_llm_recipient("a@x.com, b@x.com")
+
+        assert result is not None
+        assert result.value == "a@x.com"
+        assert result.values == ["a@x.com", "b@x.com"]
+        assert result.type == TaskRecipientType.WORKLOAD
+        # Regression guard: display_name drives the trace `assignedTo` attribute.
+        assert result.display_name == "a@x.com, b@x.com"
+
+    @pytest.mark.asyncio
+    @patch(
+        "uipath_langchain.agent.tools.escalation_recipient._filter_to_directory_users"
+    )
+    async def test_list_input_resolves(self, mock_filter):
+        """A list of emails is accepted and resolved."""
+        mock_filter.return_value = ["a@x.com"]
+
+        result = await _build_llm_recipient(["a@x.com"])
+
+        assert result is not None
+        assert result.value == "a@x.com"
+        assert result.values == ["a@x.com"]
+        assert result.type == TaskRecipientType.WORKLOAD
+        assert result.display_name == "a@x.com"
+
+    @pytest.mark.asyncio
+    @patch(
+        "uipath_langchain.agent.tools.escalation_recipient._filter_to_directory_users"
+    )
+    async def test_invalid_email_format_returns_none(self, mock_filter):
+        """A value with no valid email format fails closed before any directory lookup."""
+        result = await _build_llm_recipient("not-an-email")
+
+        assert result is None
+        mock_filter.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(
+        "uipath_langchain.agent.tools.escalation_recipient._filter_to_directory_users"
+    )
+    async def test_overlong_candidate_is_dropped_before_matching(self, mock_filter):
+        """A candidate over the email length cap is rejected without running the regex/directory lookup."""
+        overlong = (
+            "a" * 250 + "@example.com"
+        )  # 262 chars, exceeds MAX_EMAIL_LENGTH (254)
+
+        result = await _build_llm_recipient(overlong)
+
+        assert result is None
+        mock_filter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_string_non_list_returns_none(self):
+        """Unsupported raw types (e.g. None, int) fail closed."""
+        assert await _build_llm_recipient(None) is None
+        assert await _build_llm_recipient(123) is None
+
+    @pytest.mark.asyncio
+    @patch(
+        "uipath_langchain.agent.tools.escalation_recipient._filter_to_directory_users"
+    )
+    async def test_unresolved_directory_users_fails_closed(self, mock_filter):
+        """A well-formed email that resolves to no tenant user leaves the task unassigned."""
+        mock_filter.return_value = []
+
+        result = await _build_llm_recipient("ghost@x.com")
+
+        assert result is None
+
+
+class TestGetUserEmail:
+    """Test the _get_user_email helper function."""
+
+    def test_none_returns_none(self):
+        """Test that None input returns None."""
+        assert _get_user_email(None) is None
+
+    def test_dict_with_email_address(self):
+        """Test extraction from dict with emailAddress field."""
+        user = {"emailAddress": "test@example.com", "name": "Test"}
+        assert _get_user_email(user) == "test@example.com"
+
+    def test_dict_without_email_address(self):
+        """Test dict without emailAddress returns None."""
+        user = {"name": "Test", "id": 123}
+        assert _get_user_email(user) is None
+
+    def test_object_with_email_address(self):
+        """Test extraction from object with emailAddress attribute."""
+        user = MagicMock(emailAddress="test@example.com")
+        assert _get_user_email(user) == "test@example.com"
+
+    def test_object_without_email_address(self):
+        """Test object without emailAddress attribute returns None."""
+        user = MagicMock(spec=["name", "id"])
+        assert _get_user_email(user) is None

--- a/tests/agent/tools/test_escalation_tool.py
+++ b/tests/agent/tools/test_escalation_tool.py
@@ -12,21 +12,17 @@ from uipath.agent.models.agent import (
     AgentEscalationResourceConfig,
     AgentQuickFormChannelProperties,
     AgentQuickFormEscalationChannel,
-    AssetRecipient,
     StandardRecipient,
 )
 from uipath.platform.action_center.tasks import Task, TaskRecipient, TaskRecipientType
 
 from uipath_langchain.agent.tools.escalation_memory import (
     EscalationMemoryCachedResult,
-    _get_user_email,
 )
 from uipath_langchain.agent.tools.escalation_tool import (
     _build_escalation_memory_payload,
     _parse_task_data,
     create_escalation_tool,
-    resolve_asset,
-    resolve_recipient_value,
 )
 
 
@@ -35,178 +31,6 @@ def _make_mock_task(**overrides):
     defaults = {"id": 1, "key": "task-key", "title": "Test Task"}
     defaults.update(overrides)
     return Task(**defaults)
-
-
-class TestResolveAsset:
-    """Test the resolve_asset function."""
-
-    @pytest.mark.asyncio
-    @patch("uipath_langchain.agent.tools.escalation_tool.UiPath")
-    async def test_resolve_asset_success(self, mock_uipath_class):
-        """Test successful asset retrieval."""
-        # Setup mock
-        mock_client = MagicMock()
-        mock_uipath_class.return_value = mock_client
-        mock_result = MagicMock()
-        mock_result.value = "test@example.com"
-        mock_client.assets.retrieve_async = AsyncMock(return_value=mock_result)
-
-        # Execute
-        result = await resolve_asset("email_asset", "/Test/Folder")
-
-        # Assert
-        assert result == "test@example.com"
-        mock_client.assets.retrieve_async.assert_called_once_with(
-            name="email_asset", folder_path="/Test/Folder"
-        )
-
-    @pytest.mark.asyncio
-    @patch("uipath_langchain.agent.tools.escalation_tool.UiPath")
-    async def test_resolve_asset_no_value(self, mock_uipath_class):
-        """Test asset with no value raises ValueError."""
-        # Setup mock
-        mock_client = MagicMock()
-        mock_uipath_class.return_value = mock_client
-        mock_result = MagicMock()
-        mock_result.value = None
-        mock_client.assets.retrieve_async = AsyncMock(return_value=mock_result)
-
-        # Execute and assert
-        with pytest.raises(ValueError) as exc_info:
-            await resolve_asset("empty_asset", "/Test/Folder")
-
-        assert "Asset 'empty_asset' has no value configured" in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    @patch("uipath_langchain.agent.tools.escalation_tool.UiPath")
-    async def test_resolve_asset_not_found(self, mock_uipath_class):
-        """Test asset not found raises ValueError."""
-        # Setup mock
-        mock_client = MagicMock()
-        mock_uipath_class.return_value = mock_client
-        mock_client.assets.retrieve_async = AsyncMock(return_value=None)
-
-        # Execute and assert
-        with pytest.raises(ValueError) as exc_info:
-            await resolve_asset("missing_asset", "/Test/Folder")
-
-        assert "Asset 'missing_asset' has no value configured" in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    @patch("uipath_langchain.agent.tools.escalation_tool.UiPath")
-    async def test_resolve_asset_retrieval_exception(self, mock_uipath_class):
-        """Test exception during asset retrieval raises ValueError with context."""
-        # Setup mock
-        mock_client = MagicMock()
-        mock_uipath_class.return_value = mock_client
-        mock_client.assets.retrieve_async = AsyncMock(
-            side_effect=Exception("Connection error")
-        )
-
-        # Execute and assert
-        with pytest.raises(ValueError) as exc_info:
-            await resolve_asset("problem_asset", "/Test/Folder")
-
-        assert (
-            "Failed to resolve asset 'problem_asset' in folder '/Test/Folder'"
-            in str(exc_info.value)
-        )
-        assert "Connection error" in str(exc_info.value)
-
-
-class TestResolveRecipientValue:
-    """Test the resolve_recipient_value function."""
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Test/Folder"})
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_asset")
-    async def test_resolve_recipient_asset_user_email(self, mock_resolve_asset):
-        """Test ASSET_USER_EMAIL type calls resolve_asset."""
-        mock_resolve_asset.return_value = "resolved@example.com"
-
-        recipient = AssetRecipient(
-            type=AgentEscalationRecipientType.ASSET_USER_EMAIL,
-            asset_name="email_asset",
-            folder_path="/Test/Folder",
-        )
-
-        result = await resolve_recipient_value(recipient)
-
-        assert result == TaskRecipient(
-            value="resolved@example.com",
-            type=TaskRecipientType.EMAIL,
-            displayName="resolved@example.com",
-        )
-        mock_resolve_asset.assert_called_once_with("email_asset", "/Test/Folder")
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Test/Folder"})
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_asset")
-    async def test_resolve_recipient_asset_group_name(self, mock_resolve_asset):
-        """Test ASSET_GROUP_NAME type calls resolve_asset."""
-        mock_resolve_asset.return_value = "ResolvedGroup"
-
-        recipient = AssetRecipient(
-            type=AgentEscalationRecipientType.ASSET_GROUP_NAME,
-            asset_name="group_asset",
-            folder_path="/Test/Folder",
-        )
-
-        result = await resolve_recipient_value(recipient)
-
-        assert result == TaskRecipient(
-            value="ResolvedGroup",
-            type=TaskRecipientType.GROUP_NAME,
-            displayName="ResolvedGroup",
-        )
-        mock_resolve_asset.assert_called_once_with("group_asset", "/Test/Folder")
-
-    @pytest.mark.asyncio
-    async def test_resolve_recipient_user_email(self):
-        """Test USER_EMAIL type returns value directly."""
-        recipient = StandardRecipient(
-            type=AgentEscalationRecipientType.USER_EMAIL,
-            value="direct@example.com",
-        )
-
-        result = await resolve_recipient_value(recipient)
-
-        assert result == TaskRecipient(
-            value="direct@example.com",
-            type=TaskRecipientType.EMAIL,
-            displayName="direct@example.com",
-        )
-
-    @pytest.mark.asyncio
-    @patch("uipath_langchain.agent.tools.escalation_tool.resolve_asset")
-    async def test_resolve_recipient_propagates_error_when_asset_resolution_fails(
-        self, mock_resolve_asset
-    ):
-        """Test AssetRecipient when asset resolution fails."""
-        mock_resolve_asset.side_effect = ValueError("Asset not found")
-
-        recipient = AssetRecipient(
-            type=AgentEscalationRecipientType.ASSET_USER_EMAIL,
-            asset_name="nonexistent",
-            folder_path="Shared",
-        )
-
-        with pytest.raises(ValueError) as exc_info:
-            await resolve_recipient_value(recipient)
-
-        assert "Asset not found" in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_resolve_recipient_no_value(self):
-        """Test recipient without value attribute returns None."""
-        # Create a minimal recipient object without value
-        recipient = MagicMock()
-        recipient.type = AgentEscalationRecipientType.USER_EMAIL
-        del recipient.value  # Simulate no value attribute
-
-        result = await resolve_recipient_value(recipient)
-
-        assert result is None
 
 
 class TestEscalationToolMetadata:
@@ -858,34 +682,6 @@ class TestEscalationToolOutputSchema:
             mock_check_memory_cache.await_args.kwargs["memory_space_name"]
             == "MemorySpace"
         )
-
-
-class TestGetUserEmail:
-    """Test the _get_user_email helper function."""
-
-    def test_none_returns_none(self):
-        """Test that None input returns None."""
-        assert _get_user_email(None) is None
-
-    def test_dict_with_email_address(self):
-        """Test extraction from dict with emailAddress field."""
-        user = {"emailAddress": "test@example.com", "name": "Test"}
-        assert _get_user_email(user) == "test@example.com"
-
-    def test_dict_without_email_address(self):
-        """Test dict without emailAddress returns None."""
-        user = {"name": "Test", "id": 123}
-        assert _get_user_email(user) is None
-
-    def test_object_with_email_address(self):
-        """Test extraction from object with emailAddress attribute."""
-        user = MagicMock(emailAddress="test@example.com")
-        assert _get_user_email(user) == "test@example.com"
-
-    def test_object_without_email_address(self):
-        """Test object without emailAddress attribute returns None."""
-        user = MagicMock(spec=["name", "id"])
-        assert _get_user_email(user) is None
 
 
 class TestEscalationToolTaskInfo:

--- a/tests/agent/tools/test_integration_tool.py
+++ b/tests/agent/tools/test_integration_tool.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
 from uipath.agent.models.agent import (
     AgentIntegrationToolParameter,
     AgentIntegrationToolProperties,
@@ -855,7 +856,9 @@ class TestCreateIntegrationToolWithArgumentProperties:
 
         tool = create_integration_tool(resource)
 
-        assert isinstance(tool.args_schema, type)
+        assert isinstance(tool.args_schema, type) and issubclass(
+            tool.args_schema, BaseModel
+        )
         schema = tool.args_schema.model_json_schema()
         opp_field = schema["properties"]["opportunityID"]
         assert "enum" not in opp_field

--- a/tests/agent/tools/test_mcp/claude.md
+++ b/tests/agent/tools/test_mcp/claude.md
@@ -28,7 +28,7 @@ The tests mock **only the HTTP layer** (`httpx.AsyncClient`), allowing the real 
 
 ```
 tests/agent/tools/test_mcp/
-├── test_mcp_client.py         # McpClient session tests (7 tests)
+├── test_mcp_client.py         # McpClient session + tool-list caching tests
 │   └── TestMcpClient (class)
 │       ├── create_mock_stream_response()
 │       ├── create_mock_http_client()
@@ -38,7 +38,10 @@ tests/agent/tools/test_mcp/
 │       ├── test_max_retries_exceeded
 │       ├── test_dispose_releases_resources
 │       ├── test_client_initialized_property
-│       └── test_session_can_be_reused_after_dispose
+│       ├── test_session_can_be_reused_after_dispose
+│       ├── test_list_tools_caches_result_across_calls   ← list_tools fetched once per lifetime
+│       ├── test_list_tools_force_refresh_bypasses_cache
+│       └── test_dispose_clears_tools_cache
 │
 └── test_mcp_tool.py           # Tool factory tests (17 tests)
     ├── TestMcpToolMetadata (class)
@@ -64,10 +67,46 @@ tests/agent/tools/test_mcp/
     ├── TestMcpToolInvocation (class)
     │   └── test_tool_invocation_initializes_session_and_returns_result
     │
-    └── TestMcpToolNameSanitization (class)
-        ├── test_tool_name_with_spaces
-        └── test_tool_name_with_special_chars
+    ├── TestMcpToolNameSanitization (class)
+    │   ├── test_tool_name_with_spaces
+    │   └── test_tool_name_with_special_chars
+    │
+    └── TestCachedRefreshSchemaBeforeCall (class)  ← refresh_schema_before_call + self-heal
+        ├── test_refresh_enabled_lists_tools_before_call
+        ├── test_refresh_disabled_skips_list_tools
+        ├── test_refresh_falls_back_when_list_tools_fails
+        ├── test_refresh_returns_removed_message_when_tool_missing
+        ├── test_cached_default_enables_refresh
+        ├── test_cached_refresh_disabled_via_config
+        ├── test_breaking_drift_heals_and_asks_retry
+        ├── test_after_heal_next_call_executes
+        ├── test_nonbreaking_change_executes_without_retry
+        └── test_schema_change_message_lists_param_types
 ```
+
+### TestCachedRefreshSchemaBeforeCall
+
+Covers the cached-mode `refresh_schema_before_call` flag (default `True`) and the
+self-healing behaviour. Asserts ordering via `manager.attach_mock` (list_tools before
+call_tool), graceful fallback when `list_tools` raises, a clear "tool removed" message
+when the tool is gone from the server, that `create_mcp_tools` does not list tools at
+creation time, and that
+`refresh_schema_before_call=False` disables the refresh.
+
+Self-heal cases: on a **breaking** schema change (cached `query` vs live `question`)
+the tool is not executed (`call_tool` not awaited), `tool_fn` returns a retry message
+listing each refreshed param with its type, and the wrapper's `args_schema` is healed
+to the live schema; a subsequent call against
+the healed schema executes; an **additive/non-breaking** change executes normally
+without a retry. These tests invoke the tool's `coroutine` directly (not `ainvoke`)
+because the stale arguments would fail `args_schema` validation before reaching the
+tool.
+
+`tool_fn` tests mock `mcpClient.list_tools` directly, so they exercise the refresh
+logic per invocation independent of the client's caching. The once-per-run caching
+itself lives in `McpClient.list_tools` and is covered in `test_mcp_client.py`
+(`test_list_tools_caches_result_across_calls`, `..._force_refresh_bypasses_cache`,
+`test_dispose_clears_tools_cache`).
 
 ## Mocking Strategy
 

--- a/tests/agent/tools/test_mcp/test_mcp_client.py
+++ b/tests/agent/tools/test_mcp/test_mcp_client.py
@@ -750,10 +750,46 @@ class TestMcpClient:
 
     @pytest.mark.asyncio
     @patch("httpx.AsyncClient")
-    async def test_list_tools_reuses_session(
+    async def test_list_tools_caches_result_across_calls(
         self, mock_async_client_class, mcp_resource_config, mock_uipath_sdk
     ):
-        """Test that list_tools reuses existing session on subsequent calls."""
+        """list_tools caches its result: a second call reuses the session and the
+        cached tool list, issuing only one tools/list RPC."""
+        method_call_sequence: list[str] = []
+        initialize_count = [0]
+        tool_call_count = [0]
+
+        MockStreamResponse = self.create_mock_stream_response(
+            method_call_sequence, initialize_count, tool_call_count
+        )
+
+        mock_http_client = self.create_mock_http_client(MockStreamResponse)
+        mock_async_client_class.return_value = mock_http_client
+
+        client = McpClient(config=mcp_resource_config)
+
+        with patch(
+            "uipath.platform.UiPath",
+            return_value=mock_uipath_sdk,
+        ):
+            first = await client.list_tools()
+            assert initialize_count[0] == 1
+
+            second = await client.list_tools()
+            assert initialize_count[0] == 1  # Still only one initialization
+
+        # Fetched once per lifetime: second call returns the cached result, no new RPC.
+        assert method_call_sequence.count("tools/list") == 1
+        assert first is second
+
+        await client.dispose()
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_list_tools_force_refresh_bypasses_cache(
+        self, mock_async_client_class, mcp_resource_config, mock_uipath_sdk
+    ):
+        """force_refresh=True re-queries the server instead of returning the cache."""
         method_call_sequence: list[str] = []
         initialize_count = [0]
         tool_call_count = [0]
@@ -772,15 +808,43 @@ class TestMcpClient:
             return_value=mock_uipath_sdk,
         ):
             await client.list_tools()
-            assert initialize_count[0] == 1
+            await client.list_tools(force_refresh=True)
 
-            await client.list_tools()
-            assert initialize_count[0] == 1  # Still only one initialization
-
-        list_tools_count = method_call_sequence.count("tools/list")
-        assert list_tools_count == 2
+        # Session reused, but the server is queried twice.
+        assert initialize_count[0] == 1
+        assert method_call_sequence.count("tools/list") == 2
 
         await client.dispose()
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_dispose_clears_tools_cache(
+        self, mock_async_client_class, mcp_resource_config, mock_uipath_sdk
+    ):
+        """dispose() clears the cached tool list so a reused (or resumed) client
+        re-fetches it once."""
+        method_call_sequence: list[str] = []
+        initialize_count = [0]
+        tool_call_count = [0]
+
+        MockStreamResponse = self.create_mock_stream_response(
+            method_call_sequence, initialize_count, tool_call_count
+        )
+
+        mock_http_client = self.create_mock_http_client(MockStreamResponse)
+        mock_async_client_class.return_value = mock_http_client
+
+        client = McpClient(config=mcp_resource_config)
+
+        with patch(
+            "uipath.platform.UiPath",
+            return_value=mock_uipath_sdk,
+        ):
+            await client.list_tools()
+            assert client._tools_cache is not None
+
+        await client.dispose()
+        assert client._tools_cache is None
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Shared/TestFolder"})

--- a/tests/agent/tools/test_mcp/test_mcp_tool.py
+++ b/tests/agent/tools/test_mcp/test_mcp_tool.py
@@ -12,12 +12,15 @@ from uipath.agent.models.agent import (
     AgentMcpResourceConfig,
     AgentMcpTool,
     AgentResourceType,
+    CachedToolsConfig,
     DynamicToolsConfig,
     ToolsConfiguration,
 )
 
 from uipath_langchain.agent.tools.mcp import McpClient
 from uipath_langchain.agent.tools.mcp.mcp_tool import (
+    _schema_change_message,
+    build_mcp_tool,
     create_mcp_tools,
     create_mcp_tools_and_clients,
     open_mcp_tools,
@@ -973,6 +976,287 @@ class TestToolsConfiguration:
         assert tools[0].description == "My local description"
         assert isinstance(tools[0].args_schema, dict)
         assert "local_param" in tools[0].args_schema["properties"]
+
+
+class TestCachedRefreshSchemaBeforeCall:
+    """Test the refresh_schema_before_call behaviour for cached discovery mode."""
+
+    @pytest.fixture
+    def mcp_tool(self):
+        return AgentMcpTool(
+            name="tool_a",
+            description="Tool A (cached)",
+            input_schema={"type": "object", "properties": {}},
+        )
+
+    @pytest.fixture
+    def server_tool(self):
+        return Tool(
+            name="tool_a",
+            description="Tool A from server",
+            inputSchema={"type": "object", "properties": {"x": {"type": "string"}}},
+        )
+
+    def _mock_client(self, server_tools, result_content="ok"):
+        client = MagicMock(spec=McpClient)
+        client.list_tools = AsyncMock(return_value=ListToolsResult(tools=server_tools))
+        mock_result = MagicMock()
+        mock_result.content = result_content
+        client.call_tool = AsyncMock(return_value=mock_result)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_refresh_enabled_lists_tools_before_call(self, mcp_tool, server_tool):
+        """With refresh on, list_tools runs before call_tool."""
+        manager = MagicMock()
+        client = self._mock_client([server_tool])
+        manager.attach_mock(client.list_tools, "list_tools")
+        manager.attach_mock(client.call_tool, "call_tool")
+
+        tool_fn = build_mcp_tool(mcp_tool, client, refresh_schema_before_call=True)
+        await tool_fn()
+
+        client.list_tools.assert_awaited_once()
+        client.call_tool.assert_awaited_once()
+        called = [name for name, _, _ in manager.mock_calls]
+        assert called.index("list_tools") < called.index("call_tool")
+
+    @pytest.mark.asyncio
+    async def test_refresh_disabled_skips_list_tools(self, mcp_tool, server_tool):
+        """With refresh off, list_tools is not called at invocation."""
+        client = self._mock_client([server_tool])
+
+        tool_fn = build_mcp_tool(mcp_tool, client, refresh_schema_before_call=False)
+        await tool_fn()
+
+        client.list_tools.assert_not_awaited()
+        client.call_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_falls_back_when_list_tools_fails(self, mcp_tool):
+        """A failing list_tools does not block the call; it falls back to the cached schema."""
+        client = MagicMock(spec=McpClient)
+        client.list_tools = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_result = MagicMock()
+        mock_result.content = "ok"
+        client.call_tool = AsyncMock(return_value=mock_result)
+
+        tool_fn = build_mcp_tool(mcp_tool, client, refresh_schema_before_call=True)
+        result = await tool_fn()
+
+        client.call_tool.assert_awaited_once()
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_refresh_returns_removed_message_when_tool_missing(
+        self, mcp_tool, caplog
+    ):
+        """If the tool is gone from the live list, skip the call and tell the model."""
+        other_tool = Tool(
+            name="other_tool",
+            description="A different tool",
+            inputSchema={"type": "object", "properties": {}},
+        )
+        client = self._mock_client([other_tool])
+
+        tool_fn = build_mcp_tool(mcp_tool, client, refresh_schema_before_call=True)
+        with caplog.at_level(logging.WARNING):
+            result = await tool_fn()
+
+        client.call_tool.assert_not_awaited()
+        assert "no longer available" in result
+        assert mcp_tool.name in result
+        assert any(
+            "is no longer exposed by the MCP server" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_cached_default_enables_refresh(self):
+        """A cached resource defaults to refresh on, so the tool lists before calling."""
+        resource = AgentMcpResourceConfig(
+            name="cached_server",
+            description="Cached server",
+            folder_path="/Shared",
+            slug="cached",
+            tools_configuration=ToolsConfiguration(discovery_mode=CachedToolsConfig()),
+            available_tools=[
+                AgentMcpTool(
+                    name="tool_a",
+                    description="Tool A",
+                    input_schema={"type": "object", "properties": {}},
+                ),
+            ],
+        )
+        server_tool = Tool(
+            name="tool_a",
+            description="Tool A from server",
+            inputSchema={"type": "object", "properties": {}},
+        )
+        client = self._mock_client([server_tool])
+
+        tools = await create_mcp_tools(resource, client)
+        # create_mcp_tools must not list tools for cached mode (refresh is per-call)
+        client.list_tools.assert_not_awaited()
+
+        await tools[0].ainvoke({})
+        client.list_tools.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cached_refresh_disabled_via_config(self):
+        """refresh_schema_before_call=False on the cached config disables the per-call refresh."""
+        resource = AgentMcpResourceConfig(
+            name="cached_server",
+            description="Cached server",
+            folder_path="/Shared",
+            slug="cached",
+            tools_configuration=ToolsConfiguration(
+                discovery_mode=CachedToolsConfig(refresh_schema_before_call=False)
+            ),
+            available_tools=[
+                AgentMcpTool(
+                    name="tool_a",
+                    description="Tool A",
+                    input_schema={"type": "object", "properties": {}},
+                ),
+            ],
+        )
+        client = self._mock_client([])
+
+        tools = await create_mcp_tools(resource, client)
+        await tools[0].ainvoke({})
+        client.list_tools.assert_not_awaited()
+
+    def _cached_resource(self, input_schema):
+        return AgentMcpResourceConfig(
+            name="cached_server",
+            description="Cached server",
+            folder_path="/Shared",
+            slug="cached",
+            tools_configuration=ToolsConfiguration(discovery_mode=CachedToolsConfig()),
+            available_tools=[
+                AgentMcpTool(
+                    name="ask_question",
+                    description="Ask a question",
+                    input_schema=input_schema,
+                ),
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_breaking_drift_heals_and_asks_retry(self):
+        """On a breaking schema change the tool is not executed: it refreshes the bound
+        schema and returns a retry instruction to the model."""
+        resource = self._cached_resource(
+            {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            }
+        )
+        live_tool = Tool(
+            name="ask_question",
+            description="Ask a question",
+            inputSchema={
+                "type": "object",
+                "properties": {"question": {"type": "string"}},
+                "required": ["question"],
+            },
+        )
+        client = self._mock_client([live_tool])
+
+        tools = await create_mcp_tools(resource, client)
+        tool = cast(StructuredToolWithArgumentProperties, tools[0])
+        assert tool.coroutine is not None
+        # Model issued the call using the stale cached parameter name.
+        result = await tool.coroutine(query="What is X?")
+
+        assert "ask_question" in result
+        # the refreshed param list now includes the type hint
+        assert "question (string)" in result
+        client.call_tool.assert_not_awaited()
+        # The schema bound to the model was healed to the live one.
+        assert tool.args_schema == live_tool.inputSchema
+
+    def test_schema_change_message_lists_param_types(self):
+        """The retry message lists each refreshed param with its type and optionality."""
+        msg = _schema_change_message(
+            "search",
+            {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"},
+                    "filter": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                },
+                "required": ["query"],
+            },
+        )
+        assert "query (string)" in msg
+        assert "limit (integer, optional)" in msg
+        # no simple type -> name (+ optional) only, never a misleading type
+        assert "filter (optional)" in msg
+
+    @pytest.mark.asyncio
+    async def test_after_heal_next_call_executes(self):
+        """After healing, a call matching the live schema executes normally."""
+        resource = self._cached_resource(
+            {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            }
+        )
+        live_tool = Tool(
+            name="ask_question",
+            description="Ask a question",
+            inputSchema={
+                "type": "object",
+                "properties": {"question": {"type": "string"}},
+                "required": ["question"],
+            },
+        )
+        client = self._mock_client([live_tool])
+        tools = await create_mcp_tools(resource, client)
+        tool = cast(StructuredToolWithArgumentProperties, tools[0])
+        assert tool.coroutine is not None
+
+        # First call drifts and heals (the tool is not executed).
+        await tool.coroutine(query="What is X?")
+        client.call_tool.assert_not_awaited()
+
+        # Second call matches the healed schema and executes.
+        await tool.coroutine(question="What is X?")
+        client.call_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_nonbreaking_change_executes_without_retry(self):
+        """An additive (non-breaking) schema change does not trigger a retry."""
+        resource = self._cached_resource(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "required": ["a"],
+            }
+        )
+        live_tool = Tool(
+            name="ask_question",
+            description="Ask a question",
+            inputSchema={
+                "type": "object",
+                "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+                "required": ["a"],
+            },
+        )
+        client = self._mock_client([live_tool])
+        tools = await create_mcp_tools(resource, client)
+        tool = cast(StructuredToolWithArgumentProperties, tools[0])
+        assert tool.coroutine is not None
+
+        result = await tool.coroutine(a="x")
+
+        client.call_tool.assert_awaited_once()
+        assert result == "ok"
 
 
 class TestCreateMcpToolsFromConfig:

--- a/tests/agent/tools/test_static_args.py
+++ b/tests/agent/tools/test_static_args.py
@@ -205,6 +205,53 @@ class TestStaticArgsHandler:
         handler.apply_to_response([call])
         assert call["args"] == {"host": "h"}
 
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["output.", "$.foo.", "foo[", "$.foo[*", "", "$['a'"],
+        ids=[
+            "trailing-dot",
+            "trailing-dot-dollar",
+            "open-bracket",
+            "open-filter",
+            "empty",
+            "open-quote",
+        ],
+    )
+    def test_initialize_raises_typed_error_on_malformed_argument_path(
+        self, bad_path: str
+    ):
+        """A malformed (truncated) JSONPath argument_path surfaces as a typed
+        SYSTEM AgentRuntimeError naming the tool, argument, and offending path -
+        not an opaque jsonpath_ng JsonPathParserError that lands as Unknown
+        (SRE-610701 cat-5)."""
+
+        class InputSchema(BaseModel):
+            present: str = ""
+
+        tool = _create_tool(
+            "verification_tool",
+            {
+                "$['query']": AgentToolArgumentArgumentProperties(
+                    is_sensitive=False, argument_path=bad_path
+                ),
+            },
+        )
+        handler = StaticArgsHandler()
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            handler.initialize([tool], InputSchema(), InputSchema)
+
+        error = exc_info.value
+        assert error.error_info.category == UiPathErrorCategory.SYSTEM
+        assert error.error_info.code.endswith(
+            AgentRuntimeErrorCode.INVALID_STATIC_ARGUMENT.value
+        )
+        # The offending path, argument key, and tool name must all be named so
+        # the failure is debuggable (the raw error names none of them).
+        assert repr(bad_path) in error.error_info.detail
+        assert "$['query']" in error.error_info.detail
+        assert "verification_tool" in error.error_info.detail
+
     def test_apply_to_response_merges_with_existing_args(self):
         """Test that apply_to_response merges static args with existing tool call args."""
         tool = _create_tool(

--- a/tests/chat/test_provider_errors.py
+++ b/tests/chat/test_provider_errors.py
@@ -1,0 +1,127 @@
+"""Tests for normalizing provider HTTP errors into a common shape.
+
+Each provider behind the LLM Gateway raises a different exception type, but all
+carry the same gateway body (``{status, detail, ...}``). ``extract_provider_error``
+reads the status code + detail off whichever attribute the SDK exposes, walking
+the ``__cause__`` chain when LangChain wraps the SDK error.
+"""
+
+import pytest
+from uipath.runtime.errors import UiPathErrorCategory
+
+from uipath_langchain.agent.exceptions.exceptions import (
+    AgentRuntimeError,
+    AgentRuntimeErrorCode,
+)
+from uipath_langchain.agent.exceptions.licensing import raise_for_provider_http_error
+from uipath_langchain.chat.provider_errors import (
+    ProviderError,
+    extract_provider_error,
+)
+
+_DETAIL = "License not available for LLM usage. You need additional 'AGU'."
+_BODY = {
+    "title": "License not available",
+    "status": 403,
+    "detail": _DETAIL,
+}
+
+
+class TestExtractProviderError:
+    def test_openai_status_code_and_body(self) -> None:
+        class OpenAIError(Exception):
+            status_code = 403
+            body = _BODY
+
+        result = extract_provider_error(OpenAIError("Forbidden"))
+        assert result == ProviderError(status_code=403, detail=_DETAIL)
+
+    def test_bedrock_uipath_api_error_same_shape_as_openai(self) -> None:
+        # Bedrock via WrappedBotoClient surfaces as a UiPathAPIError (httpx
+        # subclass) exposing OpenAI-style .status_code / .body.
+        class UiPathPermissionDeniedError(Exception):
+            status_code = 403
+            body = _BODY
+
+        result = extract_provider_error(UiPathPermissionDeniedError("Forbidden"))
+        assert result == ProviderError(status_code=403, detail=_DETAIL)
+
+    def test_vertex_wrapped_in_langchain_error(self) -> None:
+        # google.genai exposes .code + .details; LangChain wraps it in a class
+        # that itself exposes nothing, so the fields live on the __cause__.
+        class GenAIError(Exception):
+            code = 403
+            details = _BODY
+
+        class ChatGoogleGenerativeAIError(Exception):
+            pass
+
+        try:
+            try:
+                raise GenAIError("403")
+            except GenAIError as cause:
+                raise ChatGoogleGenerativeAIError("wrapped") from cause
+        except ChatGoogleGenerativeAIError as wrapper:
+            result = extract_provider_error(wrapper)
+
+        assert result == ProviderError(status_code=403, detail=_DETAIL)
+
+    def test_botocore_response_dict(self) -> None:
+        # Legacy direct boto3 path: botocore.ClientError carries a response dict.
+        class ClientError(Exception):
+            response = {
+                "ResponseMetadata": {"HTTPStatusCode": 403},
+                "Error": {"Code": "AccessDenied", "detail": _BODY["detail"]},
+            }
+
+        result = extract_provider_error(ClientError("denied"))
+        assert result.status_code == 403
+
+    def test_none_returns_empty(self) -> None:
+        result = extract_provider_error(None)
+        assert result == ProviderError()
+        assert not result
+
+    def test_non_int_status_attribute_is_ignored(self) -> None:
+        # An unrelated exception that happens to carry a string `code` must not
+        # be mistaken for a provider HTTP error.
+        class OSLike(Exception):
+            code = "ENOENT"
+
+        assert extract_provider_error(OSLike("nope")) == ProviderError()
+
+
+class TestRaiseForProviderHttpError:
+    def test_403_maps_to_license_not_available(self) -> None:
+        class OpenAIError(Exception):
+            status_code = 403
+            body = _BODY
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            raise_for_provider_http_error(OpenAIError("Forbidden"))
+
+        info = exc_info.value.error_info
+        assert info.status == 403
+        assert info.category == UiPathErrorCategory.DEPLOYMENT
+        assert info.code.endswith(AgentRuntimeErrorCode.LICENSE_NOT_AVAILABLE.value)
+        assert _DETAIL in info.detail
+
+    def test_other_status_falls_back_to_http_error_and_str(self) -> None:
+        # Non-403 status, and no `detail` in the body → detail falls back to str(e).
+        class OpenAIError(Exception):
+            status_code = 500
+            body: dict[str, str] = {}
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            raise_for_provider_http_error(OpenAIError("boom"))
+
+        info = exc_info.value.error_info
+        assert info.status == 500
+        assert info.category == UiPathErrorCategory.UNKNOWN
+        assert info.code.endswith(AgentRuntimeErrorCode.HTTP_ERROR.value)
+        assert "boom" in info.detail  # str(e) fallback
+
+    def test_no_status_does_not_raise(self) -> None:
+        # No extractable HTTP status → no-op (the original exception is left to
+        # propagate from the caller). Reaching the end without raising is the assert.
+        raise_for_provider_http_error(ValueError("unrelated transport error"))

--- a/tests/cli/test_agent_with_guardrails.py
+++ b/tests/cli/test_agent_with_guardrails.py
@@ -1169,7 +1169,7 @@ graph = create_agent(
                         return_value=mock_uipath_instance,
                     ),
                     patch(
-                        "uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value",
+                        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value",
                         mock_resolve,
                     ),
                 ):
@@ -1379,7 +1379,7 @@ graph = create_agent(
                         return_value=mock_uipath_instance,
                     ),
                     patch(
-                        "uipath_langchain.agent.tools.escalation_tool.resolve_recipient_value",
+                        "uipath_langchain.agent.guardrails.actions.escalate_action.resolve_recipient_value",
                         mock_resolve,
                     ),
                 ):

--- a/uv.lock
+++ b/uv.lock
@@ -476,6 +476,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/f5/4473ad9b48cd0420a2d762a3750fa0e078e23e060b1af72662e5987e5530/bracex-3.0.tar.gz", hash = "sha256:b73f718d6bd98d8419e45df02426c86e9967c179949f779340d6c3a8c83b9111", size = 43162, upload-time = "2026-06-30T00:43:35.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/2e/68781b78e764e5ccc4af1e3d27e060069c73af90234853fa80000e7ee79d/bracex-3.0-py3-none-any.whl", hash = "sha256:3833e61c2f092d5aa0468fa2e6c6e990a306185abf763b6d122f0158e59c58a5", size = 11738, upload-time = "2026-06-30T00:43:34.196Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -561,6 +570,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/52/505c207f334d51e937cbaa27ff95776e16e2d120e13cbe491cd7b3a70b50/chardet-7.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:25a862cddc6a9ac07023e808aedd297115345fbaabc2690479481ddc0f980e09", size = 870747, upload-time = "2026-04-13T21:32:56.916Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4b/d3c79495dee4831b8bebca2790e72cb90f0c5849c940570a7c7e5b70b952/chardet-7.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7005c88da26fd95d8abb8acbe6281d833e9a9181b03cf49b4546c4555389bd97", size = 853210, upload-time = "2026-04-13T21:32:58.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/99/f6a822ad1bde25a4c38dc3e770485e78e0893dfd871cd6e18ed3ea3a795e/chardet-7.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc50f28bad067393cce0af9091052c3b8df7a23115afd8ba7b2e0947f0cef1f8", size = 873625, upload-time = "2026-04-13T21:32:59.606Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/10/31932775c94a86814f76b41c4a772b52abfb0e6125324f32c6da1196c297/chardet-7.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3da294de1a681097848ab58bd3f2771a674f8039d2d87a5538b28856b815e9", size = 883436, upload-time = "2026-04-13T21:33:01.351Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/63/0f43e3acf2c436fdb32a0f904aeb03a2904d2126eed34a042a194d235926/chardet-7.4.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:93c45e116dd51b66226a53ade3f9f635e870de5399b90e00ce45dcc311093bf4", size = 876589, upload-time = "2026-04-13T21:33:02.636Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a6/e9b8f8a3e99602792b01fa7d0a731737615ab56d8bfd0b52935a0ef88b85/chardet-7.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:ccc1f83ab4bcfb901cf39e0c4ba6bc6e726fc6264735f10e24ceb5cb47387578", size = 941866, upload-time = "2026-04-13T21:33:04.282Z" },
+    { url = "https://files.pythonhosted.org/packages/61/33/29de185079e6675c3f375546e30a559b7ddc75ce972f18d6e566cd9ea4eb/chardet-7.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971", size = 874870, upload-time = "2026-04-13T21:33:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/4c5af01fd1a7506a1d5375403d68925eac70289229492db5aa68b58103d8/chardet-7.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a", size = 854859, upload-time = "2026-04-13T21:33:07.381Z" },
+    { url = "https://files.pythonhosted.org/packages/36/21/edb36ad5dfa48d7f8eed97ab43931ecdaa8c15166c21b1d614967e49d681/chardet-7.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235", size = 875032, upload-time = "2026-04-13T21:33:08.741Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/a32a241d861cf180853a11c8e5a67641cb1b2af13c3a5ccce83ec07e2c9f/chardet-7.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb", size = 888283, upload-time = "2026-04-13T21:33:10.213Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/e1ee6a77abf3782c00e05b89c4d4328c8353bf9500661c4348df1dd68614/chardet-7.4.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f", size = 879974, upload-time = "2026-04-13T21:33:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/32/60/fca69c534602a7ced04280c952a246ad1edde2a6ca3a164f65d32ac41fe7/chardet-7.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101", size = 943973, upload-time = "2026-04-13T21:33:12.756Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/79ac9b4db5bc87020c9dbc419125371d80882d1d197e9c4765ba8682b605/chardet-7.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e4486df251b8962e86ea9f139ca235aa6e0542a00f7844c9a04160afb99aa9", size = 873769, upload-time = "2026-04-13T21:33:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/25bdec773905bff0ff6cf35ca73b17bd05593b4f87bd8c5fa43705f7167d/chardet-7.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fbff1907925b0c5a1064cffb5e040cd5e338585c9c552625f30de6bc2f3107a", size = 853991, upload-time = "2026-04-13T21:33:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/a29380ee0b215d23d77733b5ad60c5c0c7969650e080c667acdf9462040d/chardet-7.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:365135eaf37ba65a828f8e668eb0a8c38c479dcbec724dc25f4dfd781049c357", size = 874024, upload-time = "2026-04-13T21:33:16.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b1/3338e121cbd4c8a126b8ccb1061170c2ce51a53f678c502793ea49c6fd6d/chardet-7.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc134b70c846c21ead8e43ada3ae1a805fff732f6922f8abcf2ff27b8f6493d", size = 887410, upload-time = "2026-04-13T21:33:18.368Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1c/44a9a9e0c59c185a5d307ceaeee8768afa1558f0a24f7a4b5fa11b67586b/chardet-7.4.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9acd9988a93e09390f3cd231201ea7166c415eb8da1b735928990ffc05cb9fbb", size = 879269, upload-time = "2026-04-13T21:33:20.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b3/5d0e77ea774bd3224321c248880ea0c0379000ac5c2bb6d77609549de247/chardet-7.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:e1b98790c284ff813f18f7cf7de5f05ea2435a080030c7f1a8318f3a4f80b131", size = 944155, upload-time = "2026-04-13T21:33:21.694Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a8/bf0811d859e13801279a2ae64f37a408027b282f2047bc0001c75dd356ad/chardet-7.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531", size = 872887, upload-time = "2026-04-13T21:33:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/b9d68ebddfe1b02c77af5bf81120e12b036b4432dc6af7a303d90e2bc38b/chardet-7.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4", size = 853964, upload-time = "2026-04-13T21:33:24.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/17fa103ea9caf5d325a5e4051ab2ba65996fd66baa60b81ee41af1f54e10/chardet-7.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea", size = 876006, upload-time = "2026-04-13T21:33:26.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/193faab46a68ea550587331a698c3dca8099f8901d10937c4443135c7ed9/chardet-7.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7", size = 887680, upload-time = "2026-04-13T21:33:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/94a3c673327392652ee8bdea9a45bc8a5f5365197a7387d68f0eed007115/chardet-7.4.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93", size = 879865, upload-time = "2026-04-13T21:33:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/cad8b5e3623a987f3c930b68e2bdd06cfc388cd91cd42ed05f1227701b73/chardet-7.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c", size = 939594, upload-time = "2026-04-13T21:33:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e0/d06e42fd6f02a58e5e227e5106587751cb38adcff0aaf949add744b78b6e/chardet-7.4.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e", size = 889714, upload-time = "2026-04-13T21:33:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ed/40d091954d48abea037baae6be8fb79905e5f78d34d12ea955132c7d8011/chardet-7.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11", size = 872319, upload-time = "2026-04-13T21:33:34.427Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/82a46821dbfbdfe062710d2bf2ede13426304e3567a23c57d919c0c31630/chardet-7.4.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c", size = 892021, upload-time = "2026-04-13T21:33:35.766Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/42d30c562bda5b4a839766c1aad8d5856b798ad2a1c3247b72a679afec94/chardet-7.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04", size = 902509, upload-time = "2026-04-13T21:33:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
 ]
 
 [[package]]
@@ -834,6 +880,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
     { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
     { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+]
+
+[[package]]
+name = "deepagents"
+version = "0.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-core" },
+    { name = "langchain-google-genai" },
+    { name = "langsmith" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/74/776e606f0508a4d7d4c9d061c797dcde43eed2452fea546ae29047aeaaa6/deepagents-0.5.9.tar.gz", hash = "sha256:74fe0f998641b20bda8adac662a018051c623a3c8e5ed4b6ff9ad53fc493a783", size = 165651, upload-time = "2026-05-10T22:31:17.095Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/f6/9698f98da72dfa8dc8e1d0f0542f2407a40a50cfdccf522fdb5cb43e39e2/deepagents-0.5.9-py3-none-any.whl", hash = "sha256:ce24a41763b2793bd21217411e9fb9f187a9128da6789f5a81654da1de9e4c7c", size = 188118, upload-time = "2026-05-10T22:31:15.974Z" },
 ]
 
 [[package]]
@@ -1718,30 +1781,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.15"
+version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/a2/91a7197c604a3ce1b774b3c10dd114c3c745c6186a304fc2573b3f94d400/langchain-1.3.11.tar.gz", hash = "sha256:f3cf9cd4d2329b1a03eb8fd92b9d73e4e58a4d52570d67725fc77fbe0f104b32", size = 633374, upload-time = "2026-06-22T23:00:33.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a4/3a181967294f8876362cc4ba36840d50b8286fa23bb3f5e602b69eb3cb1e/langchain-1.3.11-py3-none-any.whl", hash = "sha256:7ae011f95a09b22feea1e8ae4e43f0b6164aebf4c61b8ad845b45f72ff3a90a2", size = 133639, upload-time = "2026-06-22T23:00:31.619Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.1"
+version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/19/55e0d3548a4d85ccee630fcfc0979af54ff4ea4f39ab0ed1ed3c6bf25f4e/langchain_anthropic-1.4.1.tar.gz", hash = "sha256:e17d027091438620e35ff2f06aefdfd63c8dcdf6abc606009ddfe3c764f2bc2e", size = 676043, upload-time = "2026-04-17T14:26:17.31Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/22/40ab129b08329ca295b391aa1d48267692b42594757084c6918e22b655ac/langchain_anthropic-1.4.8.tar.gz", hash = "sha256:c76891b2044d56105ff13c106ed12650637b53bd598a4bdf15b4796eefa2a4ec", size = 708524, upload-time = "2026-06-26T21:28:46.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/0a/20625dfea38a26e8b43654e18cafbc3595e7dc223da80f23d4fa8451dc1d/langchain_anthropic-1.4.1-py3-none-any.whl", hash = "sha256:5a48afbb2b1bad9c46badaccc8e23b0dd7ae07b7583f76bac21ddb3dac831efd", size = 49020, upload-time = "2026-04-17T14:26:15.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/14/746235c4da89d9bc6a608c5f489f628e03feb8f697195c146e452c8f23c8/langchain_anthropic-1.4.8-py3-none-any.whl", hash = "sha256:778e9301b6fd517824f76ec1776975ce8add97a1f6a36c50ae3c2f4b03a66f7f", size = 52366, upload-time = "2026-06-26T21:28:45.535Z" },
 ]
 
 [[package]]
@@ -1790,10 +1853,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -1802,9 +1866,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload-time = "2026-06-18T19:39:23.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload-time = "2026-06-18T19:39:21.902Z" },
 ]
 
 [[package]]
@@ -1905,6 +1969,18 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-protocol"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
+]
+
+[[package]]
 name = "langchain-tests"
 version = "1.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1928,7 +2004,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.9"
+version = "1.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1938,22 +2014,22 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/d5/9d9c65d5500a1ca7ea63d6d65aecfb248037018a74d7d4ef52e276bb4e4b/langgraph-1.1.9.tar.gz", hash = "sha256:bc5a49d5a5e71fda1f9c53c06c62f4caec9a95545b739d130a58b6ab3269e274", size = 560717, upload-time = "2026-04-21T13:43:06.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/11/c3961537ac7577125aabba68effc33ecc3dc0962e2d287d734dbd61caad7/langgraph-1.2.7.tar.gz", hash = "sha256:dcdf5b441bf8c7c7c154e603b302c9dbfbfd2d11e1b7ae7d93a5aba979dc87bd", size = 721385, upload-time = "2026-06-30T01:24:12.528Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/58/0380420e66619d12c992c1f8cfda0c7a04e8f0fe8a84752245b9e7b1cba7/langgraph-1.1.9-py3-none-any.whl", hash = "sha256:7db13ceecde4ea643df6c097dcc9e534895dcd9fcc6500eeff2f2cde0fab16b2", size = 173744, upload-time = "2026-04-21T13:43:05.513Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5d/19de0c674cf2d8bc95b25cdb4c13ba3f4fbe0f35bf2224ef19cc46bbb4cd/langgraph-1.2.7-py3-none-any.whl", hash = "sha256:249349a5d6a32cb0aa2304a8fb6529bd0cf56db8780d21db9e086e5383668f89", size = 246930, upload-time = "2026-06-30T01:24:11.15Z" },
 ]
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.2"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/f2/cf8086e1f1a3358d9228805614e72602c281b18307f3fae64a5b854aad2d/langgraph_checkpoint-4.0.2.tar.gz", hash = "sha256:4f6f99cba8e272deabf81b2d8cdc96582af07a57a6ad591cdf216bb310497039", size = 160810, upload-time = "2026-04-15T21:03:00.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/5a/6dba29dd89b0a46ae21c707da0f9d17e94f27d3e481ed15bc99d6bd20aa6/langgraph_checkpoint-4.0.2-py3-none-any.whl", hash = "sha256:59b0f29216128a629c58dd07c98aa004f82f51805d5573126ffb419b753ff253", size = 51000, upload-time = "2026-04-15T21:02:59.096Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
 ]
 
 [[package]]
@@ -1972,48 +2048,56 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.10"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/01471b1b5601f2e9c9a69c39fc9a2fb8611613ede0002e5a2b81c0acd850/langgraph_prebuilt-1.0.10.tar.gz", hash = "sha256:5a6fc513f8907074563b6218ff991c4ed9db19ac63101314919686e8029ddb07", size = 169769, upload-time = "2026-04-17T17:59:45.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/49/d073375beabdc6955df6cbe570ba7786836bd4c817ae998955d35037f2fd/langgraph_prebuilt-1.0.10-py3-none-any.whl", hash = "sha256:e3baa1977d819982e690a357ba5bb77ccc1d4d8d4a029c48e502a3b6d171185f", size = 36086, upload-time = "2026-04-17T17:59:44.395Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
 ]
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.3.13"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
     { name = "orjson" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/db/77a45127dddcfea5e4256ba916182903e4c31dc4cfca305b8c386f0a9e53/langgraph_sdk-0.3.13.tar.gz", hash = "sha256:419ca5663eec3cec192ad194ac0647c0c826866b446073eb40f384f950986cd5", size = 196360, upload-time = "2026-04-07T20:34:18.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ef/64d64e9f8eea47ce7b939aa6da6863b674c8d418647813c20111645fcc62/langgraph_sdk-0.3.13-py3-none-any.whl", hash = "sha256:aee09e345c90775f6de9d6f4c7b847cfc652e49055c27a2aed0d981af2af3bd0", size = 96668, upload-time = "2026-04-07T20:34:17.866Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
 ]
 
 [[package]]
 name = "langsmith"
-version = "0.7.33"
+version = "0.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
     { name = "uuid-utils" },
+    { name = "websockets" },
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/75/1ee27b3510bf5b1b569b9695c9466c256caab45885bd569c0c67720236ad/langsmith-0.7.33.tar.gz", hash = "sha256:fa2d81ad6e8374a81fda9291894f6fcae714e55fbf11a0b07578e3cd4b1ea384", size = 1186298, upload-time = "2026-04-20T16:17:54.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a7/a78b4105d1c01ee8d404d122d9acc047b8b9f628f3733cb837a321b2f6c6/langsmith-0.9.4.tar.gz", hash = "sha256:36c15e5a692e7812ee927e43d777c6166c839eb02b1d482ba9a805b438b1d91c", size = 4576594, upload-time = "2026-06-30T10:20:43.373Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/76/53033db34ffccd25d62c32b23b9468f7228b455da6976e1c420ae31555c4/langsmith-0.7.33-py3-none-any.whl", hash = "sha256:5b535b991d52d3b664ebb8dc6f95afcf8d0acb42e062ac45a54a6a4820139f20", size = 378981, upload-time = "2026-04-20T16:17:52.503Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/15/79367a3d159141fe4fc138f41db4ef21eb4759cd64cf8f635f41d55ded67/langsmith-0.9.4-py3-none-any.whl", hash = "sha256:f10f07438c7c6f9f907e8c810d8f338268fe863a74c37ded3d8a90830bb25451", size = 603804, upload-time = "2026-06-30T10:20:41.052Z" },
 ]
 
 [[package]]
@@ -4344,7 +4428,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.79"
+version = "2.12.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -4367,31 +4451,32 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/11/d9217e8be4a38414a41c0f03d269cb6fd0b68875a2da3c63c825fbf8ceee/uipath-2.10.79.tar.gz", hash = "sha256:6c5b9a7f55edf2e6ab7e2b09a676f9d4c76c602952470da02d3e2332e6b79b1c", size = 4434820, upload-time = "2026-06-09T06:49:52.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/ad/988407115f57d96b240129ca6fc81dc0ebb13c48c66fe29596bc506cdb22/uipath-2.12.4.tar.gz", hash = "sha256:aff02b54aa5d1a4297e4bf4af0f85cdf917c9d8ad7e8220653b821e956c6ee5c", size = 4470227, upload-time = "2026-07-01T16:19:16.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/84/13fdecc2edb85d9a7148cb6adac518f7da74bc0febe357c4a2c33f14bf4c/uipath-2.10.79-py3-none-any.whl", hash = "sha256:e373ecf855769968c814fc17efba65b2c2aab6e5a24394bfe2698663f919cd7c", size = 393048, upload-time = "2026-06-09T06:49:50.897Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/db/5fbfe8965b5c14673f9a20d2b4bd8212b41dfb2f6dbaf04774136223dc6c/uipath-2.12.4-py3-none-any.whl", hash = "sha256:d2b022f91f5046c8e1560fb002dc0d8c534ed44569d5939223404e248437829b", size = 408359, upload-time = "2026-07-01T16:19:15.018Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.20"
+version = "0.5.28"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/da/011ced5af57363caf7ca6d263261fc4b64f19bf7f7b2a5e54132906a36a6/uipath_core-0.5.20.tar.gz", hash = "sha256:2a2430185522869b10c05273128c23a81fbb8c53ee5dd8686c8b5089ea270fa7", size = 132363, upload-time = "2026-06-19T12:01:37.545Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f9/8d2f1d98cbebbcf059cf4561f38f34ad4cd58423e4f15cad22bd297a2563/uipath_core-0.5.28.tar.gz", hash = "sha256:942987f6b612c64f93d612ad7b242276ed75f129fdd8f25bc71c24ec8887e388", size = 130578, upload-time = "2026-06-30T14:04:48.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/02/b518bb5569c9c35f4ed19a7f23c744c471352a1fa5233071dd75a4cc9324/uipath_core-0.5.20-py3-none-any.whl", hash = "sha256:2be116ec68d034348ea58fd541675863d73e96649f528648d533206b8c8853cc", size = 55005, upload-time = "2026-06-19T12:01:36.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/1e/385bb166232a57ebe938cc57ad2717f350bc922bb5d2ce31af84306b7569/uipath_core-0.5.28-py3-none-any.whl", hash = "sha256:b952a46a21710073cbc16d6d5684e9aa645c107f57a636b778cfb94aa81a1e48", size = 54980, upload-time = "2026-06-30T14:04:47.374Z" },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.12.3"
+version = "0.13.19"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
+    { name = "deepagents" },
     { name = "httpx" },
     { name = "jsonpath-ng" },
     { name = "jsonschema-pydantic-converter" },
@@ -4450,11 +4535,12 @@ dev = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.2.0,<1.0.0" },
     { name = "boto3-stubs", marker = "extra == 'bedrock'", specifier = ">=1.41.4" },
+    { name = "deepagents", specifier = ">=0.5.9,<0.6.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "jsonschema-pydantic-converter", specifier = ">=0.4.0" },
-    { name = "langchain", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.11,<2.0.0" },
+    { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-mcp-adapters", specifier = "==0.2.1" },
     { name = "langgraph", specifier = ">=1.1.8,<2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.3,<4.0.0" },
@@ -4463,17 +4549,17 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.10.79,<2.12.0" },
+    { name = "uipath", specifier = ">=2.11.14,<2.13.0" },
     { name = "uipath-core", specifier = ">=0.5.20,<0.6.0" },
-    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.14.0,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.14.0,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.14.0,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.14.0,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.14.0,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.14.0,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.14.0,<1.15.0" },
-    { name = "uipath-platform", specifier = ">=0.1.71,<0.2.0" },
-    { name = "uipath-runtime", specifier = ">=0.11.0,<0.12.0" },
+    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.14.1,<1.15.0" },
+    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.14.1,<1.15.0" },
+    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.14.1,<1.15.0" },
+    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.14.1,<1.15.0" },
+    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.14.1,<1.15.0" },
+    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.14.1,<1.15.0" },
+    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.14.1,<1.15.0" },
+    { name = "uipath-platform", specifier = ">=0.1.86,<0.2.0" },
+    { name = "uipath-runtime", specifier = ">=0.11.4,<0.12.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
 
@@ -4495,15 +4581,15 @@ dev = [
 
 [[package]]
 name = "uipath-langchain-client"
-version = "1.14.0"
+version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
     { name = "uipath-llm-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/8a/93612bac64797689121bd936edb1c84ff581a574786eb6d2ae34b8b6a966/uipath_langchain_client-1.14.0.tar.gz", hash = "sha256:ccc58027fa5cd4f3931f69549d0dee5b39c704e442bbadeddcac5382c5484fe1", size = 37861, upload-time = "2026-06-16T08:07:39.326Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/7d/e23a745eff9591068d8ee78c0de5b908bed0a9cb3a91b3efd9fba3b37577/uipath_langchain_client-1.14.1.tar.gz", hash = "sha256:c8840d4750f47d3cc85b3b84860330c4950eca2c6609e09114e2eadef83ecdb8", size = 38388, upload-time = "2026-06-23T10:52:45.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/97/3244a64c7cc24df600b5b6637ee0e83e5eb69b4a50555da05c98c5d111fb/uipath_langchain_client-1.14.0-py3-none-any.whl", hash = "sha256:651c4621bfbfe64c79d3181677c5098c12acaac5f1e2da582d52497f02a65337", size = 46668, upload-time = "2026-06-16T08:07:38.452Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a7/72ee48420f26bfb09ee13d5ec951065be40e54609feafc0a997b1af60ffd/uipath_langchain_client-1.14.1-py3-none-any.whl", hash = "sha256:fa85c798c99491819b8b4e6f06d7ba02d8ef848588892babb712f8e760867aae", size = 46794, upload-time = "2026-06-23T10:52:44.193Z" },
 ]
 
 [package.optional-dependencies]
@@ -4556,7 +4642,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.71"
+version = "0.1.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4566,21 +4652,23 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/98/72ed759c6938c2cb9df6994dab516ebdeb127201727591a2bcf3ce71df47/uipath_platform-0.1.71.tar.gz", hash = "sha256:c7b1ff062f894bcbaaff3a69457c47ef9d37712282917cb03b6c2ffda43394ed", size = 378313, upload-time = "2026-06-19T12:03:05.234Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/eb/2882ebad6bd0645a922a7f6fbf16a5204cf54fddd88fd01f3c43e39a9279/uipath_platform-0.1.90.tar.gz", hash = "sha256:11a24264413dfc122401f2702c82b6f4f59e8dacfb476b1ed8a0bcf38133cce5", size = 411800, upload-time = "2026-07-02T09:44:42.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/7a/9ddf7027c7c73a5d94fa2649c4a20a207933b8d481236dc06ba5be662e1f/uipath_platform-0.1.71-py3-none-any.whl", hash = "sha256:8459c0f58255f7ebc1a401e53d62198d2b4845ada8231d9b37cfa71fcefa994f", size = 250513, upload-time = "2026-06-19T12:03:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/42/7a/c60466ca2fd4625542bd92957c25c0a23eb0f93e1ac629e6ec9cdbb72f4b/uipath_platform-0.1.90-py3-none-any.whl", hash = "sha256:6c828d9267d14043a18a9cebc1d27dea3301fa5ca3b5b57d3d9f09140fa1b8e8", size = 271046, upload-time = "2026-07-02T09:44:40.59Z" },
 ]
 
 [[package]]
 name = "uipath-runtime"
-version = "0.11.0"
+version = "0.11.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "chardet" },
     { name = "uipath-core" },
+    { name = "vadersentiment" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/8d/4d36d6a5dda4ca5f25e52508bc20dd82cb92fcdf2a36cd0adc4f9832d047/uipath_runtime-0.11.0.tar.gz", hash = "sha256:cc94f2fdab43b593ef678eff904fc6cdd4831963cffe39a83909ffcf9082d76f", size = 143685, upload-time = "2026-05-29T15:13:30.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/bfe5fedbb50dc8bee83c4e94ce52de8b4ba593384bb7632f52f4aba9d80f/uipath_runtime-0.11.6.tar.gz", hash = "sha256:8d5ba5ad15956df5a478e3be2d0119781e582746cbee12e6bce9b0d4a8e14623", size = 231808, upload-time = "2026-07-01T18:13:58.216Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/08/c7b90851d4544ff5e76ca7c55452597aae1619cf1ebc2c0aa7b098110f14/uipath_runtime-0.11.0-py3-none-any.whl", hash = "sha256:08bf53a0e38bb3d19edc6708d2ecb7d918aa96fdda13e35f3ad0e6f2a6c392b9", size = 43770, upload-time = "2026-05-29T15:13:29.282Z" },
+    { url = "https://files.pythonhosted.org/packages/50/54/8650f261a5d09d77fc4e9b6da7d4fb7c01b7547545db61be41c3cfdb5e9d/uipath_runtime-0.11.6-py3-none-any.whl", hash = "sha256:565b8aa96f97d229d283673dd3fde34078b785984fe5147d995e9ae2115f0f2a", size = 91104, upload-time = "2026-07-01T18:13:56.584Z" },
 ]
 
 [[package]]
@@ -4635,6 +4723,18 @@ wheels = [
 ]
 
 [[package]]
+name = "vadersentiment"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/8c/4a48c10a50f750ae565e341e697d74a38075a3e43ff0df6f1ab72e186902/vaderSentiment-3.3.2.tar.gz", hash = "sha256:5d7c06e027fc8b99238edb0d53d970cf97066ef97654009890b83703849632f9", size = 2466783, upload-time = "2020-05-22T15:06:32.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/fc/310e16254683c1ed35eeb97386986d6c00bc29df17ce280aed64d55537e9/vaderSentiment-3.3.2-py2.py3-none-any.whl", hash = "sha256:3bf1d243b98b1afad575b9f22bc2cb1e212b94ff89ca74f8a23a588d024ea311", size = 125950, upload-time = "2020-05-22T15:07:00.052Z" },
+]
+
+[[package]]
 name = "validators"
 version = "0.35.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4669,6 +4769,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/eb989c3113908e2ef46d940a53695a1ebb4be5a732c4a4f700be8f8d682b/wcmatch-10.2.tar.gz", hash = "sha256:92204839e3e9c945e1e71d7e1e4edeab2601ed50a5c51ff4f3f97ca711eeb738", size = 132499, upload-time = "2026-06-30T00:50:07.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/73/aef4aaf16b8d785762e2b14cf321a9178cc84a1bf4c40f58320f499a2d65/wcmatch-10.2-py3-none-any.whl", hash = "sha256:f1a79e80ccbe296907b7eaf57d8d3bc49eab0b428d35f7d09986b5079b6e4a5d", size = 39742, upload-time = "2026-06-30T00:50:05.927Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Wraps `QueryExecutor.__call__` in a dedicated OTEL span (`"Data Fabric SQL query"`) with structured attributes:
  - `df.sql_query` — the executed SQL
  - `df.success`, `df.record_count` — on success
  - `df.error.code`, `df.error.category`, `df.error.message`, `df.error.trace_id` — on error (parsed from DF server response via `DataFabricError`)
  - `df.entity_count`, `df.native_entity_count`, `df.federated_entity_count`, `df.native_entities`, `df.federated_entities` — entity type classification based on `external_fields` presence
- Builds structured error messages for the inner LLM with error code and actionable hint (e.g. "Fix the SQL syntax and retry")
- Gracefully degrades when `DataFabricError` is not available (older `uipath-platform` without the companion PR)

**Motivation:** DF query errors (400s and 500s) were previously swallowed by `QueryExecutor` with no span attributes — invisible in App Insights. This adds the telemetry needed to diagnose SQL generation failures and track native vs federated usage.

**Companion PR:** UiPath/uipath-python — adds `DataFabricError` classification consumed here.

## Test plan

- [ ] Verify import succeeds with and without `DataFabricError` in `uipath-platform`
- [ ] Verify span attributes are emitted on success and error paths
- [ ] Verify native/federated entity classification based on `external_fields`
- [ ] Existing datafabric tests pass (`uv run pytest -k "datafabric"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)