### PR TITLE
feat: rename reserved escalation field to something more specific

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.18"
+version = "0.13.19"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/escalation_recipient.py
+++ b/src/uipath_langchain/agent/tools/escalation_recipient.py
@@ -33,7 +33,7 @@ _logger = logging.getLogger(__name__)
 
 
 # Reserved input-schema field that carries the agent-inferred ("Custom") recipient.
-RESERVED_RECIPIENT_FIELD = "escalationRecipient"
+RESERVED_RECIPIENT_FIELD = "dynamic__escalationRecipient"
 
 MAX_RECIPIENTS = 50
 MAX_EMAIL_LENGTH = 254

--- a/uv.lock
+++ b/uv.lock
@@ -4439,7 +4439,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.18"
+version = "0.13.19"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Rename reserved escalation field to something more specific in order to avoid possible collisions with app fields defined by user