### PR TITLE
feat(guardrails): consume uipath-platform 0.2.9 for BYOG evaluation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.6"
+version = "0.14.7"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
     "uipath>=2.13.7, <2.14.0",
     "uipath-core>=0.5.29, <0.6.0",
-    "uipath-platform>=0.2.5, <0.3.0",
+    "uipath-platform>=0.2.9, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
     "uipath-llm-client>=1.16.3, <1.17.0",
     "langgraph>=1.1.8, <2.0.0",

--- a/tests/agent/guardrails/test_guardrail_stage_filtering.py
+++ b/tests/agent/guardrails/test_guardrail_stage_filtering.py
@@ -78,3 +78,44 @@ class TestGuardrailStageFiltering:
         )
         assert len(post_filtered) == 1
         assert post_filtered[0][0] == judge_guardrail
+
+    def test_filter_by_stage_byog_sentinel_runs_in_all_stages(self):
+        """BYOG built-in validators ("byo" sentinel) run in every stage."""
+        byog_guardrail = MagicMock(spec=BuiltInValidatorGuardrail)
+        byog_guardrail.validator_type = "byo"
+        byog_guardrail.name = "BYOG-Databricks-PII"
+
+        action = MagicMock(spec=GuardrailAction)
+        guardrails = [(byog_guardrail, action)]
+
+        pre_filtered = uipath_langchain.agent.react.guardrails.guardrails_subgraph._filter_guardrails_by_stage(
+            guardrails, ExecutionStage.PRE_EXECUTION
+        )
+        assert len(pre_filtered) == 1
+        assert pre_filtered[0][0] == byog_guardrail
+
+        post_filtered = uipath_langchain.agent.react.guardrails.guardrails_subgraph._filter_guardrails_by_stage(
+            guardrails, ExecutionStage.POST_EXECUTION
+        )
+        assert len(post_filtered) == 1
+        assert post_filtered[0][0] == byog_guardrail
+
+    def test_filter_by_stage_byog_alongside_restricted_ootb_validator(self):
+        """A stage-restricted OOTB validator is dropped in the unsupported stage while
+        a co-located BYOG validator is preserved."""
+        pi_guardrail = MagicMock(spec=BuiltInValidatorGuardrail)
+        pi_guardrail.validator_type = "prompt_injection"
+        pi_guardrail.name = "Prompt-Injection"
+
+        byog_guardrail = MagicMock(spec=BuiltInValidatorGuardrail)
+        byog_guardrail.validator_type = "byo"
+        byog_guardrail.name = "BYOG-Acme"
+
+        action = MagicMock(spec=GuardrailAction)
+        guardrails = [(pi_guardrail, action), (byog_guardrail, action)]
+
+        post_filtered = uipath_langchain.agent.react.guardrails.guardrails_subgraph._filter_guardrails_by_stage(
+            guardrails, ExecutionStage.POST_EXECUTION
+        )
+        assert len(post_filtered) == 1
+        assert post_filtered[0][0] == byog_guardrail

