### PR TITLE
test: add protocol conformance pins for runtime implementations

### DIFF
--- a/tests/runtime/test_protocol_conformance.py
+++ b/tests/runtime/test_protocol_conformance.py
@@ -1,0 +1,68 @@
+"""Protocol conformance for uipath-runtime protocol implementations.
+
+Every protocol-annotated assignment below is a typed boundary: mypy verifies
+the implementation against the protocol surface of the installed
+uipath-runtime version. A dependency bump that adds or changes protocol
+members fails typecheck on these lines until the implementations catch up.
+
+The wiring mirrors UiPathLangGraphRuntimeFactory._create_runtime_instance,
+so the exact production composition is what gets checked. Deliberately
+construction-only: no runtime behavior is exercised here.
+"""
+
+from typing import TypedDict
+
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from langgraph.graph import END, START, StateGraph
+from uipath.platform.resume_triggers import UiPathResumeTriggerHandler
+from uipath.runtime import (
+    UiPathResumableRuntime,
+    UiPathResumableStorageProtocol,
+    UiPathResumeTriggerProtocol,
+    UiPathRuntimeContext,
+    UiPathRuntimeFactoryProtocol,
+    UiPathRuntimeProtocol,
+)
+
+from uipath_langchain.runtime.factory import UiPathLangGraphRuntimeFactory
+from uipath_langchain.runtime.runtime import UiPathLangGraphRuntime
+from uipath_langchain.runtime.storage import SqliteResumableStorage
+
+
+class _State(TypedDict, total=False):
+    value: str
+
+
+async def test_langgraph_wiring_satisfies_runtime_protocols() -> None:
+    graph = StateGraph(_State)
+    graph.add_node("noop", lambda state: state)
+    graph.add_edge(START, "noop")
+    graph.add_edge("noop", END)
+
+    async with AsyncSqliteSaver.from_conn_string(":memory:") as memory:
+        compiled_graph = graph.compile(checkpointer=memory)
+
+        delegate: UiPathRuntimeProtocol = UiPathLangGraphRuntime(
+            graph=compiled_graph,
+            runtime_id="protocol-conformance-test",
+            entrypoint="test",
+        )
+        storage: UiPathResumableStorageProtocol = SqliteResumableStorage(memory)
+        trigger_manager: UiPathResumeTriggerProtocol = UiPathResumeTriggerHandler()
+
+        runtime: UiPathRuntimeProtocol = UiPathResumableRuntime(
+            delegate=delegate,
+            storage=storage,
+            trigger_manager=trigger_manager,
+            runtime_id="protocol-conformance-test",
+        )
+
+        assert runtime is not None
+
+
+def test_langgraph_factory_satisfies_factory_protocol() -> None:
+    factory: UiPathRuntimeFactoryProtocol = UiPathLangGraphRuntimeFactory(
+        context=UiPathRuntimeContext()
+    )
+
+    assert factory is not None


### PR DESCRIPTION
## Summary

Static conformance pins for this repo's `uipath-runtime` protocol implementations: `UiPathLangGraphRuntime`, `UiPathLangGraphRuntimeFactory`, and `SqliteResumableStorage`, plus the platform's `UiPathResumeTriggerHandler` as wired here.

Each protocol-annotated assignment is a typed boundary: mypy verifies the implementation against the protocol surface of the **installed** uipath-runtime version. When a future runtime bump adds or changes protocol members (the uipath-runtime#138 / uipath-python#1764 scenario — the missing `create_triggers` crash originated in this repo's factory wiring), the ordinary mypy job fails on these pre-existing lines, naming the exact class and missing member — no one needs to know about the protocol change in advance.

The test mirrors `UiPathLangGraphRuntimeFactory._create_runtime_instance` with real objects (compiled StateGraph, in-memory AsyncSqliteSaver, real trigger handler) flowing into `UiPathResumableRuntime` — the exact production composition that broke in the incident, expressed entirely as typed boundaries. Construction-only: no runtime behavior is exercised.

## Verification

Simulated a protocol change by installing a locally modified uipath-runtime (new `create_triggers_v2` member on `UiPathResumeTriggerCreatorProtocol`): mypy failed on the `trigger_manager` pin naming `create_triggers_v2`. Restored to the lockfile: green. Tests pass, mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)