### PR TITLE
docs: add wait until timeout sample

### DIFF
--- a/docs/human_in_the_loop.md
+++ b/docs/human_in_the_loop.md
@@ -215,6 +215,155 @@ The return value of the interrupt is the job output. If the job did not produce 
 
 ---
 
+## Time waits and composite interrupts
+
+### WaitUntil
+
+Waits until an absolute point in time. The `resume_time` value must include timezone information; it is normalized to a UTC instant.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `resume_time` | `datetime` | The timezone-aware instant when the agent should resume. |
+
+```python
+from datetime import UTC, datetime, timedelta
+
+from langgraph.types import interrupt
+from uipath.platform.common import WaitUntil
+
+resume_at = datetime.now(UTC) + timedelta(minutes=10)
+timer_result = interrupt(WaitUntil(resume_time=resume_at))
+```
+
+`WaitUntil` returns a payload containing the resume time. Use it directly when the timer itself is the work the agent is waiting for.
+
+### Waiting for the first completed trigger
+
+Pass a list of interrupt models when the agent should resume on whichever trigger completes first. Composite interrupts can combine any supported interrupt models, such as tasks, process jobs, Integration Service events, timers, and so on.
+
+Use this pattern whenever several independent events can unblock the same suspended agent.
+
+```python
+from langgraph.types import interrupt
+from uipath.core.triggers import UiPathResumeTriggerType
+from uipath.platform.common import CreateEscalation, InvokeProcess
+from uipath.platform.common import get_resume_metadata
+
+result = interrupt(
+    [
+        InvokeProcess(
+            name="background-validator",
+            process_folder_path="Shared",
+            input_arguments={"invoice_id": "INV-1001"},
+        ),
+        CreateEscalation(
+            app_name="Invoice Review",
+            app_folder_path="Shared",
+            title="Review invoice INV-1001",
+            data={"invoice_id": "INV-1001"},
+        ),
+    ]
+)
+```
+
+In this example, the agent resumes when either the validation process finishes or the reviewer completes the escalation task. The interrupt result is the resume value from whichever model completed first.
+
+When a composite interrupt resumes, UiPath adds metadata under the reserved `__uipath` key:
+
+```python
+{
+    "__uipath": {
+        "triggerType": "Job",
+        "triggerName": "Job",
+    },
+    ...
+}
+```
+
+Timeout resume values also include `"kind": "timeout"`.
+
+Use `get_resume_metadata(...)` to read this metadata as a typed object:
+
+```python
+metadata = get_resume_metadata(result)
+
+if metadata and metadata.trigger_type == UiPathResumeTriggerType.JOB:
+    # result is the InvokeProcess output
+    ...
+elif metadata and metadata.trigger_type == UiPathResumeTriggerType.TASK:
+    # result is the CreateEscalation task
+    ...
+```
+
+You can also combine more than two operations:
+
+```python
+from langgraph.types import interrupt
+from uipath.platform.common import CreateDeepRag, CreateEscalation, InvokeProcess
+
+result = interrupt(
+    [
+        CreateDeepRag(
+            name="contract-search",
+            index_name="Contracts",
+            prompt="Find termination clauses for Contoso",
+        ),
+        InvokeProcess(
+            name="contract-summary-agent",
+            process_folder_path="Shared",
+            input_arguments={"customer": "Contoso"},
+        ),
+        CreateEscalation(
+            app_name="Contract Review",
+            app_folder_path="Shared",
+            title="Review Contoso contract",
+            data={"customer": "Contoso"},
+        ),
+    ]
+)
+```
+
+This is also useful for timeout-style flows by adding a `WaitUntil` timer to the same list:
+
+```python
+from datetime import UTC, datetime, timedelta
+
+from langgraph.types import interrupt
+from uipath.platform.common import InvokeProcess, WaitUntil, assert_no_timeout
+
+resume_at = datetime.now(UTC) + timedelta(minutes=10)
+child_result = interrupt(
+    [
+        InvokeProcess(
+            name="timeout-child-agent",
+            process_folder_path="Shared",
+            input_arguments={"message": "start child work"},
+        ),
+        WaitUntil(resume_time=resume_at),
+    ]
+)
+
+assert_no_timeout(child_result)
+```
+
+When `InvokeProcess` completes first, `child_result` is the child process output. When `WaitUntil` completes first, `assert_no_timeout(child_result)` raises `UiPathTimeoutError`.
+
+For a practical implementation, refer to the [wait-until-timeout-agent sample](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/wait-until-timeout-agent).
+
+### Timeout helpers
+
+Timeout helper functions are imported from `uipath.platform.common`.
+
+| Helper | Description |
+| --- | --- |
+| `assert_no_timeout(value)` | Returns the original value when it is not a timeout. Raises `UiPathTimeoutError` when the resume value came from a timeout trigger. |
+| `is_timeout(value)` | Returns `True` when the resume value came from a timeout trigger. |
+| `get_resume_metadata(value)` | Returns typed UiPath resume metadata when the value includes UiPath metadata. The metadata includes fields such as `kind`, `trigger_type`, and `trigger_name`. |
+
+Use `assert_no_timeout(...)` when timeout should stop the current path. Use `is_timeout(...)` when timeout is a branch you want to handle explicitly. Use `get_resume_metadata(...)` when a composite interrupt has more than one non-time trigger and the code needs to inspect which UiPath trigger resumed the agent.
+
+---
+
 ## Context Grounding (RAG)
 
 These models drive Context Grounding operations: Deep RAG queries, ephemeral indexes, and batch transforms. Each `Create*` model starts an asynchronous operation and suspends the agent; the matching `Wait*` model resumes once the operation completes. Where a `Raw` variant exists, it returns the underlying response without validating its final status, so the agent can inspect the status itself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "Python SDK that enables developers to build and deploy LangGraph 
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.13.0, <2.14.0",
-    "uipath-core>=0.5.28, <0.6.0",
-    "uipath-platform>=0.2.0, <0.3.0",
+    "uipath>=2.13.3, <2.14.0",
+    "uipath-core>=0.5.29, <0.6.0",
+    "uipath-platform>=0.2.2, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
     "uipath-llm-client>=1.16.2, <1.17.0",
     "langgraph>=1.1.8, <2.0.0",

