### PR TITLE
chore: require uipath-llm-client 1.16.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.5"
+version = "0.14.6"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -9,7 +9,7 @@ dependencies = [
     "uipath-core>=0.5.29, <0.6.0",
     "uipath-platform>=0.2.5, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
-    "uipath-llm-client>=1.16.2, <1.17.0",
+    "uipath-llm-client>=1.16.3, <1.17.0",
     "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.27, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.5"
+version = "0.14.6"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4587,7 +4587,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
-    { name = "uipath-llm-client", specifier = ">=1.16.2,<1.17.0" },
+    { name = "uipath-llm-client", specifier = ">=1.16.3,<1.17.0" },
     { name = "uipath-platform", specifier = ">=0.2.5,<0.3.0" },
     { name = "uipath-runtime", specifier = ">=0.12.1,<0.13.0" },
 ]
@@ -4656,7 +4656,7 @@ vertexai = [
 
 [[package]]
 name = "uipath-llm-client"
-version = "1.16.2"
+version = "1.16.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4665,9 +4665,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "uipath-platform" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/aa/787e092ee901c763887e4ce2d68d2f7575e689db987b493242589a52f1ac/uipath_llm_client-1.16.2.tar.gz", hash = "sha256:6911d5b31552ec32100c036d6c902f9ca938f6142020230d3f88b78c0ca5fc23", size = 12516632, upload-time = "2026-07-06T15:42:50.911Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/7a/9970e29a0d1e5e25d07bf9f4dc18f665a53786982e6764a28998943e5998/uipath_llm_client-1.16.3.tar.gz", hash = "sha256:a5891368f822473056601bf3f241669de4655ba3d905fa1d4ef09289de824b8d", size = 12517747, upload-time = "2026-07-13T13:48:04.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/c7/9ab74b89a990751210e7ae54735dd29472b00748a8fea2bd63ca885afd0a/uipath_llm_client-1.16.2-py3-none-any.whl", hash = "sha256:c9c1f964d6508b60d2fd0e45402154a5099c661e03b525773db80b16fd888993", size = 68729, upload-time = "2026-07-06T15:42:49.379Z" },
+    { url = "https://files.pythonhosted.org/packages/87/17/258b8305748ad0df3ad78168f6ba57375b2d08da249360cf991adcad6d75/uipath_llm_client-1.16.3-py3-none-any.whl", hash = "sha256:7b11fa658d8708d5c89d4f04bd1952ddc1ab06206aa6077d453f7a1c6c47eb8b", size = 69275, upload-time = "2026-07-13T13:48:01.983Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- bump `uipath-langchain` from `0.14.5` to `0.14.6`
- raise the `uipath-llm-client` minimum from `1.16.2` to `1.16.3`
- regenerate `uv.lock` against the published `1.16.3` artifact

This makes the case-insensitive request-header merge fix from UiPath/uipath-llm-client-python#106 a required transitive dependency.

## Verification

- `uv sync --all-extras` succeeded and installed `uipath-llm-client==1.16.3`
- `uv sync --locked --all-extras` succeeded
- Ruff lint and formatting passed
- MyPy passed for 346 source files
- HTTPX client usage lint passed