### PR TITLE
chore(deps): bump sample min versions to require uipath-langchain>=0.14.5 [AL-470]

### DIFF
--- a/samples/joke-agent-decorator/pyproject.toml
+++ b/samples/joke-agent-decorator/pyproject.toml
@@ -5,8 +5,8 @@ description = "Joke generating agent that creates family-friendly jokes based on
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 requires-python = ">=3.11"
 dependencies = [
-    "uipath-langchain>=0.14.3, <0.15.0",
-    "uipath>=2.13.6, <2.14.0",
+    "uipath-langchain>=0.14.5, <0.15.0",
+    "uipath>=2.13.7, <2.14.0",
 ]
 
 [dependency-groups]

--- a/samples/joke-agent/pyproject.toml
+++ b/samples/joke-agent/pyproject.toml
@@ -5,8 +5,8 @@ description = "Joke generating agent that creates family-friendly jokes based on
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 requires-python = ">=3.11"
 dependencies = [
-    "uipath-langchain>=0.14.3, <0.15.0",
-    "uipath>=2.13.6, <2.14.0",
+    "uipath-langchain>=0.14.5, <0.15.0",
+    "uipath>=2.13.7, <2.14.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Closes AL-470

## What changed?

Bumped minimum dependency versions in both sample agents:

- `uipath-langchain`: `>=0.14.3` → `>=0.14.5` — 0.14.5 is the first release shipping `UiPathLLMAsJudgeMiddleware`
- `uipath`: `>=2.13.6` → `>=2.13.7` — required minimum to match

Affects `samples/joke-agent` and `samples/joke-agent-decorator`.

## How has this been tested?

- Ran `uv sync` in both sample directories — both resolved to `uipath-langchain==0.14.5` successfully
- Ran `uv run uipath run agent '{"topic": "banana"}'` in `joke-agent` — agent ran end-to-end, all guardrails including `UiPathLLMAsJudgeMiddleware` fired correctly

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] None
- [ ] DB migrations
- [ ] API removals / breaking API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)