--- a/samples/README.md
+++ b/samples/README.md
@@ -41,3 +41,6 @@ This sample shows how to build a LangGraph agent that connects to a remote UiPat
 
 ## [Ticket classification](ticket-classification)
 This sample demonstrates automatic classification of support tickets into categories. It includes a human approval step via UiPath Action Center.
+
+## [Wait until timeout agent](wait-until-timeout-agent)
+This sample demonstrates waiting for whichever happens first: a child UiPath process completes, or a timer expires.

--- a/samples/wait-until-timeout-agent/README.md
+++ b/samples/wait-until-timeout-agent/README.md
@@ -1,0 +1,55 @@
+# Wait Until Timeout Agent
+
+This sample shows how a LangGraph agent can wait for whichever happens first:
+a child UiPath process completes, or a timer expires.
+
+The parent agent uses:
+
+```python
+interrupt([
+    InvokeProcess(...),
+    WaitUntil(...),
+])
+```
+
+If the child process completes first, the interrupt returns the child process
+output. If the timer completes first, `assert_no_timeout(...)` raises
+`UiPathTimeoutError`.
+
+## Files
+
+- `graph.py`: parent agent graph.
+- `bindings.json`: process binding for the child process.
+- `uipath.json`: UiPath agent configuration.
+- `langgraph.json`: LangGraph graph entrypoint.
+
+## Child Process
+
+The sample references a process named `timeout-child-agent` in the `Shared`
+folder:
+
+```python
+CHILD_PROCESS_NAME = "timeout-child-agent"
+CHILD_PROCESS_FOLDER_PATH = "Shared"
+```
+
+For local runs, change `CHILD_PROCESS_NAME` and `CHILD_PROCESS_FOLDER_PATH` to
+match a process in your tenant.
+
+For cloud runs, deploy the package and choose an override from your tenant for
+the `timeout-child-agent.Shared` process binding. The binding is already
+configured in `bindings.json`.
+
+For timeout testing, use a child process that runs longer than 10 minutes, or
+reduce the `WaitUntil` duration in `graph.py`.
+
+## Run
+
+```bash
+cd samples/wait-until-timeout-agent
+uv sync
+uipath run agent '{"message": "start child work"}'
+```
+
+When publishing the sample, use the existing `timeout-child-agent.Shared`
+binding and select the process you want the parent agent to invoke.

