### PR TITLE
fix(agent): attachment permission error mapping

### DIFF
--- a/src/uipath_langchain/agent/react/job_attachments.py
+++ b/src/uipath_langchain/agent/react/job_attachments.py
@@ -8,10 +8,42 @@ from jsonpath_ng import parse  # type: ignore[import-untyped]
 from langchain_core.messages import BaseMessage, HumanMessage
 from pydantic import BaseModel, ValidationError
 from uipath.platform.attachments import Attachment
+from uipath.platform.errors import EnrichedException
 from uipath.runtime.errors import UiPathErrorCategory
 
-from ..exceptions import AgentRuntimeError, AgentRuntimeErrorCode
+from ..exceptions import AgentRuntimeError, AgentRuntimeErrorCode, raise_for_enriched
 from .json_utils import extract_values_by_paths, get_json_paths_by_type
+
+_JOB_ATTACHMENT_ERRORS: dict[
+    tuple[int, str | None], tuple[str, UiPathErrorCategory]
+] = {
+    (404, None): (
+        "Attachment '{attachment_name}' ({attachment_id}) was not found.",
+        UiPathErrorCategory.SYSTEM,
+    ),
+    (403, "1108"): (
+        "You don't have permissions to access attachment "
+        "'{attachment_name}' ({attachment_id}).",
+        UiPathErrorCategory.DEPLOYMENT,
+    ),
+}
+
+
+def raise_for_job_attachment_error(
+    e: EnrichedException,
+    *,
+    title: str,
+    attachment_name: str | None,
+    attachment_id: uuid.UUID,
+) -> None:
+    """Raise a structured error for known job attachment failures."""
+    raise_for_enriched(
+        e,
+        _JOB_ATTACHMENT_ERRORS,
+        title=title,
+        attachment_name=attachment_name or "<unknown>",
+        attachment_id=str(attachment_id),
+    )
 
 
 def get_job_attachments(

--- a/src/uipath_langchain/agent/tools/extraction_tool.py
+++ b/src/uipath_langchain/agent/tools/extraction_tool.py
@@ -12,7 +12,9 @@ from uipath.agent.models.agent import AgentIxpExtractionResourceConfig
 from uipath.eval.mocks import mockable
 from uipath.platform.common import DocumentExtraction
 from uipath.platform.documents import ExtractionResponseIXP
+from uipath.platform.errors import EnrichedException
 
+from uipath_langchain.agent.react.job_attachments import raise_for_job_attachment_error
 from uipath_langchain.agent.react.types import AgentGraphState
 from uipath_langchain.agent.tools.tool_node import (
     ToolWrapperMixin,
@@ -80,9 +82,18 @@ def create_ixp_extraction_tool(
         # TODO: current workaround. DocumentExtraction model should support attachment_id and use the
         # start_ixp_extraction_from_attachment sdk method once support is added
 
-        attachment_local_file_path = await uipath.attachments.download_async(
-            key=attachment.id, destination_path=attachment.full_name
-        )
+        try:
+            attachment_local_file_path = await uipath.attachments.download_async(
+                key=attachment.id, destination_path=attachment.full_name
+            )
+        except EnrichedException as e:
+            raise_for_job_attachment_error(
+                e,
+                title="Failed to download job attachment",
+                attachment_name=attachment.full_name,
+                attachment_id=attachment.id,
+            )
+            raise
         document_extraction_response = interrupt(
             DocumentExtraction(
                 project_name=project_name,

--- a/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
@@ -34,12 +34,12 @@ from uipath.tracing import (
 from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
     AgentRuntimeErrorCode,
-    raise_for_enriched,
 )
 from uipath_langchain.agent.multimodal import (
     FileInfo,
     build_file_content_blocks_for,
 )
+from uipath_langchain.agent.react.job_attachments import raise_for_job_attachment_error
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
 from uipath_langchain.agent.tools.internal_tools.pii_masker import (
     PiiMasker,
@@ -416,17 +416,11 @@ async def _resolve_job_attachment_arguments(
                 key=attachment_id
             )
         except EnrichedException as e:
-            raise_for_enriched(
+            raise_for_job_attachment_error(
                 e,
-                {
-                    (404, None): (
-                        "Attachment '{attachment_name}' ({attachment_id}) was not found.",
-                        UiPathErrorCategory.SYSTEM,
-                    ),
-                },
                 title="Failed to resolve job attachment",
                 attachment_name=attachment_name,
-                attachment_id=str(attachment_id),
+                attachment_id=attachment_id,
             )
             raise
 

--- a/tests/agent/tools/internal_tools/test_analyze_files_tool.py
+++ b/tests/agent/tools/internal_tools/test_analyze_files_tool.py
@@ -50,6 +50,25 @@ def _make_enriched_404() -> EnrichedException:
     return enriched
 
 
+def _make_enriched_403_1108() -> EnrichedException:
+    req = httpx.Request(
+        "GET", "https://cloud.uipath.com/orchestrator_/odata/Attachments(x)"
+    )
+    resp = httpx.Response(
+        403,
+        request=req,
+        content=(
+            b'{"message":"You don\'t have permissions to access this attachment.",'
+            b'"errorCode":1108}'
+        ),
+        headers={"content-type": "application/json"},
+    )
+    err = httpx.HTTPStatusError("403", request=req, response=resp)
+    enriched = EnrichedException(err)
+    enriched.__cause__ = err
+    return enriched
+
+
 class MockAttachment(BaseModel):
     """Mock attachment model for testing."""
 
@@ -591,6 +610,25 @@ class TestResolveJobAttachmentArguments:
         assert exc_info.value.error_info.category == UiPathErrorCategory.SYSTEM
         detail = exc_info.value.error_info.detail
         assert "document.pdf" in detail
+
+    async def test_resolve_attachment_permission_denied_raises(
+        self, mock_uipath_client
+    ):
+        """A 403/1108 from Orchestrator surfaces as a DEPLOYMENT error, not UNKNOWN."""
+        mock_attachment = MockAttachment(
+            ID="11111111-1111-1111-1111-111111111111",
+            FullName="document.pdf",
+            MimeType="application/pdf",
+        )
+        mock_uipath_client.attachments.get_blob_file_access_uri_async = AsyncMock(
+            side_effect=_make_enriched_403_1108()
+        )
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            await _resolve_job_attachment_arguments([mock_attachment])
+        assert exc_info.value.error_info.category == UiPathErrorCategory.DEPLOYMENT
+        assert "permissions" in exc_info.value.error_info.detail
+        assert "document.pdf" in exc_info.value.error_info.detail
 
     async def test_resolve_attachments_mixed_valid_and_invalid(
         self, mock_uipath_client

--- a/tests/agent/tools/test_extraction_tool.py
+++ b/tests/agent/tools/test_extraction_tool.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
+import httpx
 import pytest
 from uipath.agent.models.agent import (
     AgentIxpExtractionResourceConfig,
@@ -10,11 +11,30 @@ from uipath.agent.models.agent import (
 )
 from uipath.platform.attachments import Attachment
 from uipath.platform.documents import ExtractionResponseIXP
+from uipath.platform.errors import EnrichedException
+from uipath.runtime.errors import UiPathErrorCategory
 
+from uipath_langchain.agent.exceptions import AgentRuntimeError
 from uipath_langchain.agent.tools.extraction_tool import (
     ExtractionToolInputSchema,
     create_ixp_extraction_tool,
 )
+
+
+def _make_attachment_error(status_code: int, content: bytes) -> EnrichedException:
+    req = httpx.Request(
+        "GET", "https://cloud.uipath.com/orchestrator_/odata/Attachments(x)"
+    )
+    resp = httpx.Response(
+        status_code,
+        request=req,
+        content=content,
+        headers={"content-type": "application/json"},
+    )
+    err = httpx.HTTPStatusError(str(status_code), request=req, response=resp)
+    enriched = EnrichedException(err)
+    enriched.__cause__ = err
+    return enriched
 
 
 class TestExtractionToolMetadata:
@@ -243,6 +263,67 @@ class TestExtractionToolFunctionality:
             )
 
         assert "Download failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("uipath.platform.UiPath")
+    async def test_extraction_tool_permission_denied_raises_deployment(
+        self, mock_uipath_class, extraction_resource
+    ):
+        """A 403/1108 from Orchestrator surfaces as a DEPLOYMENT error, not UNKNOWN."""
+        enriched = _make_attachment_error(
+            403,
+            (
+                b'{"message":"You don\'t have permissions to access this attachment.",'
+                b'"errorCode":1108}'
+            ),
+        )
+
+        mock_client = MagicMock()
+        mock_uipath_class.return_value = mock_client
+        mock_client.attachments.download_async = AsyncMock(side_effect=enriched)
+
+        tool = create_ixp_extraction_tool(extraction_resource)
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            await tool.ainvoke(
+                {
+                    "id": "fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f",
+                    "full_name": "file.pdf",
+                    "mime_type": "application/pdf",
+                }
+            )
+
+        assert exc_info.value.error_info.category == UiPathErrorCategory.DEPLOYMENT
+        assert "permissions" in exc_info.value.error_info.detail
+
+    @pytest.mark.asyncio
+    @patch("uipath.platform.UiPath")
+    async def test_extraction_tool_missing_attachment_raises_system(
+        self, mock_uipath_class, extraction_resource
+    ):
+        """A missing attachment uses the same structured mapping as attachment URI resolution."""
+        mock_client = MagicMock()
+        mock_uipath_class.return_value = mock_client
+        mock_client.attachments.download_async = AsyncMock(
+            side_effect=_make_attachment_error(
+                404,
+                b'{"message":"Attachment not found"}',
+            )
+        )
+
+        tool = create_ixp_extraction_tool(extraction_resource)
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            await tool.ainvoke(
+                {
+                    "id": "fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f",
+                    "full_name": "file.pdf",
+                    "mime_type": "application/pdf",
+                }
+            )
+
+        assert exc_info.value.error_info.category == UiPathErrorCategory.SYSTEM
+        assert "file.pdf" in exc_info.value.error_info.detail
 
     @pytest.mark.asyncio
     @patch("uipath.platform.UiPath")


### PR DESCRIPTION
## Summary

- Add a single `raise_for_job_attachment_error` categorizer to the existing job attachment utilities.
- Use that categorizer from both IXP extraction attachment download and analyze-files attachment URI resolution.
- Add regression coverage for attachment permission failures in both paths, plus missing-attachment handling on the extraction download path.

## Root cause

Attachment access failures from Orchestrator arrive as `EnrichedException` instances. The agent had attachment-specific handling in one caller and no classification in another, which made known attachment failures easy to handle inconsistently. The shared categorizer now maps attachment `404` and `403` / `errorCode: 1108` failures uniformly while leaving each caller's SDK operation local.

## Validation

- `uv run pytest tests/agent/tools/internal_tools/test_analyze_files_tool.py tests/agent/tools/test_extraction_tool.py -q`
- `uv run ruff check src/uipath_langchain/agent/react/job_attachments.py src/uipath_langchain/agent/tools/extraction_tool.py src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py tests/agent/tools/internal_tools/test_analyze_files_tool.py tests/agent/tools/test_extraction_tool.py`
- `uv run ruff format src/uipath_langchain/agent/react/job_attachments.py src/uipath_langchain/agent/tools/extraction_tool.py src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py tests/agent/tools/internal_tools/test_analyze_files_tool.py tests/agent/tools/test_extraction_tool.py`
- `git diff --check origin/main...HEAD`