--- a/tests/agent/guardrails/test_guardrails_factory.py
+++ b/tests/agent/guardrails/test_guardrails_factory.py
@@ -9,6 +9,7 @@ from langchain_core.tools import BaseTool
 from uipath.agent.models.agent import (  # type: ignore[attr-defined]
     AgentBooleanOperator,
     AgentBooleanRule,
+    AgentBuiltInValidatorGuardrail,
     AgentCustomGuardrail,
     AgentEscalationRecipientType,
     AgentGuardrailActionType,
@@ -41,6 +42,7 @@ from uipath.core.guardrails import (
     UniversalRule,
     WordRule,
 )
+from uipath.platform.guardrails import BuiltInValidatorGuardrail
 
 from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErrorCode
 from uipath_langchain.agent.guardrails.actions.block_action import BlockAction
@@ -332,6 +334,64 @@ class TestGuardrailsFactory:
         assert exc_info.value.error_info.code == AgentStartupError.full_code(
             AgentStartupErrorCode.INVALID_GUARDRAIL_CONFIG
         )
+
+    def test_byog_builtin_validator_is_mapped_and_preserves_byo_validator_name(
+        self,
+    ) -> None:
+        """A BYOG ("byo") built-in validator maps through unchanged, preserving
+        byo_validator_name."""
+        guardrail = AgentBuiltInValidatorGuardrail.model_validate(
+            {
+                "$guardrailType": "builtInValidator",
+                "id": "byog-databricks-pii",
+                "name": "Databricks PII (BYOG)",
+                "description": "Customer-provided PII validator",
+                "enabledForEvals": True,
+                "validatorType": "byo",
+                "byoValidatorName": "my_databricks_pii",
+                "validatorParameters": [],
+                "selector": {"scopes": ["Llm"]},
+                "action": {"$actionType": "block", "reason": "blocked by BYOG"},
+            }
+        )
+
+        result = build_guardrails_with_actions([guardrail], [])
+
+        assert len(result) == 1
+        gr, action = result[0]
+        assert gr is guardrail
+        assert isinstance(gr, BuiltInValidatorGuardrail)
+        assert gr.validator_type == "byo"
+        assert gr.byo_validator_name == "my_databricks_pii"
+        assert isinstance(action, BlockAction)
+        assert action.reason == "blocked by BYOG"
+
+    def test_byog_builtin_validator_tool_scope_sanitizes_match_names(self) -> None:
+        """A tool-scoped BYOG validator has its selector match_names sanitized so they
+        line up with the sanitized tool node names."""
+        guardrail = AgentBuiltInValidatorGuardrail.model_validate(
+            {
+                "$guardrailType": "builtInValidator",
+                "id": "byog-tool",
+                "name": "Custom tool validator (BYOG)",
+                "enabledForEvals": True,
+                "validatorType": "byo",
+                "byoValidatorName": "acme_toxicity",
+                "validatorParameters": [],
+                "selector": {"scopes": ["Tool"], "matchNames": ["My Tool!"]},
+                "action": {"$actionType": "block", "reason": "blocked"},
+            }
+        )
+
+        result = build_guardrails_with_actions([guardrail], [])
+
+        assert len(result) == 1
+        gr, action = result[0]
+        assert isinstance(gr, BuiltInValidatorGuardrail)
+        assert gr.selector is not None
+        assert gr.selector.match_names is not None
+        assert gr.selector.match_names != ["My Tool!"]
+        assert isinstance(action, BlockAction)
 
     def test_filter_action_is_mapped_with_fields(self) -> None:
         """FILTER action is mapped to FilterAction with correct fields."""

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.6"
+version = "0.14.7"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4588,7 +4588,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
     { name = "uipath-llm-client", specifier = ">=1.16.3,<1.17.0" },
-    { name = "uipath-platform", specifier = ">=0.2.5,<0.3.0" },
+    { name = "uipath-platform", specifier = ">=0.2.9,<0.3.0" },
     { name = "uipath-runtime", specifier = ">=0.12.1,<0.13.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
@@ -4672,7 +4672,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.5"
+version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4682,9 +4682,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/d5/497e6d681f8f19a6621875956562cc6da8c514568fb89b773844899c8656/uipath_platform-0.2.5.tar.gz", hash = "sha256:8e9e02111ca9485ee7289d75613a62d882c95d34beccb6f8b59c76050882cf2d", size = 424528, upload-time = "2026-07-08T08:58:56.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/4e/c555419c622b77a3b939f512faceaa73407669e51337c155b3c9697abce0/uipath_platform-0.2.9.tar.gz", hash = "sha256:86abad2c124f016b8da739ca9b794a3e3dc7fa10515750b8402278979c787783", size = 426699, upload-time = "2026-07-13T18:07:58.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/bf/11bb0b11777568c4e079d37f3ec003e816ca9be4e57f0455cafbccc67212/uipath_platform-0.2.5-py3-none-any.whl", hash = "sha256:ee14cd49e88ac1cdfc81e392025cc6f5c54b924fd20491d72ad6d55a5bc15db7", size = 279891, upload-time = "2026-07-08T08:58:53.575Z" },
+    { url = "https://files.pythonhosted.org/packages/de/75/94769a5107c69c0bbf0e3bbf625378bd9c0697b32bb2d602c2d6f860beb8/uipath_platform-0.2.9-py3-none-any.whl", hash = "sha256:2693668b9f00eb8c958c6f7615850b4123ced4bd735027cba28a04ba166ccada", size = 280892, upload-time = "2026-07-13T18:07:56.692Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed?

Bumps the `uipath-platform` floor to **0.2.9** so **Bring-Your-Own-Guardrail (BYOG)** guardrails are evaluated correctly at runtime.

A BYOG guardrail is persisted as a `BuiltInValidatorGuardrail` with the `"byo"` sentinel `validatorType` and a `byoValidatorName` referencing the connector-backed configuration. `uipath-platform` 0.2.9 exposes `byo_validator_name` as a typed field and forwards it in the guardrail validation request; earlier versions dropped it, so the service could not resolve the configuration.

- `pyproject.toml` — `uipath-platform>=0.2.5` → `>=0.2.9`; version `0.14.6` → `0.14.7`.
- `uv.lock` — regenerated (`uipath-platform` 0.2.9).
- Regression tests confirming a `"byo"` built-in validator guardrail:
  - maps through `build_guardrails_with_actions` unchanged, preserving `byo_validator_name`
  - is not dropped by the stage filter (runs in every stage its scope runs)

## Why

The runtime already passes the guardrail object straight through to `evaluate_guardrail`, so no source change is needed here — only the dependency floor so the forwarding is guaranteed present. With this bump, BYOG guardrails execute end-to-end.

## Notes

Requires the platform change in UiPath/uipath-python#1810 (merged, released as `uipath-platform` 0.2.9).

All guardrail tests pass (279); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)