--- a/samples/wait-until-timeout-agent/bindings.json
+++ b/samples/wait-until-timeout-agent/bindings.json
@@ -1,0 +1,26 @@
+{
+  "version": "2.0",
+  "resources": [
+    {
+      "resource": "process",
+      "key": "timeout-child-agent.Shared",
+      "value": {
+        "name": {
+          "defaultValue": "timeout-child-agent",
+          "isExpression": false,
+          "displayName": "Child Process Name"
+        },
+        "folderPath": {
+          "defaultValue": "Shared",
+          "isExpression": false,
+          "displayName": "Child Process Folder Path"
+        }
+      },
+      "metadata": {
+        "ActivityName": "InvokeProcess",
+        "BindingsVersion": "2.2",
+        "DisplayLabel": "timeout-child-agent"
+      }
+    }
+  ]
+}

--- a/samples/wait-until-timeout-agent/graph.py
+++ b/samples/wait-until-timeout-agent/graph.py
@@ -1,0 +1,56 @@
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from langgraph.constants import END, START
+from langgraph.graph import StateGraph
+from langgraph.types import interrupt
+from pydantic import BaseModel
+from uipath.platform.common import InvokeProcess, WaitUntil, assert_no_timeout
+
+CHILD_PROCESS_NAME = "timeout-child-agent"
+CHILD_PROCESS_FOLDER_PATH = "Shared"
+
+
+class Input(BaseModel):
+    message: str = "run the child process"
+
+
+class Output(BaseModel):
+    result: str
+
+
+class State(BaseModel):
+    message: str
+    result: str = ""
+
+
+async def parent_node(state: State) -> dict[str, Any]:
+    resume_time = datetime.now(UTC) + timedelta(minutes=10)
+
+    child_result = interrupt(
+        [
+            InvokeProcess(
+                name=CHILD_PROCESS_NAME,
+                process_folder_path=CHILD_PROCESS_FOLDER_PATH,
+                input_arguments={"message": state.message},
+            ),
+            # allows up to 10 minutes for the child process to finish.
+            WaitUntil(resume_time=resume_time),
+        ]
+    )
+
+    # raises UiPathTimeoutError on timeout.
+    assert_no_timeout(child_result)
+
+    return {
+        "message": state.message,
+        "result": f"child completed: {child_result}",
+    }
+
+
+builder = StateGraph(state_schema=State)
+builder.add_node("parent", parent_node)
+builder.add_edge(START, "parent")
+builder.add_edge("parent", END)
+
+graph = builder.compile()

--- a/samples/wait-until-timeout-agent/langgraph.json
+++ b/samples/wait-until-timeout-agent/langgraph.json
@@ -1,0 +1,5 @@
+{
+  "graphs": {
+    "agent": "./graph.py:graph"
+  }
+}

--- a/samples/wait-until-timeout-agent/pyproject.toml
+++ b/samples/wait-until-timeout-agent/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "wait-until-timeout-agent"
+version = "0.0.1"
+description = "LangGraph agent that waits for a child process or a timer"
+authors = [{ name = "UiPath", email = "support@uipath.com" }]
+requires-python = ">=3.11"
+dependencies = [
+    "uipath-langchain",
+    "uipath>=2.13.3,<2.14.0",
+]
+
+[dependency-groups]
+dev = [
+    "uipath-dev",
+]

