### PR TITLE
chore(deps): bump uipath-langchain-client to 1.16.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "langchain-mcp-adapters==0.2.1",
     "pillow>=12.1.1",
     "a2a-sdk>=0.2.0,<1.0.0",
-    "uipath-langchain-client[openai]>=1.14.1,<1.15.0",
+    "uipath-langchain-client[openai]>=1.16.1,<1.17.0",
 ]
 
 classifiers = [
@@ -41,21 +41,21 @@ maintainers = [
 
 [project.optional-dependencies]
 anthropic = [
-    "uipath-langchain-client[anthropic]>=1.14.1,<1.15.0",
+    "uipath-langchain-client[anthropic]>=1.16.1,<1.17.0",
 ]
 vertex = [
-    "uipath-langchain-client[google]>=1.14.1,<1.15.0",
-    "uipath-langchain-client[vertexai]>=1.14.1,<1.15.0",
+    "uipath-langchain-client[google]>=1.16.1,<1.17.0",
+    "uipath-langchain-client[vertexai]>=1.16.1,<1.17.0",
 ]
 bedrock = [
-    "uipath-langchain-client[bedrock]>=1.14.1,<1.15.0",
+    "uipath-langchain-client[bedrock]>=1.16.1,<1.17.0",
     "boto3-stubs>=1.41.4",
 ]
 fireworks = [
-    "uipath-langchain-client[fireworks]>=1.14.1,<1.15.0",
+    "uipath-langchain-client[fireworks]>=1.16.1,<1.17.0",
 ]
 all = [
-    "uipath-langchain-client[all]>=1.14.1,<1.15.0",
+    "uipath-langchain-client[all]>=1.16.1,<1.17.0",
 ]
 
 [project.entry-points."uipath.middlewares"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.13.21"
+version = "0.13.22"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -4477,7 +4477,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.13.21"
+version = "0.13.22"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -4556,13 +4556,13 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "uipath", specifier = ">=2.12.7,<2.13.0" },
     { name = "uipath-core", specifier = ">=0.5.20,<0.6.0" },
-    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.14.1,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.14.1,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.14.1,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.14.1,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.14.1,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.14.1,<1.15.0" },
-    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.14.1,<1.15.0" },
+    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.16.1,<1.17.0" },
+    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.16.1,<1.17.0" },
+    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.16.1,<1.17.0" },
+    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.16.1,<1.17.0" },
+    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
+    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.16.1,<1.17.0" },
+    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-platform", specifier = ">=0.1.91,<0.2.0" },
     { name = "uipath-runtime", specifier = ">=0.11.4,<0.12.0" },
 ]
@@ -4586,15 +4586,15 @@ dev = [
 
 [[package]]
 name = "uipath-langchain-client"
-version = "1.14.1"
+version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
     { name = "uipath-llm-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/7d/e23a745eff9591068d8ee78c0de5b908bed0a9cb3a91b3efd9fba3b37577/uipath_langchain_client-1.14.1.tar.gz", hash = "sha256:c8840d4750f47d3cc85b3b84860330c4950eca2c6609e09114e2eadef83ecdb8", size = 38388, upload-time = "2026-06-23T10:52:45.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ab/8081d6dfe07f7d71c1ec3607e3cca4b5e11aff1b81dae23b7a46ca9d2d0a/uipath_langchain_client-1.16.1.tar.gz", hash = "sha256:60d96cc52dafce267a401607ddf9e46f04a5d22e7d616a765f6d8338c0a2b5f8", size = 39484, upload-time = "2026-07-03T15:42:43.356Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/a7/72ee48420f26bfb09ee13d5ec951065be40e54609feafc0a997b1af60ffd/uipath_langchain_client-1.14.1-py3-none-any.whl", hash = "sha256:fa85c798c99491819b8b4e6f06d7ba02d8ef848588892babb712f8e760867aae", size = 46794, upload-time = "2026-06-23T10:52:44.193Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b4/384e3f824b7d870aac1dabd5f90ea65327c56fc1262339658088e0c6ee3d/uipath_langchain_client-1.16.1-py3-none-any.whl", hash = "sha256:313fdf19de27d4d9bf8e9897dbec1462d8528b73a4607f70399b8e9b0e47305c", size = 47613, upload-time = "2026-07-03T15:42:44.19Z" },
 ]
 
 [package.optional-dependencies]
@@ -4631,7 +4631,7 @@ vertexai = [
 
 [[package]]
 name = "uipath-llm-client"
-version = "1.14.0"
+version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4640,9 +4640,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "uipath-platform" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/73/ee91ab5a3066ae96884dd6c19bda1609cfceb9592e1288b4fe69a81f4055/uipath_llm_client-1.14.0.tar.gz", hash = "sha256:6704f4f07b60ea5481f485016c1eff91686a106038f30b662116a842f5321c82", size = 12499974, upload-time = "2026-06-16T08:06:14.627Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/4c/8ee6787ba632fcfe50f5928e50964320c9f4d64ec6df3bd1451e896a8aa2/uipath_llm_client-1.16.0.tar.gz", hash = "sha256:d81605938394fbc12c3130ecd98abd85d3cc4cf317bca65a41a8b8fadb7e1d74", size = 12512889, upload-time = "2026-07-03T12:10:32.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/71/34e87d62366b4b66fde6a961d39a352debecf0644a51e295afad0a0695aa/uipath_llm_client-1.14.0-py3-none-any.whl", hash = "sha256:5f09b9723185febf2e5a91ea42257b84df83cf3e105f2ae85291abcd4fa24074", size = 66103, upload-time = "2026-06-16T08:06:16.849Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/03/c5a988b0a869d6207b1bb693c4674b92fdefb3771f5eb238b1b60cd28b02/uipath_llm_client-1.16.0-py3-none-any.whl", hash = "sha256:fd586a6c05ff6876e33773c915bb87cd643110bf9ff0936e3bb228e1167274bb", size = 67958, upload-time = "2026-07-03T12:10:31Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
| Package | Pin | Locked |
|---|---|---|
| uipath-langchain-client | `>=1.16.1, <1.17.0` (all extras) | 1.14.1 → 1.16.1 |
| uipath-llm-client (transitive) | — | 1.14.0 → 1.16.0 |
| uipath-langchain (this package) | `0.13.21` → `0.13.22` | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)