### PR TITLE
fix: tolerate malformed tool output schemas at agent startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.7"
+version = "0.14.8"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.6"
+version = "0.14.7"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
+++ b/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import sys
 from types import ModuleType
 from typing import Any, Type, cast
@@ -7,6 +8,12 @@ from jsonschema_pydantic_converter import transform_with_modules
 from pydantic import BaseModel, PydanticUndefinedAnnotation
 
 from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErrorCode
+
+logger = logging.getLogger(__name__)
+
+# Empty, always-parseable output model used as a non-fatal fallback
+# (see create_output_model).
+_EMPTY_OUTPUT_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
 
 # Shared pseudo-module for all dynamically created types
 # This allows get_type_hints() to resolve forward references
@@ -60,3 +67,27 @@ def create_model(
     model.__module__ = _DYNAMIC_MODULE_NAME
 
     return model
+
+
+def create_output_model(
+    schema: dict[str, Any],
+    tool_name: str,
+) -> Type[BaseModel]:
+    """Convert a tool's OUTPUT JSON schema to a Pydantic model, non-fatally.
+
+    Unlike input schemas, a tool's output schema is used only at design time
+    (guardrail definitions and eval simulations) and is never used to validate
+    output during execution.
+
+    Returns:
+        The converted model, or an empty model if the schema is unparseable.
+    """
+    try:
+        return create_model(schema)
+    except AgentStartupError as e:
+        logger.warning(
+            "Tool %r has an unparseable output schema; ignoring it (non-blocking): %s",
+            tool_name,
+            e.error_info.detail,
+        )
+        return create_model(_EMPTY_OUTPUT_SCHEMA)

--- a/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
+++ b/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
@@ -75,9 +75,9 @@ def create_output_model(
 ) -> Type[BaseModel]:
     """Convert a tool's OUTPUT JSON schema to a Pydantic model, non-fatally.
 
-    Unlike input schemas, a tool's output schema is used only at design time
-    (guardrail definitions and eval simulations) and is never used to validate
-    output during execution.
+    An output schema drives only best-effort features (job-attachment discovery,
+    output guardrails, eval simulations), not the core tool call, so an
+    unparseable one falls back to an empty model instead of failing startup.
 
     Returns:
         The converted model, or an empty model if the schema is unparseable.

--- a/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
+++ b/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
@@ -11,10 +11,6 @@ from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErr
 
 logger = logging.getLogger(__name__)
 
-# Empty, always-parseable output model used as a last-resort non-fatal fallback
-# (see create_output_model).
-_EMPTY_OUTPUT_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
-
 # Marker left on any OUTPUT-schema node whose $ref target could not be resolved.
 # The converter discards $defs names and non-standard (x-*) keys but preserves the
 # standard `title`/`description` annotations on a property, so the marker lives as
@@ -136,18 +132,24 @@ def create_output_model(
     schema: dict[str, Any],
     tool_name: str,
 ) -> Type[BaseModel]:
-    """Convert a tool's OUTPUT JSON schema to a Pydantic model, non-fatally.
+    """Convert a tool's OUTPUT JSON schema to a Pydantic model.
 
-    An output schema drives only best-effort features (job-attachment discovery,
-    output guardrails, eval simulations), not the core tool call, so it must never
-    block agent startup. Unresolvable ``$ref``s (the common failure -- see
-    _neutralize_dangling_refs) are neutralized in place so all valid fields are
-    kept. As a last resort, any remaining conversion failure degrades to an empty
-    model.
+    Unresolvable ``$ref``s -- the malformed output schema seen in practice (see
+    _neutralize_dangling_refs) -- are neutralized in place so all valid fields are
+    kept; since an output schema drives only best-effort features (job-attachment
+    discovery, output guardrails, eval simulations), losing a single unresolvable
+    field is preferable to failing startup.
+
+    Any *other* conversion failure is deliberately left fatal: we would rather fail
+    loudly at startup than swallow an unexpected malformation into a degraded model
+    that fails obscurely at runtime.
 
     Returns:
-        The converted model (dangling refs neutralized), or an empty model if the
-        schema is still unparseable.
+        The converted model, with dangling refs neutralized.
+
+    Raises:
+        AgentStartupError: If the schema is unparseable for a reason other than a
+            dangling ``$ref``.
     """
     sanitized, dropped = _neutralize_dangling_refs(schema)
     if dropped:
@@ -160,16 +162,4 @@ def create_output_model(
             ", ".join(sorted(set(dropped))),
             _UNRESOLVED_TYPE_TITLE,
         )
-    try:
-        return create_model(sanitized)
-    except AgentStartupError as e:
-        # Last-resort net for a non-$ref failure we didn't neutralize. Intentionally
-        # narrow (AgentStartupError only): other errors are unexpected and should
-        # surface rather than be silently swallowed.
-        logger.warning(
-            "Tool %r output schema still unparseable after neutralizing dangling "
-            "refs; falling back to an empty model (non-blocking): %s",
-            tool_name,
-            e.error_info.detail,
-        )
-        return create_model(_EMPTY_OUTPUT_SCHEMA)
+    return create_model(sanitized)

--- a/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
+++ b/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
@@ -11,9 +11,16 @@ from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErr
 
 logger = logging.getLogger(__name__)
 
-# Empty, always-parseable output model used as a non-fatal fallback
+# Empty, always-parseable output model used as a last-resort non-fatal fallback
 # (see create_output_model).
 _EMPTY_OUTPUT_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
+
+# Marker left on any OUTPUT-schema node whose $ref target could not be resolved.
+# The converter discards $defs names and non-standard (x-*) keys but preserves the
+# standard `title`/`description` annotations on a property, so the marker lives as
+# annotations rather than a named type. Downstream can detect an unresolved field
+# via ``title == _UNRESOLVED_TYPE_TITLE``. See create_output_model.
+_UNRESOLVED_TYPE_TITLE = "UiPathUnresolvedType"
 
 # Shared pseudo-module for all dynamically created types
 # This allows get_type_hints() to resolve forward references
@@ -69,6 +76,62 @@ def create_model(
     return model
 
 
+def _ref_resolves(ref: str, root: dict[str, Any]) -> bool:
+    """Whether a local JSON-pointer ``$ref`` (``#/...``) resolves within `root`.
+
+    External/URL refs and the bare ``#`` (whole-document) ref return False: the
+    converter cannot resolve them either, so they are treated as dangling.
+    """
+    if not ref.startswith("#/"):
+        return False
+    node: Any = root
+    for part in ref[2:].split("/"):
+        part = part.replace("~1", "/").replace("~0", "~")  # JSON-pointer unescape
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+        else:
+            return False
+    return True
+
+
+def _neutralize_dangling_refs(
+    schema: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Return a copy of `schema` with every unresolvable ``$ref`` replaced.
+
+    A ``$ref`` is dangling when its target is not present under ``$defs``/
+    ``definitions`` (e.g. a .NET ``Nullable<decimal>`` serialized without its
+    definition). Each dangling ref node is replaced *in place* by a permissive,
+    self-documenting placeholder (accepts any value; the original ref is kept in
+    its ``description``), so valid sibling fields and valid ``$ref``s -- including
+    those nested in arrays, objects, or ``$defs`` -- are preserved. This keeps the
+    output schema usable by best-effort features instead of discarding it whole.
+
+    Returns:
+        A tuple of (sanitized schema copy, list of the dangling ref strings found).
+    """
+    dropped: list[str] = []
+
+    def visit(node: Any) -> Any:
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and not _ref_resolves(ref, schema):
+                dropped.append(ref)
+                return {
+                    "title": _UNRESOLVED_TYPE_TITLE,
+                    "description": (
+                        f"Unresolved $ref '{ref}'; original type could not be "
+                        "resolved at startup, so this field accepts any value."
+                    ),
+                }
+            return {key: visit(value) for key, value in node.items()}
+        if isinstance(node, list):
+            return [visit(item) for item in node]
+        return node
+
+    return visit(schema), dropped
+
+
 def create_output_model(
     schema: dict[str, Any],
     tool_name: str,
@@ -76,17 +139,36 @@ def create_output_model(
     """Convert a tool's OUTPUT JSON schema to a Pydantic model, non-fatally.
 
     An output schema drives only best-effort features (job-attachment discovery,
-    output guardrails, eval simulations), not the core tool call, so an
-    unparseable one falls back to an empty model instead of failing startup.
+    output guardrails, eval simulations), not the core tool call, so it must never
+    block agent startup. Unresolvable ``$ref``s (the common failure -- see
+    _neutralize_dangling_refs) are neutralized in place so all valid fields are
+    kept. As a last resort, any remaining conversion failure degrades to an empty
+    model.
 
     Returns:
-        The converted model, or an empty model if the schema is unparseable.
+        The converted model (dangling refs neutralized), or an empty model if the
+        schema is still unparseable.
     """
-    try:
-        return create_model(schema)
-    except AgentStartupError as e:
+    sanitized, dropped = _neutralize_dangling_refs(schema)
+    if dropped:
         logger.warning(
-            "Tool %r has an unparseable output schema; ignoring it (non-blocking): %s",
+            "Tool %r output schema had %d unresolvable $ref(s) (%s); each replaced "
+            "with a permissive %r placeholder. Output schema does not affect the "
+            "core tool call, so agent startup is not blocked.",
+            tool_name,
+            len(dropped),
+            ", ".join(sorted(set(dropped))),
+            _UNRESOLVED_TYPE_TITLE,
+        )
+    try:
+        return create_model(sanitized)
+    except AgentStartupError as e:
+        # Last-resort net for a non-$ref failure we didn't neutralize. Intentionally
+        # narrow (AgentStartupError only): other errors are unexpected and should
+        # surface rather than be silently swallowed.
+        logger.warning(
+            "Tool %r output schema still unparseable after neutralizing dangling "
+            "refs; falling back to an empty model (non-blocking): %s",
             tool_name,
             e.error_info.detail,
         )

--- a/src/uipath_langchain/agent/tools/escalation_tool.py
+++ b/src/uipath_langchain/agent/tools/escalation_tool.py
@@ -27,7 +27,10 @@ from uipath_langchain._utils import (
     get_execution_folder_path,
 )
 from uipath_langchain._utils.durable_interrupt import durable_interrupt
-from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
+    create_model,
+    create_output_model,
+)
 from uipath_langchain.agent.tools.structured_tool_with_argument_properties import (
     StructuredToolWithArgumentProperties,
 )
@@ -267,7 +270,7 @@ def create_escalation_tool(
     channel: EscalationChannel = _resolve_channel(resource)
 
     input_model: Any = create_model(channel.input_schema)
-    output_model: Any = create_model(channel.output_schema)
+    output_model: Any = create_output_model(channel.output_schema, resource.name)
 
     class EscalationToolOutput(BaseModel):
         action: Literal["approve", "reject"]

--- a/src/uipath_langchain/agent/tools/integration_tool.py
+++ b/src/uipath_langchain/agent/tools/integration_tool.py
@@ -23,7 +23,10 @@ from uipath_langchain.agent.exceptions import (
     AgentStartupErrorCode,
     raise_for_enriched,
 )
-from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
+    create_model,
+    create_output_model,
+)
 
 from .schema_editing import strip_enum
 from .structured_tool_with_argument_properties import (
@@ -301,7 +304,9 @@ def create_integration_tool(
     input_model = create_model(cleaned_input_schema)
     # note: IS tools output schemas were recently added and are most likely not present in all resources
     output_model: Any = (
-        create_model(remove_asterisk_from_properties(resource.output_schema))
+        create_output_model(
+            remove_asterisk_from_properties(resource.output_schema), resource.name
+        )
         if resource.output_schema
         else create_model({"type": "object", "properties": {}})
     )

--- a/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
@@ -39,7 +39,10 @@ from uipath_langchain.agent.multimodal import (
     build_file_content_blocks_for,
 )
 from uipath_langchain.agent.react.job_attachments import raise_for_job_attachment_error
-from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
+    create_model,
+    create_output_model,
+)
 from uipath_langchain.agent.tools.internal_tools.pii_masker import (
     PiiMasker,
     masked_name_for,
@@ -247,7 +250,7 @@ def create_analyze_file_tool(
 
     tool_name = sanitize_tool_name(resource.name)
     input_model = create_model(resource.input_schema)
-    output_model = create_model(resource.output_schema)
+    output_model = create_output_model(resource.output_schema, resource.name)
 
     # Explicitly disable streaming - for conversational, no streaming is needed as this
     # internal tool-call does not produce streamed conversation events.

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -26,7 +26,10 @@ from uipath_langchain._utils.durable_interrupt import (
     durable_interrupt,
 )
 from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErrorCode
-from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
+    create_model,
+    create_output_model,
+)
 from uipath_langchain.agent.tools.internal_tools.schema_utils import (
     add_query_field_to_schema,
 )
@@ -85,7 +88,7 @@ def create_deeprag_tool(
         )
 
     input_model = create_model(input_schema)
-    output_model = create_model(resource.output_schema)
+    output_model = create_output_model(resource.output_schema, resource.name)
 
     async def deeprag_tool_fn(**kwargs: Any) -> dict[str, Any]:
         query = kwargs.get("query") if not is_query_static else static_query

--- a/src/uipath_langchain/agent/tools/process_tool.py
+++ b/src/uipath_langchain/agent/tools/process_tool.py
@@ -16,7 +16,10 @@ from uipath_langchain._utils import get_execution_folder_path
 from uipath_langchain._utils.durable_interrupt import durable_interrupt
 from uipath_langchain.agent.exceptions import raise_for_enriched
 from uipath_langchain.agent.react.job_attachments import get_job_attachments
-from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
+    create_model,
+    create_output_model,
+)
 from uipath_langchain.agent.tools.structured_tool_with_argument_properties import (
     StructuredToolWithArgumentProperties,
 )
@@ -52,7 +55,7 @@ def create_process_tool(
     folder_path = get_execution_folder_path()
 
     input_model: Any = create_model(resource.input_schema)
-    output_model: Any = create_model(resource.output_schema)
+    output_model: Any = create_output_model(resource.output_schema, resource.name)
 
     _span_context: dict[str, Any] = {}
     _bts_context: dict[str, Any] = {}

--- a/tests/agent/react/test_jsonschema_pydantic_converter.py
+++ b/tests/agent/react/test_jsonschema_pydantic_converter.py
@@ -1,11 +1,19 @@
-"""Tests for jsonschema_pydantic_converter wrapper — create_model()."""
+"""Tests for jsonschema_pydantic_converter — create_model() and create_output_model()."""
 
+import copy
+import logging
 from typing import Any
 
 import pytest
 
 from uipath_langchain.agent.exceptions import AgentStartupError
-from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
+    _UNRESOLVED_TYPE_TITLE,
+    _neutralize_dangling_refs,
+    _ref_resolves,
+    create_model,
+    create_output_model,
+)
 
 # --- Fixtures: reusable schema fragments ---
 
@@ -296,3 +304,204 @@ class TestPseudoModuleIsolation:
         assert "report" in complex_model.model_fields
         assert model.__pydantic_complete__
         assert "name" in model.model_fields
+
+
+# --- 5. Output-schema pre-pass: dangling $refs are neutralized, never fatal ---
+
+
+class TestRefResolves:
+    """_ref_resolves: only a local pointer with a present target resolves."""
+
+    def test_present_local_ref_resolves(self, schema_with_defs: dict[str, Any]) -> None:
+        assert _ref_resolves("#/$defs/Contact", schema_with_defs) is True
+
+    def test_missing_local_ref_does_not_resolve(self) -> None:
+        assert _ref_resolves("#/$defs/Missing", {"$defs": {}}) is False
+
+    def test_definitions_keyword_resolves(self) -> None:
+        root = {"definitions": {"Foo": {"type": "object"}}}
+        assert _ref_resolves("#/definitions/Foo", root) is True
+
+    def test_nested_pointer(self) -> None:
+        root = {"$defs": {"A": {"$defs": {"B": {"type": "string"}}}}}
+        assert _ref_resolves("#/$defs/A/$defs/B", root) is True
+        assert _ref_resolves("#/$defs/A/$defs/Missing", root) is False
+
+    def test_external_and_bare_refs_do_not_resolve(self) -> None:
+        assert _ref_resolves("https://example.com/Foo", {}) is False
+        assert _ref_resolves("#", {}) is False
+        assert _ref_resolves("Contact", {}) is False
+
+
+class TestNeutralizeDanglingRefs:
+    """_neutralize_dangling_refs: surgical, in-place, preserves valid nodes."""
+
+    def test_valid_schema_returned_unchanged(
+        self, schema_with_defs: dict[str, Any]
+    ) -> None:
+        sanitized, dropped = _neutralize_dangling_refs(schema_with_defs)
+        assert dropped == []
+        assert sanitized == schema_with_defs
+
+    def test_dangling_top_level_ref_neutralized(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"amount": {"$ref": "#/$defs/Missing"}},
+        }
+        sanitized, dropped = _neutralize_dangling_refs(schema)
+        assert dropped == ["#/$defs/Missing"]
+        node = sanitized["properties"]["amount"]
+        assert "$ref" not in node
+        assert node["title"] == _UNRESOLVED_TYPE_TITLE
+        assert "#/$defs/Missing" in node["description"]
+
+    def test_valid_sibling_and_valid_ref_preserved(
+        self, contact_def: dict[str, Any]
+    ) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "status": {"type": "string"},
+                "owner": {"$ref": "#/$defs/Contact"},
+                "amount": {"$ref": "#/$defs/Missing"},
+            },
+            "$defs": {"Contact": contact_def},
+        }
+        sanitized, dropped = _neutralize_dangling_refs(schema)
+        assert dropped == ["#/$defs/Missing"]
+        assert sanitized["properties"]["status"] == {"type": "string"}
+        assert sanitized["properties"]["owner"] == {"$ref": "#/$defs/Contact"}
+        assert sanitized["properties"]["amount"]["title"] == _UNRESOLVED_TYPE_TITLE
+
+    def test_nested_in_array_items_neutralized(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "rows": {"type": "array", "items": {"$ref": "#/$defs/Missing"}},
+            },
+        }
+        sanitized, dropped = _neutralize_dangling_refs(schema)
+        assert dropped == ["#/$defs/Missing"]
+        items = sanitized["properties"]["rows"]["items"]
+        assert items["title"] == _UNRESOLVED_TYPE_TITLE
+
+    def test_dangling_ref_inside_valid_def_neutralized(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"w": {"$ref": "#/$defs/Wrapper"}},
+            "$defs": {
+                "Wrapper": {
+                    "type": "object",
+                    "properties": {"x": {"$ref": "#/$defs/Missing"}},
+                },
+            },
+        }
+        sanitized, dropped = _neutralize_dangling_refs(schema)
+        assert dropped == ["#/$defs/Missing"]
+        # outer, resolvable ref kept; inner dangling ref neutralized
+        assert sanitized["properties"]["w"] == {"$ref": "#/$defs/Wrapper"}
+        inner = sanitized["$defs"]["Wrapper"]["properties"]["x"]
+        assert inner["title"] == _UNRESOLVED_TYPE_TITLE
+
+    def test_does_not_mutate_input(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"a": {"$ref": "#/$defs/Missing"}},
+        }
+        original = copy.deepcopy(schema)
+        _neutralize_dangling_refs(schema)
+        assert schema == original
+
+
+class TestCreateOutputModel:
+    """create_output_model: never crashes on dangling refs; keeps valid fields."""
+
+    def test_neutralized_field_accepts_any_and_keeps_original_ref(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "status": {"type": "string"},
+                "amount": {"$ref": "#/$defs/Nullableofdecimal", "type": "object"},
+            },
+        }
+        model = create_output_model(schema, "my_tool")
+        props = model.model_json_schema()["properties"]
+        assert "status" in props  # valid sibling preserved
+        assert props["amount"]["title"] == _UNRESOLVED_TYPE_TITLE
+        assert "Nullableofdecimal" in props["amount"]["description"]
+        # Permissive: every value kind validates (a typed field would raise here).
+        for value in [1.5, "text", {"k": 1}, [1, 2], True, None]:
+            model.model_validate({"status": "ok", "amount": value})
+
+    def test_valid_schema_matches_create_model_fields(
+        self, schema_with_defs: dict[str, Any]
+    ) -> None:
+        """A valid schema is passed through untouched: same fields as create_model."""
+        via_output = create_output_model(schema_with_defs, "t")
+        via_direct = create_model(schema_with_defs)
+        assert via_output.model_fields.keys() == via_direct.model_fields.keys()
+        assert "owner" in via_output.model_fields
+
+    def test_many_fields_distinct_refs_create_no_named_types(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "f1": {"$ref": "#/$defs/A"},
+                "f2": {"$ref": "#/$defs/A"},
+                "f3": {"$ref": "#/$defs/B"},
+                "f4": {"$ref": "#/$defs/B"},
+                "f5": {"$ref": "#/$defs/C"},
+            },
+        }
+        model = create_output_model(schema, "t")
+        js = model.model_json_schema()
+        # no named types are generated -> nothing to collide / deduplicate
+        assert js.get("$defs", {}) == {}
+        for field in ["f1", "f2", "f3", "f4", "f5"]:
+            assert js["properties"][field]["title"] == _UNRESOLVED_TYPE_TITLE
+        model.model_validate(
+            {"f1": 1, "f2": "x", "f3": None, "f4": [1], "f5": {"a": 1}}
+        )
+
+    def test_last_resort_empty_model_on_non_ref_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If conversion still raises AgentStartupError after neutralizing refs
+        (a non-$ref failure), degrade to an empty model rather than crash."""
+        import uipath_langchain.agent.react.jsonschema_pydantic_converter as mod
+
+        # Capture a real AgentStartupError from the low-level converter.
+        try:
+            mod.create_model(
+                {"type": "object", "properties": {"x": {"$ref": "#/$defs/Missing"}}}
+            )
+            raise AssertionError("expected AgentStartupError")
+        except AgentStartupError as exc:
+            captured = exc
+
+        real_create_model = mod.create_model
+
+        def fake_create_model(schema: dict[str, Any]) -> Any:
+            if schema is not mod._EMPTY_OUTPUT_SCHEMA:
+                raise captured
+            return real_create_model(schema)
+
+        monkeypatch.setattr(mod, "create_model", fake_create_model)
+
+        model = mod.create_output_model(
+            {"type": "object", "properties": {"y": {"type": "string"}}}, "t"
+        )
+        assert model.model_json_schema().get("properties", {}) == {}
+
+    def test_neutralized_refs_are_logged_with_tool_and_ref(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Dropped refs must be logged (named) so the degradation is debuggable."""
+        schema = {
+            "type": "object",
+            "properties": {"amount": {"$ref": "#/$defs/Nullableofdecimal"}},
+        }
+        with caplog.at_level(logging.WARNING):
+            create_output_model(schema, "my_tool")
+        assert "my_tool" in caplog.text
+        assert "#/$defs/Nullableofdecimal" in caplog.text

--- a/tests/agent/react/test_jsonschema_pydantic_converter.py
+++ b/tests/agent/react/test_jsonschema_pydantic_converter.py
@@ -463,14 +463,15 @@ class TestCreateOutputModel:
             {"f1": 1, "f2": "x", "f3": None, "f4": [1], "f5": {"a": 1}}
         )
 
-    def test_last_resort_empty_model_on_non_ref_failure(
+    def test_non_ref_conversion_failure_is_fatal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """If conversion still raises AgentStartupError after neutralizing refs
-        (a non-$ref failure), degrade to an empty model rather than crash."""
+        """A conversion failure that is NOT a dangling ref must propagate (fail
+        loud) -- there is deliberately no last-resort fallback that would swallow
+        an unexpected malformation into a degraded model."""
         import uipath_langchain.agent.react.jsonschema_pydantic_converter as mod
 
-        # Capture a real AgentStartupError from the low-level converter.
+        # Capture a real AgentStartupError, then make create_model raise it.
         try:
             mod.create_model(
                 {"type": "object", "properties": {"x": {"$ref": "#/$defs/Missing"}}}
@@ -479,19 +480,15 @@ class TestCreateOutputModel:
         except AgentStartupError as exc:
             captured = exc
 
-        real_create_model = mod.create_model
+        def always_raise(_schema: dict[str, Any]) -> Any:
+            raise captured
 
-        def fake_create_model(schema: dict[str, Any]) -> Any:
-            if schema is not mod._EMPTY_OUTPUT_SCHEMA:
-                raise captured
-            return real_create_model(schema)
+        monkeypatch.setattr(mod, "create_model", always_raise)
 
-        monkeypatch.setattr(mod, "create_model", fake_create_model)
-
-        model = mod.create_output_model(
-            {"type": "object", "properties": {"y": {"type": "string"}}}, "t"
-        )
-        assert model.model_json_schema().get("properties", {}) == {}
+        with pytest.raises(AgentStartupError):
+            mod.create_output_model(
+                {"type": "object", "properties": {"y": {"type": "string"}}}, "t"
+            )
 
     def test_neutralized_refs_are_logged_with_tool_and_ref(
         self, caplog: pytest.LogCaptureFixture

--- a/tests/agent/tools/test_tool_factory.py
+++ b/tests/agent/tools/test_tool_factory.py
@@ -480,14 +480,12 @@ class TestCreateToolsFromResources:
     async def test_malformed_output_schema_is_non_blocking(
         self, resource_fixture, mock_uipath_sdk, request
     ):
-        """Each of the 5 tool factories that convert an output schema must tolerate
-        a malformed one instead of failing agent startup.
+        """A malformed output schema must not fail agent startup.
 
-        Output schemas are design-time only (guardrails + eval simulation) and are
-        never used during execution, so a dangling ``$ref`` (e.g. a .NET
-        ``Nullableofdecimal`` with no ``$defs``) must not raise
-        ``AGENT_STARTUP.INVALID_TOOL_CONFIG``. The tool is still built, with its
-        output model degraded to an empty schema.
+        An output schema drives only best-effort features (not the core tool call),
+        so a dangling ``$ref`` (e.g. a .NET ``Nullableofdecimal`` with no ``$defs``)
+        must not raise ``AGENT_STARTUP.INVALID_TOOL_CONFIG``; the tool is still
+        built, with its output model degraded to an empty schema.
         """
         resource = request.getfixturevalue(resource_fixture)
         _set_malformed_output_schema(resource)

--- a/tests/agent/tools/test_tool_factory.py
+++ b/tests/agent/tools/test_tool_factory.py
@@ -15,6 +15,8 @@ from uipath.agent.models.agent import (
     AgentIntegrationToolProperties,
     AgentIntegrationToolResourceConfig,
     AgentInternalAnalyzeFilesToolProperties,
+    AgentInternalDeepRagSettings,
+    AgentInternalDeepRagToolProperties,
     AgentInternalToolResourceConfig,
     AgentInternalToolType,
     AgentIxpExtractionResourceConfig,
@@ -28,6 +30,10 @@ from uipath.agent.models.agent import (
     AgentResourceType,
     AgentSettings,
     AgentToolType,
+    CitationMode,
+    DeepRagCitationModeSetting,
+    DeepRagFileExtension,
+    DeepRagFileExtensionSetting,
     LowCodeAgentDefinition,
 )
 from uipath.platform.connections import Connection
@@ -226,6 +232,33 @@ def internal_resource() -> AgentInternalToolResourceConfig:
 
 
 @pytest.fixture
+def deeprag_resource() -> AgentInternalToolResourceConfig:
+    """Create a DeepRAG internal tool resource config."""
+    return AgentInternalToolResourceConfig(
+        type=AgentToolType.INTERNAL,
+        name="test_deeprag",
+        description="Test DeepRAG description",
+        input_schema=EMPTY_SCHEMA,
+        output_schema=EMPTY_SCHEMA,
+        properties=AgentInternalDeepRagToolProperties(
+            tool_type=AgentInternalToolType.DEEP_RAG,
+            settings=AgentInternalDeepRagSettings(
+                context_type="index",
+                query=AgentContextQuerySetting(
+                    variant="static",
+                    value="test query",
+                    description="test description",
+                ),
+                citation_mode=DeepRagCitationModeSetting(value=CitationMode.INLINE),
+                file_extension=DeepRagFileExtensionSetting(
+                    value=DeepRagFileExtension.PDF
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
 def ixp_extraction_resource() -> AgentIxpExtractionResourceConfig:
     """Create an IXP extraction tool resource config."""
     return AgentIxpExtractionResourceConfig(
@@ -296,6 +329,30 @@ def assert_tool_is_base_uipath(tool):
     else:
         assert tool is not None
         assert isinstance(tool, BaseUiPathStructuredTool)
+
+
+# A tool output schema with a dangling $ref (no matching $defs entry) -- the shape
+# Studio Web emits for a .NET decimal? output argument. See create_output_model.
+_MALFORMED_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "left": {"$ref": "#/$defs/Nullableofdecimal", "type": "object"},
+    },
+}
+
+
+def _set_malformed_output_schema(resource):
+    """Put a malformed output schema where the given resource type reads it.
+
+    Escalation tools take the output schema from their channel(s); every other
+    tool type reads ``resource.output_schema`` directly.
+    """
+    channels = getattr(resource, "channels", None)
+    if channels:
+        for channel in channels:
+            channel.output_schema = _MALFORMED_OUTPUT_SCHEMA
+    else:
+        resource.output_schema = _MALFORMED_OUTPUT_SCHEMA
 
 
 @pytest.mark.asyncio
@@ -405,3 +462,36 @@ class TestCreateToolsFromResources:
             function_resource, run_as_me=False
         )
         assert tool is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "resource_fixture",
+        [
+            "process_resource",
+            "escalation_resource",
+            "integration_resource",
+            "internal_resource",  # analyze_files
+            "deeprag_resource",
+        ],
+    )
+    async def test_malformed_output_schema_is_non_blocking(
+        self, resource_fixture, mock_uipath_sdk, request
+    ):
+        """Each of the 5 tool factories that convert an output schema must tolerate
+        a malformed one instead of failing agent startup.
+
+        Output schemas are design-time only (guardrails + eval simulation) and are
+        never used during execution, so a dangling ``$ref`` (e.g. a .NET
+        ``Nullableofdecimal`` with no ``$defs``) must not raise
+        ``AGENT_STARTUP.INVALID_TOOL_CONFIG``. The tool is still built, with its
+        output model degraded to an empty schema.
+        """
+        resource = request.getfixturevalue(resource_fixture)
+        _set_malformed_output_schema(resource)
+
+        # Must not raise (this previously threw AGENT_STARTUP.INVALID_TOOL_CONFIG).
+        tool = await _build_tool_for_resource(resource, AsyncMock(spec=BaseChatModel))
+
+        assert_tool_is_base_uipath(tool)
+        # Output model degraded to an empty schema rather than crashing startup.
+        assert tool.output_type.model_json_schema().get("properties", {}) == {}

--- a/tests/agent/tools/test_tool_factory.py
+++ b/tests/agent/tools/test_tool_factory.py
@@ -41,6 +41,9 @@ from uipath.platform.connections import Connection
 from uipath_langchain.agent.tools.base_uipath_structured_tool import (
     BaseUiPathStructuredTool,
 )
+from uipath_langchain.agent.tools.structured_tool_with_output_type import (
+    StructuredToolWithOutputType,
+)
 from uipath_langchain.agent.tools.tool_factory import (
     _build_tool_for_resource,
     create_tools_from_resources,
@@ -492,6 +495,7 @@ class TestCreateToolsFromResources:
         # Must not raise (this previously threw AGENT_STARTUP.INVALID_TOOL_CONFIG).
         tool = await _build_tool_for_resource(resource, AsyncMock(spec=BaseChatModel))
 
-        assert_tool_is_base_uipath(tool)
-        # Output model degraded to an empty schema rather than crashing startup.
+        # Tool still built (not None / a list), with its output model degraded to
+        # an empty schema rather than crashing startup.
+        assert isinstance(tool, StructuredToolWithOutputType)
         assert tool.output_type.model_json_schema().get("properties", {}) == {}

--- a/tests/agent/tools/test_tool_factory.py
+++ b/tests/agent/tools/test_tool_factory.py
@@ -38,6 +38,9 @@ from uipath.agent.models.agent import (
 )
 from uipath.platform.connections import Connection
 
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
+    _UNRESOLVED_TYPE_TITLE,
+)
 from uipath_langchain.agent.tools.base_uipath_structured_tool import (
     BaseUiPathStructuredTool,
 )
@@ -335,11 +338,13 @@ def assert_tool_is_base_uipath(tool):
 
 
 # A tool output schema with a dangling $ref (no matching $defs entry) -- the shape
-# Studio Web emits for a .NET decimal? output argument. See create_output_model.
+# Studio Web emits for a .NET decimal? output argument -- alongside a valid sibling
+# that must survive. See create_output_model.
 _MALFORMED_OUTPUT_SCHEMA = {
     "type": "object",
     "properties": {
-        "left": {"$ref": "#/$defs/Nullableofdecimal", "type": "object"},
+        "status": {"type": "string"},  # valid sibling -- must be preserved
+        "left": {"$ref": "#/$defs/Nullableofdecimal", "type": "object"},  # dangling
     },
 }
 
@@ -484,8 +489,9 @@ class TestCreateToolsFromResources:
 
         An output schema drives only best-effort features (not the core tool call),
         so a dangling ``$ref`` (e.g. a .NET ``Nullableofdecimal`` with no ``$defs``)
-        must not raise ``AGENT_STARTUP.INVALID_TOOL_CONFIG``; the tool is still
-        built, with its output model degraded to an empty schema.
+        must not raise ``AGENT_STARTUP.INVALID_TOOL_CONFIG``. The tool is still built;
+        the dangling-ref field is neutralized to a permissive placeholder while valid
+        sibling fields are preserved.
         """
         resource = request.getfixturevalue(resource_fixture)
         _set_malformed_output_schema(resource)
@@ -493,7 +499,8 @@ class TestCreateToolsFromResources:
         # Must not raise (this previously threw AGENT_STARTUP.INVALID_TOOL_CONFIG).
         tool = await _build_tool_for_resource(resource, AsyncMock(spec=BaseChatModel))
 
-        # Tool still built (not None / a list), with its output model degraded to
-        # an empty schema rather than crashing startup.
         assert isinstance(tool, StructuredToolWithOutputType)
-        assert tool.output_type.model_json_schema().get("properties", {}) == {}
+        properties = tool.output_type.model_json_schema().get("properties", {})
+        # Valid sibling survives; dangling-ref field is neutralized (not dropped).
+        assert "status" in properties
+        assert properties["left"]["title"] == _UNRESOLVED_TYPE_TITLE

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.7"
+version = "0.14.8"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.6"
+version = "0.14.7"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Agents that ran on the legacy Temporal/.NET runtime crash on URT at startup with
`AGENT_STARTUP.INVALID_TOOL_CONFIG` when a tool's **output** schema has a dangling
`$ref` (e.g. a .NET `decimal?` → `Nullableofdecimal` with no `$defs`). URT eagerly
converts every tool schema to Pydantic and throws; the old runtime never resolved
`$ref`s. Output schemas are design-time only (guardrails + eval sims), never used
during execution, so the crash is gratuitous.

- Added `create_output_model()` in `jsonschema_pydantic_converter.py` — falls back
  to an empty model (with a warning) instead of raising on an unparseable schema.
- Applied it to the 5 output-schema tool factories: `process`, `escalation`,
  `integration`, `analyze_files`, `deeprag`.
- Left fatal (intentional): all **input** schemas and the agent-level output schema
  in `react/utils.py` (used at runtime for terminate-node validation).