--- a/samples/wait-until-timeout-agent/uipath.json
+++ b/samples/wait-until-timeout-agent/uipath.json
@@ -1,0 +1,5 @@
+{
+  "runtimeOptions": {
+    "isConversational": false
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -4432,7 +4432,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.0"
+version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -4456,23 +4456,23 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/15/c01594e4458b0963379f3f13fe5472b7740480d2497deba3cbda2f5ef04f/uipath-2.13.0.tar.gz", hash = "sha256:7e8ae855d25e1ab1716aa1e2a1e8ba98118c3b3d671772ebb5869d03cae32139", size = 4493516, upload-time = "2026-07-06T13:44:42.007Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/2b/42848522df8a0d9e674aef9a0267fe15c3c4df69d490e080a3166f2400d2/uipath-2.13.3.tar.gz", hash = "sha256:5f35669d9f96f4e797a22278006f551be2ee24e067d0ad32b61d983933d18418", size = 4495433, upload-time = "2026-07-07T10:29:23.936Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/97/54bfcddb08aa1203be74fed1d02d8dd4aace433716979ecc31a152cecd4f/uipath-2.13.0-py3-none-any.whl", hash = "sha256:313e1a3049b22326ab5dfa04a5892c79651a275b9ddeec1f896c28607fe771ce", size = 417567, upload-time = "2026-07-06T13:44:40.12Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ee/f3991b7b5f321b5a5ae195d4bb0315ea99dc184d2670126269f294ff1378/uipath-2.13.3-py3-none-any.whl", hash = "sha256:95159a1d1b237152125327d52b33941b0aae808c77825240c2953629fe502649", size = 417701, upload-time = "2026-07-07T10:29:21.363Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.28"
+version = "0.5.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/f9/8d2f1d98cbebbcf059cf4561f38f34ad4cd58423e4f15cad22bd297a2563/uipath_core-0.5.28.tar.gz", hash = "sha256:942987f6b612c64f93d612ad7b242276ed75f129fdd8f25bc71c24ec8887e388", size = 130578, upload-time = "2026-06-30T14:04:48.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/bf/83e261295dd5d5137d2a17d455ee43d090decdb683654042f0f97bae74a5/uipath_core-0.5.29.tar.gz", hash = "sha256:f931d6ad866c3b70dc93e25e3d1cc9e484deb7061d61efe41f6ae094e5acafb2", size = 130862, upload-time = "2026-07-07T10:27:13.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/1e/385bb166232a57ebe938cc57ad2717f350bc922bb5d2ce31af84306b7569/uipath_core-0.5.28-py3-none-any.whl", hash = "sha256:b952a46a21710073cbc16d6d5684e9aa645c107f57a636b778cfb94aa81a1e48", size = 54980, upload-time = "2026-06-30T14:04:47.374Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/34/0b58685eacae7cfff0a2281348f33ea1f2559d91f3702f16c2b15ac4f504/uipath_core-0.5.29-py3-none-any.whl", hash = "sha256:fac1521f3963ff5787b63dc02d2e26417f298eef4bbc40a2851f857f24aa37cd", size = 55049, upload-time = "2026-07-07T10:27:11.921Z" },
 ]
 
 [[package]]
@@ -4555,8 +4555,8 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "uipath", specifier = ">=2.13.0,<2.14.0" },
-    { name = "uipath-core", specifier = ">=0.5.28,<0.6.0" },
+    { name = "uipath", specifier = ">=2.13.3,<2.14.0" },
+    { name = "uipath-core", specifier = ">=0.5.29,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.16.1,<1.17.0" },
@@ -4565,7 +4565,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-llm-client", specifier = ">=1.16.2,<1.17.0" },
-    { name = "uipath-platform", specifier = ">=0.2.0,<0.3.0" },
+    { name = "uipath-platform", specifier = ">=0.2.2,<0.3.0" },
     { name = "uipath-runtime", specifier = ">=0.12.1,<0.13.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
@@ -4649,7 +4649,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4659,9 +4659,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2e/86bee6d9aa5d00ef95e729f3d37c78b3dbe8ebf83519f88357be5240ae76/uipath_platform-0.2.0.tar.gz", hash = "sha256:86bb1dbb4267afe43719276809bc7ebe7e9f9885ca8238da13a9776848636576", size = 412145, upload-time = "2026-07-06T13:42:39.658Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b6/a776ef1ba59189e69f6d04f3728dde1fbd02219f78f03bd80d9b888a834f/uipath_platform-0.2.2.tar.gz", hash = "sha256:c131b7c943efdde83f08e4161c8d1b4170b8fffd9d961dbea2486d6f8b85daf4", size = 414645, upload-time = "2026-07-07T10:28:10.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/94/70e858975f022c44fa3d539632eb22a1a038ae39b4b187376e678371941a/uipath_platform-0.2.0-py3-none-any.whl", hash = "sha256:378986cb161521301560e32c2ea93950e1f14e8905bc7e3f6e034f548f2c6ac0", size = 271644, upload-time = "2026-07-06T13:42:38.246Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c6/cab60e437565e9ca600d793e1ab60f6dc5aeac785de1ee5dde498fee642c/uipath_platform-0.2.2-py3-none-any.whl", hash = "sha256:9882f6d25473b6b4df3d26f537e46339d6f52081c1113f8b7e5543f8bafa9494", size = 274146, upload-time = "2026-07-07T10:28:08.971Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a LangGraph sample that waits on a child process or `WaitUntil`
- document `WaitUntil`, composite interrupts, and timeout helpers
- update UiPath dependency floors to the published helper-capable patch versions