### PR TITLE
feat(retry): consume uipath-llm-client 1.17.0 and raise default max retries to 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.9"
+version = "0.14.10"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -9,7 +9,7 @@ dependencies = [
     "uipath-core>=0.5.29, <0.6.0",
     "uipath-platform>=0.2.10, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
-    "uipath-llm-client>=1.16.3, <1.17.0",
+    "uipath-llm-client>=1.17.0, <1.18.0",
     "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.27, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",
@@ -26,7 +26,7 @@ dependencies = [
     "pillow>=12.1.1",
     "rdflib>=7.0.0, <8.0.0",
     "a2a-sdk>=0.2.0,<1.0.0",
-    "uipath-langchain-client[openai]>=1.16.1,<1.17.0",
+    "uipath-langchain-client[openai]>=1.17.0,<1.18.0",
 ]
 
 classifiers = [
@@ -43,21 +43,21 @@ maintainers = [
 
 [project.optional-dependencies]
 anthropic = [
-    "uipath-langchain-client[anthropic]>=1.16.1,<1.17.0",
+    "uipath-langchain-client[anthropic]>=1.17.0,<1.18.0",
 ]
 vertex = [
-    "uipath-langchain-client[google]>=1.16.1,<1.17.0",
-    "uipath-langchain-client[vertexai]>=1.16.1,<1.17.0",
+    "uipath-langchain-client[google]>=1.17.0,<1.18.0",
+    "uipath-langchain-client[vertexai]>=1.17.0,<1.18.0",
 ]
 bedrock = [
-    "uipath-langchain-client[bedrock]>=1.16.1,<1.17.0",
+    "uipath-langchain-client[bedrock]>=1.17.0,<1.18.0",
     "boto3-stubs>=1.41.4",
 ]
 fireworks = [
-    "uipath-langchain-client[fireworks]>=1.16.1,<1.17.0",
+    "uipath-langchain-client[fireworks]>=1.17.0,<1.18.0",
 ]
 all = [
-    "uipath-langchain-client[all]>=1.16.1,<1.17.0",
+    "uipath-langchain-client[all]>=1.17.0,<1.18.0",
 ]
 
 [project.entry-points."uipath.middlewares"]

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -59,7 +59,9 @@ _UNSET: Final[Any] = object()
 DEFAULT_TIMEOUT_SECONDS: Final[float] = 895.0
 DEFAULT_MAX_TOKENS: Final[int] = 1000
 DEFAULT_TEMPERATURE: Final[float] = 0.0
-DEFAULT_MAX_RETRIES: Final[int] = 3
+# 5 attempts for parity with the legacy in-repo retryers (BedrockRetryer /
+# VertexRetryer) and the uipath-llm-client transport defaults.
+DEFAULT_MAX_RETRIES: Final[int] = 5
 
 
 def get_chat_model(
@@ -99,7 +101,7 @@ def get_chat_model(
             forward an explicit unset value (lets the underlying client apply
             its own default or use no limit).
         timeout: Request timeout in seconds. Defaults to 895 seconds.
-        max_retries: Max retry count. Defaults to 3.
+        max_retries: Max retry count. Defaults to 5.
         callbacks: LangChain callbacks (handlers or a manager) attached to the
             returned chat model. Accepts ``list[BaseCallbackHandler]`` or a
             ``BaseCallbackManager``. Forwarded only when explicitly set.

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -59,8 +59,8 @@ _UNSET: Final[Any] = object()
 DEFAULT_TIMEOUT_SECONDS: Final[float] = 895.0
 DEFAULT_MAX_TOKENS: Final[int] = 1000
 DEFAULT_TEMPERATURE: Final[float] = 0.0
-# 5 attempts for parity with the legacy in-repo retryers (BedrockRetryer /
-# VertexRetryer) and the uipath-llm-client transport defaults.
+# 5 total attempts (initial request + up to 4 retries) for parity with the
+# legacy in-repo retryers (BedrockRetryer / VertexRetryer) and uipath-llm-client defaults.
 DEFAULT_MAX_RETRIES: Final[int] = 5
 
 

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -101,7 +101,8 @@ def get_chat_model(
             forward an explicit unset value (lets the underlying client apply
             its own default or use no limit).
         timeout: Request timeout in seconds. Defaults to 895 seconds.
-        max_retries: Max retry count. Defaults to 5.
+        max_retries: Maximum number of attempts (ignored when
+            use_new_llm_clients=False). Defaults to 5.
         callbacks: LangChain callbacks (handlers or a manager) attached to the
             returned chat model. Accepts ``list[BaseCallbackHandler]`` or a
             ``BaseCallbackManager``. Forwarded only when explicitly set.

--- a/tests/chat/test_chat_model_factory.py
+++ b/tests/chat/test_chat_model_factory.py
@@ -465,3 +465,31 @@ class TestGetChatModelTemperatureGating:
 
         _, kwargs = mock_cls.call_args
         assert kwargs.get("temperature") == 0.5
+
+
+class TestDefaultMaxRetriesForwarding:
+    """Pins ``DEFAULT_MAX_RETRIES`` to 5 (parity with the legacy in-repo
+    retryers) and asserts the default reaches the ``uipath_langchain_client``
+    factory on the new-clients path, so the old default cannot be silently
+    reintroduced."""
+
+    def test_default_max_retries_is_5(self):
+        from uipath_langchain.chat.chat_model_factory import DEFAULT_MAX_RETRIES
+
+        assert DEFAULT_MAX_RETRIES == 5
+
+    def test_default_max_retries_forwarded_to_new_client_factory(self, mocker):
+        from uipath_langchain.chat import chat_model_factory as outer_factory
+
+        mock_factory = mocker.patch(
+            "uipath_langchain.chat.chat_model_factory.get_chat_model_factory"
+        )
+
+        outer_factory.get_chat_model(
+            "gpt-test",
+            agenthub_config="cfg",
+            use_new_llm_clients=True,
+        )
+
+        _, kwargs = mock_factory.call_args
+        assert kwargs["max_retries"] == 5

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.9"
+version = "0.14.10"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4580,14 +4580,14 @@ requires-dist = [
     { name = "rdflib", specifier = ">=7.0.0,<8.0.0" },
     { name = "uipath", specifier = ">=2.13.7,<2.14.0" },
     { name = "uipath-core", specifier = ">=0.5.29,<0.6.0" },
-    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.16.1,<1.17.0" },
-    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.16.1,<1.17.0" },
-    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.16.1,<1.17.0" },
-    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.16.1,<1.17.0" },
-    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
-    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.16.1,<1.17.0" },
-    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.16.1,<1.17.0" },
-    { name = "uipath-llm-client", specifier = ">=1.16.3,<1.17.0" },
+    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.17.0,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.17.0,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.17.0,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.17.0,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.17.0,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.17.0,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.17.0,<1.18.0" },
+    { name = "uipath-llm-client", specifier = ">=1.17.0,<1.18.0" },
     { name = "uipath-platform", specifier = ">=0.2.10,<0.3.0" },
     { name = "uipath-runtime", specifier = ">=0.12.1,<0.13.0" },
 ]
@@ -4611,15 +4611,15 @@ dev = [
 
 [[package]]
 name = "uipath-langchain-client"
-version = "1.16.1"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
     { name = "uipath-llm-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/ab/8081d6dfe07f7d71c1ec3607e3cca4b5e11aff1b81dae23b7a46ca9d2d0a/uipath_langchain_client-1.16.1.tar.gz", hash = "sha256:60d96cc52dafce267a401607ddf9e46f04a5d22e7d616a765f6d8338c0a2b5f8", size = 39484, upload-time = "2026-07-03T15:42:43.356Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/53/d80c788ae60cceaef25cf892d01fa0a7a3b847a30e99613bef7a438464d6/uipath_langchain_client-1.17.0.tar.gz", hash = "sha256:2699f921c8b7440a44422e72818401d799776b129408b5a4365c321fd57f5ab9", size = 39634, upload-time = "2026-07-17T10:09:54.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/b4/384e3f824b7d870aac1dabd5f90ea65327c56fc1262339658088e0c6ee3d/uipath_langchain_client-1.16.1-py3-none-any.whl", hash = "sha256:313fdf19de27d4d9bf8e9897dbec1462d8528b73a4607f70399b8e9b0e47305c", size = 47613, upload-time = "2026-07-03T15:42:44.19Z" },
+    { url = "https://files.pythonhosted.org/packages/68/30/225f5bd2ff8dd68acb8ce26288b003389fc5923396147d5a6263eb9e5437/uipath_langchain_client-1.17.0-py3-none-any.whl", hash = "sha256:554d296a2a7765c1d38a252ea52e7d190b22654c37a3f10e72f80ff73f182d78", size = 47613, upload-time = "2026-07-17T10:09:55.526Z" },
 ]
 
 [package.optional-dependencies]
@@ -4656,7 +4656,7 @@ vertexai = [
 
 [[package]]
 name = "uipath-llm-client"
-version = "1.16.3"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4665,9 +4665,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "uipath-platform" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/7a/9970e29a0d1e5e25d07bf9f4dc18f665a53786982e6764a28998943e5998/uipath_llm_client-1.16.3.tar.gz", hash = "sha256:a5891368f822473056601bf3f241669de4655ba3d905fa1d4ef09289de824b8d", size = 12517747, upload-time = "2026-07-13T13:48:04.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/d1/c89d06261037d3a669f423ab3d0736f15446d63316635d9638ec772b7279/uipath_llm_client-1.17.0.tar.gz", hash = "sha256:d292f88b1248b6d96cffab60ea70ce0b7cebe1c243012f2fc3d5fe3d7aab4c51", size = 12519048, upload-time = "2026-07-17T10:08:17.68Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/17/258b8305748ad0df3ad78168f6ba57375b2d08da249360cf991adcad6d75/uipath_llm_client-1.16.3-py3-none-any.whl", hash = "sha256:7b11fa658d8708d5c89d4f04bd1952ddc1ab06206aa6077d453f7a1c6c47eb8b", size = 69275, upload-time = "2026-07-13T13:48:01.983Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d0/70027db0fb2ef3b4a0981f5305a2532ba70f14295c5a3e900c7c71dd6191/uipath_llm_client-1.17.0-py3-none-any.whl", hash = "sha256:bf3828237f89cd38d48ec7ee732e45d461fdce70148141982e66d12785ae0160", size = 70068, upload-time = "2026-07-17T10:08:19.819Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Companion to UiPath/uipath-llm-client-python#107 (merged, released as **1.17.0**). That PR restored retry parity between the shared LLM-client transports and the legacy in-repo chat-client retryers (`BedrockRetryer`/`VertexRetryer`):

- 5-attempt budget with 5s/10s/20s/40s backoff capped at 120s (~75s absorption window vs ~6s before)
- `Retry-After` honored on **any** error status (wait hint + forced retry, matching legacy)
- HTTP **524** retryable again (`UiPathOriginTimeoutError`)
- Connection-level failures retried: `httpx.TimeoutException` (incl. `PoolTimeout` under high concurrency), `ConnectError`, `RemoteProtocolError`

This PR consumes those releases **and removes the last override that kept agent runs on the old budget**: `chat_model_factory` passes `max_retries` explicitly on the new-clients path, so its `DEFAULT_MAX_RETRIES = 3` silently defeated the new client defaults for every low-code agent run (uipath-agents doesn't pass `max_retries`, so this factory default is what agents get).

## Changes

- `uipath-llm-client >=1.17.0,<1.18.0`
- `uipath-langchain-client` (all 7 extras lines) `>=1.17.0,<1.18.0`
- `DEFAULT_MAX_RETRIES` 3 → 5 in `chat_model_factory` (legacy-retryer parity)
- `uipath-langchain` 0.14.9 → 0.14.10, lockfile refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)