### PR TITLE
fix: set_conversational_output leaking CAS event, phantom CAS events for OpenAI envelope chunk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.4"
+version = "0.14.5"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/agent.py
+++ b/src/uipath_langchain/agent/react/agent.py
@@ -135,9 +135,7 @@ def create_agent(
         and has_custom_conversational_output_fields(output_schema)
     )
 
-    terminate_node = create_terminate_node(
-        output_schema, config.is_conversational, with_conversational_output_node
-    )
+    terminate_node = create_terminate_node(output_schema, config.is_conversational)
 
     CompleteAgentGraphState = create_state_with_input(
         input_schema if input_schema is not None else BaseModel

--- a/src/uipath_langchain/agent/react/conversational_output_node.py
+++ b/src/uipath_langchain/agent/react/conversational_output_node.py
@@ -105,7 +105,7 @@ def create_conversational_output_node(
         if set_output_call is None:
             raise AgentRuntimeError(
                 code=AgentRuntimeErrorCode.LLM_INVALID_RESPONSE,
-                title="Structured-output LLM did not return set_conversational_output.",
+                title="Structured-output LLM did not call set_conversational_output.",
                 detail=(
                     "The language model was expected to call the set_conversational_output tool "
                     "to return the structured output for the turn, but no such call was made."

--- a/src/uipath_langchain/agent/react/conversational_output_node.py
+++ b/src/uipath_langchain/agent/react/conversational_output_node.py
@@ -12,6 +12,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables.config import var_child_runnable_config
 from pydantic import BaseModel
+from uipath.agent.react import SET_CONVERSATIONAL_OUTPUT_TOOL
 from uipath.agent.react.conversational_prompts import (
     get_generate_output_prompt,
 )
@@ -35,7 +36,7 @@ def create_conversational_output_node(
     model: BaseChatModel,
     agent_output_schema: type[BaseModel],
 ):
-    """Build the focused structured-output extraction node.
+    """Build the conversational structured-output node.
 
     Args:
         model: The chat model to invoke for the extraction call. Reused from
@@ -61,9 +62,6 @@ def create_conversational_output_node(
     output_prompt = get_generate_output_prompt()
 
     async def conversational_output_node(state: StateT):
-        # The appended HumanMessage stays local to this LLM call — only the
-        # response is returned to state, so the framework instruction never
-        # enters the persisted conversation history.
         messages = [*state.messages, HumanMessage(content=output_prompt)]
         config = config_without_streaming(var_child_runnable_config.get(None))
 
@@ -96,6 +94,25 @@ def create_conversational_output_node(
 
         payload_handler.check_stop_reason(response)
 
-        return {"messages": [response]}
+        set_output_call = next(
+            (
+                tc
+                for tc in (response.tool_calls or [])
+                if tc["name"] == SET_CONVERSATIONAL_OUTPUT_TOOL.name
+            ),
+            None,
+        )
+        if set_output_call is None:
+            raise AgentRuntimeError(
+                code=AgentRuntimeErrorCode.LLM_INVALID_RESPONSE,
+                title="Structured-output LLM did not return set_conversational_output.",
+                detail=(
+                    "The language model was expected to call the set_conversational_output tool "
+                    "to return the structured output for the turn, but no such call was made."
+                ),
+                category=UiPathErrorCategory.SYSTEM,
+            )
+
+        return {"inner_state": {"conversational_output": set_output_call["args"]}}
 
     return conversational_output_node

--- a/src/uipath_langchain/agent/react/terminate_node.py
+++ b/src/uipath_langchain/agent/react/terminate_node.py
@@ -77,16 +77,16 @@ def _handle_end_conversational(
     # Populated by GENERATE_CONVERSATIONAL_OUTPUT when the output schema has custom
     # fields; None otherwise. Missing required fields surface via schema validation below.
     custom_output_fields = state.inner_state.conversational_output or {}
-    new_conversation_messages = state.messages[initial_count:]
+    new_messages = state.messages[initial_count:]
 
     converted_messages: list[UiPathConversationMessageData] = []
 
     # For the agent-output messages, don't include tool-results. Just include agent's LLM outputs and tool-calls + inputs.
     # This is primarily since evaluations don't check for tool-results; this output represents the agent's actual choices rather than tool-results.
-    if new_conversation_messages:
+    if new_messages:
         converted_messages = (
             UiPathChatMessagesMapper.map_langchain_messages_to_uipath_message_data_list(
-                messages=new_conversation_messages, include_tool_results=False
+                messages=new_messages, include_tool_results=False
             )
         )
 

--- a/src/uipath_langchain/agent/react/terminate_node.py
+++ b/src/uipath_langchain/agent/react/terminate_node.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, ValidationError
 from uipath.agent.react import (
     END_EXECUTION_TOOL,
     RAISE_ERROR_TOOL,
-    SET_CONVERSATIONAL_OUTPUT_TOOL,
 )
 from uipath.core.chat import UiPathConversationMessageData
 from uipath.runtime.errors import UiPathErrorCategory
@@ -55,7 +54,6 @@ def _handle_raise_error(args: dict[str, Any]) -> NoReturn:
 def _handle_end_conversational(
     state: AgentGraphState,
     response_schema: type[BaseModel] | None,
-    with_conversational_output_node: bool = False,
 ) -> dict[str, Any]:
     """Handle conversational agent termination by returning converted messages with optional structured output fields."""
 
@@ -76,47 +74,10 @@ def _handle_end_conversational(
         )
 
     initial_count = state.inner_state.initial_message_count
-
-    custom_output_fields: dict[str, Any] = {}
-    if with_conversational_output_node:
-        # with_conversational_output_node means that a node before TERMINATE
-        # produces an AIMessage carrying a `set_conversational_output` tool call.
-        # Extract the custom-field args from that call, and strip its AIMessage from message-history.
-        last_ai_message = state.messages[-1] if state.messages else None
-
-        if not isinstance(last_ai_message, AIMessage):
-            raise AgentRuntimeError(
-                code=AgentRuntimeErrorCode.STATE_ERROR,
-                title="Expected last message to be an AIMessage for conversational agent termination.",
-                detail=(
-                    "Last message in state is expected to be an AIMessage containing a `set_conversational_output` tool call."
-                ),
-                category=UiPathErrorCategory.SYSTEM,
-            )
-
-        set_output_call = next(
-            (
-                tc
-                for tc in (last_ai_message.tool_calls or [])
-                if tc["name"] == SET_CONVERSATIONAL_OUTPUT_TOOL.name
-            ),
-            None,
-        )
-        if set_output_call is None:
-            raise AgentRuntimeError(
-                code=AgentRuntimeErrorCode.STATE_ERROR,
-                title="No set_conversational_output tool call found.",
-                detail=(
-                    "The conversational output node was expected to produce a set_conversational_output tool call "
-                    "in the last AIMessage, but none was found."
-                ),
-                category=UiPathErrorCategory.SYSTEM,
-            )
-
-        custom_output_fields = dict(set_output_call["args"])
-        new_conversation_messages = state.messages[initial_count:-1]
-    else:
-        new_conversation_messages = state.messages[initial_count:]
+    # Populated by GENERATE_CONVERSATIONAL_OUTPUT when the output schema has custom
+    # fields; None otherwise. Missing required fields surface via schema validation below.
+    custom_output_fields = state.inner_state.conversational_output or {}
+    new_conversation_messages = state.messages[initial_count:]
 
     converted_messages: list[UiPathConversationMessageData] = []
 
@@ -155,7 +116,6 @@ def _handle_end_conversational(
 def create_terminate_node(
     response_schema: type[BaseModel] | None = None,
     is_conversational: bool = False,
-    with_conversational_output_node: bool = False,
 ):
     """Handles Agent Graph termination for multiple sources and output or error propagation to Orchestrator.
 
@@ -167,9 +127,7 @@ def create_terminate_node(
 
     def terminate_node(state: AgentGraphState):
         if is_conversational:
-            return _handle_end_conversational(
-                state, response_schema, with_conversational_output_node
-            )
+            return _handle_end_conversational(state, response_schema)
         else:
             last_message = state.messages[-1]
             if not isinstance(last_message, AIMessage):

--- a/src/uipath_langchain/agent/react/types.py
+++ b/src/uipath_langchain/agent/react/types.py
@@ -28,6 +28,7 @@ class InnerAgentGraphState(BaseModel):
     initial_message_count: int | None = None
     tools_storage: Annotated[dict[Hashable, Any], merge_dicts] = {}
     memory_injection: str = ""
+    conversational_output: dict[str, Any] | None = None
 
 
 class InnerAgentGuardrailsGraphState(InnerAgentGraphState):

--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -373,6 +373,20 @@ class UiPathChatMessagesMapper:
 
         # For every new message_id, start a new message
         if message.id not in self.seen_message_ids:
+            # Edge-case: OpenAI Responses API (e.g. gpt-5.4) emits an initial envelope chunk
+            # of type `response.created` (id=`resp_...`) before any actual content;
+            # LangChain then streams the content under a different id (`lc_run--...`).
+            # This guard prevents emitting phantom startMessage/startContentPart events
+            # for envelope events. The `chunk_position != "last"` clause preserves the
+            # rare single-empty-chunk case (e.g. a refusal) so we still emit start + end.
+            if (
+                not message.content_blocks
+                and not message.tool_calls
+                and not (isinstance(message.content, str) and message.content)
+                and message.chunk_position != "last"
+            ):
+                return []
+
             self.current_message = message
             self.seen_message_ids.add(message.id)
             self._citation_stream_processor = CitationStreamProcessor()

--- a/src/uipath_langchain/runtime/messages.py
+++ b/src/uipath_langchain/runtime/messages.py
@@ -377,7 +377,7 @@ class UiPathChatMessagesMapper:
             # of type `response.created` (id=`resp_...`) before any actual content;
             # LangChain then streams the content under a different id (`lc_run--...`).
             # This guard prevents emitting phantom startMessage/startContentPart events
-            # for envelope events. The `chunk_position != "last"` clause preserves the
+            # for envelope events like this. The `chunk_position != "last"` clause preserves the
             # rare single-empty-chunk case (e.g. a refusal) so we still emit start + end.
             if (
                 not message.content_blocks

--- a/tests/agent/react/test_conversational_output_node.py
+++ b/tests/agent/react/test_conversational_output_node.py
@@ -64,18 +64,24 @@ def _make_mock_model() -> tuple[MagicMock, MagicMock, MagicMock]:
 
 class TestCreateConversationalOutputNode:
     @pytest.mark.asyncio
-    async def test_returns_response_with_tool_call(self):
+    async def test_returns_extracted_args_via_inner_state(self):
+        """The extracted set_conversational_output args land on
+        inner_state.conversational_output_args, not on `messages` — that
+        keeps the synthetic tool call off LangGraph's messages-stream
+        sweep so it never leaks to CAS."""
         model, _non_streaming, _bound = _make_mock_model()
         node = create_conversational_output_node(model, _OutputSchema)
 
         state = _make_state([SystemMessage(content="sys"), HumanMessage(content="hi")])
         result = await node(state)
 
-        assert len(result["messages"]) == 1
-        ai = result["messages"][0]
-        assert isinstance(ai, AIMessage)
-        assert ai.tool_calls[0]["name"] == SET_CONVERSATIONAL_OUTPUT_TOOL.name
-        assert ai.tool_calls[0]["args"]["handoff_target"] == "billing"
+        assert "messages" not in result
+        assert result["inner_state"] == {
+            "conversational_output": {
+                "handoff_target": "billing",
+                "ready_for_handoff": True,
+            }
+        }
 
     @pytest.mark.asyncio
     async def test_appends_human_instruction_for_llm_call(self):
@@ -101,8 +107,8 @@ class TestCreateConversationalOutputNode:
         assert isinstance(invoked_messages[-1], HumanMessage)
         assert "set_conversational_output" in invoked_messages[-1].content
 
-        # The instruction was NOT persisted into the returned messages.
-        assert len(result["messages"]) == 1
+        # Nothing is written to the messages channel — args flow via inner_state.
+        assert "messages" not in result
 
     @pytest.mark.asyncio
     async def test_binds_only_set_conversational_output_tool(self):
@@ -141,3 +147,32 @@ class TestCreateConversationalOutputNode:
         update_arg = model.model_copy.call_args.kwargs.get("update")
         assert update_arg is not None
         assert update_arg.get("disable_streaming") is True
+
+    @pytest.mark.asyncio
+    async def test_raises_when_llm_omits_set_conversational_output_call(self):
+        """When the internal LLM returns an AIMessage without the expected
+        set_conversational_output tool call, the node raises a structured
+        AgentRuntimeError rather than propagating an empty inner_state
+        payload downstream."""
+        from uipath_langchain.agent.exceptions import (
+            AgentRuntimeError,
+            AgentRuntimeErrorCode,
+        )
+
+        response = AIMessage(content="no tool call here", tool_calls=[])
+        bound = MagicMock()
+        bound.ainvoke = AsyncMock(return_value=response)
+        non_streaming = MagicMock()
+        non_streaming.bind_tools = MagicMock(return_value=bound)
+        model = MagicMock()
+        model.model_copy = MagicMock(return_value=non_streaming)
+
+        node = create_conversational_output_node(model, _OutputSchema)
+        state = _make_state([SystemMessage(content="sys"), HumanMessage(content="hi")])
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            await node(state)
+
+        assert exc_info.value.error_info.code == AgentRuntimeError.full_code(
+            AgentRuntimeErrorCode.LLM_INVALID_RESPONSE
+        )

--- a/tests/agent/react/test_conversational_output_node.py
+++ b/tests/agent/react/test_conversational_output_node.py
@@ -65,10 +65,6 @@ def _make_mock_model() -> tuple[MagicMock, MagicMock, MagicMock]:
 class TestCreateConversationalOutputNode:
     @pytest.mark.asyncio
     async def test_returns_extracted_args_via_inner_state(self):
-        """The extracted set_conversational_output args land on
-        inner_state.conversational_output_args, not on `messages` — that
-        keeps the synthetic tool call off LangGraph's messages-stream
-        sweep so it never leaks to CAS."""
         model, _non_streaming, _bound = _make_mock_model()
         node = create_conversational_output_node(model, _OutputSchema)
 

--- a/tests/agent/react/test_create_agent.py
+++ b/tests/agent/react/test_create_agent.py
@@ -157,7 +157,6 @@ class TestCreateAgent:
         mock_create_terminate_node.assert_called_once_with(
             None,  # output schema
             False,  # is_conversational
-            False,  # with_conversational_output_node
         )
 
     @_patch("create_route_agent_conversational")
@@ -254,7 +253,6 @@ class TestCreateAgent:
         mock_create_terminate_node.assert_called_once_with(
             None,  # output schema
             True,  # is_conversational
-            False,  # with_conversational_output_node (no custom output schema)
         )
 
     @_patch("create_route_agent_conversational")

--- a/tests/agent/react/test_terminate_node.py
+++ b/tests/agent/react/test_terminate_node.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 from uipath.agent.react import (
     END_EXECUTION_TOOL,
     RAISE_ERROR_TOOL,
-    SET_CONVERSATIONAL_OUTPUT_TOOL,
 )
 from uipath.core.chat import UiPathConversationMessageData
 from uipath.runtime.errors import UiPathErrorCategory
@@ -25,6 +24,7 @@ class MockInnerState(BaseModel):
 
     job_attachments: dict[str, Any] = {}
     initial_message_count: int | None = None
+    conversational_output: dict[str, Any] | None = None
 
 
 class MockAgentGraphState(BaseModel):
@@ -178,9 +178,9 @@ class TestTerminateNodeConversational:
         assert messages[0]["toolCalls"][0]["input"] == {"param": "value"}
 
     def test_conversational_extracts_custom_output_fields(self):
-        """When the response schema has custom fields, the terminate node
-        reads them from the last AIMessage's set_conversational_output tool
-        call and merges them with the response_messages."""
+        """When inner_state.conversational_output is populated (by the
+        upstream GENERATE_CONVERSATIONAL_OUTPUT node), the terminate node
+        merges those args into the schema-shaped output."""
 
         class ResponseSchema(BaseModel):
             uipath__agent_response_messages: list[UiPathConversationMessageData]
@@ -188,40 +188,28 @@ class TestTerminateNodeConversational:
             ready_for_handoff: bool
 
         terminate_node = create_terminate_node(
-            response_schema=ResponseSchema,
-            is_conversational=True,
-            with_conversational_output_node=True,
+            response_schema=ResponseSchema, is_conversational=True
         )
 
         agent_reply = AIMessage(content="Sure, I'll route you to billing.")
-        set_output_msg = AIMessage(
-            content="",
-            tool_calls=[
-                {
-                    "name": SET_CONVERSATIONAL_OUTPUT_TOOL.name,
-                    "args": {
-                        "handoff_target": "billing",
-                        "ready_for_handoff": True,
-                    },
-                    "id": "call_1",
-                }
-            ],
-        )
         state = MockAgentGraphState(
             messages=[
                 HumanMessage(content="I have a billing issue"),
                 agent_reply,
-                set_output_msg,
             ],
-            inner_state=MockInnerState(initial_message_count=1),
+            inner_state=MockInnerState(
+                initial_message_count=1,
+                conversational_output={
+                    "handoff_target": "billing",
+                    "ready_for_handoff": True,
+                },
+            ),
         )
 
         result = terminate_node(state)
 
         assert result["handoff_target"] == "billing"
         assert result["ready_for_handoff"] is True
-        # The conversational reply is preserved; the set_conversational_output
-        # AIMessage is dropped by the flow-control filter in the converter.
         messages = result["uipath__agent_response_messages"]
         assert len(messages) == 1
         assert "Sure, I'll route you to billing." in str(

--- a/tests/runtime/test_chat_message_mapper.py
+++ b/tests/runtime/test_chat_message_mapper.py
@@ -1223,26 +1223,41 @@ class TestMapEvent:
 
     @pytest.mark.asyncio
     async def test_map_event_starts_new_message_for_new_id(self):
-        """Should emit start event for new message id."""
+        """Should emit start event for new (content-bearing) message id.
+
+        Envelope-only chunks (empty content, no tool calls, not the final
+        `chunk_position="last"` marker) are skipped — see
+        `TestEnvelopeOnlyChunkSkip` — so this test uses a chunk that carries
+        content to fire the start event.
+        """
         mapper = UiPathChatMessagesMapper("test-runtime", None)
-        chunk = AIMessageChunk(content="", id="msg-123")
+        chunk = AIMessageChunk(
+            content="",
+            id="msg-123",
+            content_blocks=[{"type": "text", "text": "hi"}],
+        )
 
         result = await mapper.map_event(chunk)
 
         assert result is not None
-        assert len(result) == 1
-        event = result[0]
-        assert event.message_id == "msg-123"
-        assert event.start is not None
-        assert event.start.role == "assistant"
-        assert event.content_part is not None
-        assert event.content_part.start is not None
+        # First event is the combined start (message start + content_part start);
+        # subsequent events carry the text chunks.
+        start_event = result[0]
+        assert start_event.message_id == "msg-123"
+        assert start_event.start is not None
+        assert start_event.start.role == "assistant"
+        assert start_event.content_part is not None
+        assert start_event.content_part.start is not None
 
     @pytest.mark.asyncio
     async def test_map_event_tracks_seen_message_ids(self):
-        """Should track seen message ids."""
+        """Should track seen message ids for content-bearing chunks."""
         mapper = UiPathChatMessagesMapper("test-runtime", None)
-        chunk = AIMessageChunk(content="", id="msg-123")
+        chunk = AIMessageChunk(
+            content="",
+            id="msg-123",
+            content_blocks=[{"type": "text", "text": "hi"}],
+        )
 
         await mapper.map_event(chunk)
 
@@ -1250,13 +1265,22 @@ class TestMapEvent:
 
     @pytest.mark.asyncio
     async def test_map_event_emits_text_chunk_for_subsequent_messages(self):
-        """Should emit text chunk event for subsequent messages with same id."""
+        """Should emit text chunk event for subsequent messages with same id.
+
+        The first chunk (content-bearing) fires startMessage + startContentPart
+        + the text chunk. The second chunk with the same id should emit only
+        the text chunk event, not another start.
+        """
         mapper = UiPathChatMessagesMapper("test-runtime", None)
-        # First chunk starts the message
-        first_chunk = AIMessageChunk(content="", id="msg-123")
+        # First (content-bearing) chunk starts the message.
+        first_chunk = AIMessageChunk(
+            content="",
+            id="msg-123",
+            content_blocks=[{"type": "text", "text": "initial"}],
+        )
         await mapper.map_event(first_chunk)
 
-        # Second chunk with text content
+        # Second chunk with text content and the same id.
         second_chunk = AIMessageChunk(
             content="",
             id="msg-123",
@@ -1273,13 +1297,21 @@ class TestMapEvent:
 
     @pytest.mark.asyncio
     async def test_map_event_handles_raw_string_content(self):
-        """Should handle raw string content on chunk."""
+        """Should handle raw string content on chunk.
+
+        Uses a content-bearing first chunk to start the message; a subsequent
+        chunk with raw string content should emit only the chunk event.
+        """
         mapper = UiPathChatMessagesMapper("test-runtime", None)
-        # First chunk starts the message
-        first_chunk = AIMessageChunk(content="", id="msg-123")
+        # First (content-bearing) chunk starts the message.
+        first_chunk = AIMessageChunk(
+            content="",
+            id="msg-123",
+            content_blocks=[{"type": "text", "text": "initial"}],
+        )
         await mapper.map_event(first_chunk)
 
-        # Second chunk with string content
+        # Second chunk with raw string content and the same id.
         second_chunk = AIMessageChunk(content="raw content", id="msg-123")
         result = await mapper.map_event(second_chunk)
 
@@ -2463,3 +2495,66 @@ class TestClientSideToolEndSuppression:
             e for e in result if e.tool_call is not None and e.tool_call.end is not None
         ]
         assert len(tool_end_events) == 1
+
+
+class TestEnvelopeOnlyChunkSkip:
+    """OpenAI's Responses API emits a `response.created` frame first, carrying a
+    `resp_...` id and no content. LangChain then streams actual content chunks
+    under a different id (the run id `lc_run--...`). The mapper must skip that
+    envelope chunk so we don't fire a phantom `startMessage` for the `resp_...`
+    id and then a second `startMessage` for the run id."""
+
+    @pytest.mark.asyncio
+    async def test_envelope_chunk_emits_no_events(self):
+        storage = create_mock_storage()
+        storage.get_value.return_value = {}
+        mapper = UiPathChatMessagesMapper("test-runtime", storage)
+
+        envelope = AIMessageChunk(content="", id="resp_01env")
+        result = await mapper.map_event(envelope)
+
+        assert result == []
+        assert "resp_01env" not in mapper.seen_message_ids
+
+    @pytest.mark.asyncio
+    async def test_content_chunk_after_envelope_fires_single_start(self):
+        storage = create_mock_storage()
+        storage.get_value.return_value = {}
+        mapper = UiPathChatMessagesMapper("test-runtime", storage)
+
+        # Envelope frame (Responses API `response.created`) — should be skipped.
+        envelope = AIMessageChunk(content="", id="resp_01env")
+        envelope_events = await mapper.map_event(envelope)
+        assert envelope_events == []
+
+        # LangChain then streams under a different id (the run id).
+        content_chunk = AIMessageChunk(content="Hi", id="lc_run--abc")
+        content_events = await mapper.map_event(content_chunk)
+
+        # Exactly one startMessage event should be emitted, for the run id.
+        start_events = [e for e in (content_events or []) if e.start is not None]
+        assert len(start_events) == 1
+        assert content_events is not None
+        assert start_events[0].message_id == "lc_run--abc"
+
+    @pytest.mark.asyncio
+    async def test_truly_empty_last_chunk_still_starts_and_ends(self):
+        """When a stream produces only a single empty chunk marked
+        `chunk_position="last"` (e.g. a refusal with no text), the mapper must
+        NOT drop it — the chat UI still needs start + end events to close out
+        the turn."""
+        storage = create_mock_storage()
+        storage.get_value.return_value = {}
+        mapper = UiPathChatMessagesMapper("test-runtime", storage)
+
+        empty_last = AIMessageChunk(content="", id="msg-empty")
+        object.__setattr__(empty_last, "chunk_position", "last")
+
+        result = await mapper.map_event(empty_last)
+        assert result is not None
+
+        # Should have fired start events AND a message_end (single-chunk turn).
+        start_events = [e for e in result if e.start is not None]
+        end_events = [e for e in result if e.end is not None and e.content_part is None]
+        assert len(start_events) == 1
+        assert len(end_events) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.4"
+version = "0.14.5"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Two independent fixes that stop the runtime from emitting phantom `messageStart` / `toolCall` events to CAS for internal machinery that shouldn't be user-visible.

### 1. OpenAI Responses API envelope chunk

**Issue:** OpenAI's Responses API (e.g. gpt-5.4) fronts a stream with an empty envelope chunk (id=`resp_...`, from the SSE `response.created` event), then streams the actual content under a different id (`lc_run--...`). The mapper treated the envelope as a new message and emitted a phantom `messageStart` + `contentPartStart` pair to CAS.

**Fix:** `src/uipath_langchain/runtime/messages.py` — shape-guard that skips streaming message-start/content-part-start events for chunks with no content, no tool calls, and `chunk_position != "last"`.

**Before:**
<img width="358" height="360" alt="image" src="https://github.com/user-attachments/assets/f8bdeb4a-aee7-4ab5-908b-ee609e57dee8" />

**After:**
(With temporary prints). Note the `"Skipping phantom message start..."` print.


<img width="1702" height="409" alt="image" src="https://github.com/user-attachments/assets/40cf60b9-5a25-4bad-98ae-b76d57600979" />



### 2. `set_conversational_output` tool call leaking to CAS
cc @andrewwan-uipath 

**Why:** `GENERATE_CONVERSATIONAL_OUTPUT` runs an internal LLM call with `tool_choice="any"` bound only to the `set_conversational_output` tool. `TAG_NOSTREAM` on the invoke config correctly suppressed the LLM callback path, but LangGraph's messages-stream mode also streams message-outputs from the return of `{"messages": [response]}`. So the chat-mapper emitted `toolCallStart` + `executingToolCall` events to CAS for the synthetic tool call.

**Fix:** Extract the tool call args inside the node and route them via `inner_state.conversational_output` instead of `messages`. The AIMessage never enters the messages channel, so there's nothing for LangGraph's sweep to pick up. This refactors and simplifies a lot of the terminate_node logic since it simply just obtains the output from the `inner_state` of the graph rather than parsing the last message.

**Before**:
Note the temporary log `Mapping AIMessage to events: resp_...`
<img width="1435" height="292" alt="image" src="https://github.com/user-attachments/assets/f72ae676-278c-4e56-808c-7242dc211908" />

<img width="732" height="625" alt="image" src="https://github.com/user-attachments/assets/5d74ab47-f65f-470b-af52-d2b8a6b823d5" />


**After:**
<img width="2800" height="266" alt="image" src="https://github.com/user-attachments/assets/759d238c-d939-41e2-aaa9-a6a2ead54742" />


## Test plan
- [x] Added `test_returns_extracted_args_via_inner_state` and `test_raises_when_llm_omits_set_conversational_output_call` in `test_conversational_output_node.py`
- [x] Updated `test_conversational_extracts_custom_output_fields` to pass args via `inner_state`
- [x] Added envelope-chunk coverage in `test_chat_message_mapper.py`
- [x] All 2388 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)