### PR TITLE
feat(chat): surface missing-model discovery errors as AgentStartupError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.12"
+version = "0.14.13"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -9,7 +9,8 @@ dependencies = [
     "uipath-core>=0.5.29, <0.6.0",
     "uipath-platform>=0.2.10, <0.3.0",
     "uipath-runtime>=0.12.5, <0.13.0",
-    "uipath-llm-client>=1.17.0, <1.18.0",
+
+    "uipath-llm-client>=1.17.1, <1.18.0",
     "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.27, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",
@@ -26,7 +27,7 @@ dependencies = [
     "pillow>=12.1.1",
     "rdflib>=7.0.0, <8.0.0",
     "a2a-sdk>=0.2.0,<1.0.0",
-    "uipath-langchain-client[openai]>=1.17.0,<1.18.0",
+    "uipath-langchain-client[openai]>=1.17.1,<1.18.0",
 ]
 
 classifiers = [
@@ -43,21 +44,21 @@ maintainers = [
 
 [project.optional-dependencies]
 anthropic = [
-    "uipath-langchain-client[anthropic]>=1.17.0,<1.18.0",
+    "uipath-langchain-client[anthropic]>=1.17.1,<1.18.0",
 ]
 vertex = [
-    "uipath-langchain-client[google]>=1.17.0,<1.18.0",
-    "uipath-langchain-client[vertexai]>=1.17.0,<1.18.0",
+    "uipath-langchain-client[google]>=1.17.1,<1.18.0",
+    "uipath-langchain-client[vertexai]>=1.17.1,<1.18.0",
 ]
 bedrock = [
-    "uipath-langchain-client[bedrock]>=1.17.0,<1.18.0",
+    "uipath-langchain-client[bedrock]>=1.17.1,<1.18.0",
     "boto3-stubs>=1.41.4",
 ]
 fireworks = [
-    "uipath-langchain-client[fireworks]>=1.17.0,<1.18.0",
+    "uipath-langchain-client[fireworks]>=1.17.1,<1.18.0",
 ]
 all = [
-    "uipath-langchain-client[all]>=1.17.0,<1.18.0",
+    "uipath-langchain-client[all]>=1.17.1,<1.18.0",
 ]
 
 [project.entry-points."uipath.middlewares"]

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -14,6 +14,7 @@ from typing import Any, Final
 
 from langchain_core.callbacks import BaseCallbackHandler, Callbacks
 from langchain_core.language_models import BaseChatModel
+from uipath.llm_client.utils.exceptions import ModelNotFoundError
 from uipath.llm_client.utils.headers import (
     get_dynamic_request_headers,
     set_dynamic_request_headers,
@@ -125,40 +126,69 @@ def get_chat_model(
     # keeps the wiring consistent.
     callbacks = _ensure_trace_context_callback(callbacks)
 
-    if not use_new_llm_clients:
-        return _legacy_chat_model(
+    try:
+        if not use_new_llm_clients:
+            return _legacy_chat_model(
+                model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                agenthub_config=agenthub_config,
+                byo_connection_id=byo_connection_id,
+                **kwargs,
+            )
+
+        optional_kwargs = {
+            k: v
+            for k, v in {
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "timeout": timeout,
+                "max_retries": max_retries,
+                "callbacks": callbacks,
+            }.items()
+            if v is not _UNSET
+        }
+
+        return get_chat_model_factory(
             model,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            agenthub_config=agenthub_config,
             byo_connection_id=byo_connection_id,
+            client_settings=client_settings,
+            routing_mode=routing_mode,
+            vendor_type=vendor_type,
+            api_flavor=api_flavor,
+            custom_class=custom_class,
+            agenthub_config=agenthub_config,
+            **optional_kwargs,
             **kwargs,
         )
+    except ModelNotFoundError as e:
+        from uipath.runtime.errors import UiPathErrorCategory
 
-    optional_kwargs = {
-        k: v
-        for k, v in {
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "timeout": timeout,
-            "max_retries": max_retries,
-            "callbacks": callbacks,
-        }.items()
-        if v is not _UNSET
-    }
+        from uipath_langchain.agent.exceptions import (
+            AgentStartupError,
+            AgentStartupErrorCode,
+        )
 
-    return get_chat_model_factory(
-        model,
-        byo_connection_id=byo_connection_id,
-        client_settings=client_settings,
-        routing_mode=routing_mode,
-        vendor_type=vendor_type,
-        api_flavor=api_flavor,
-        custom_class=custom_class,
-        agenthub_config=agenthub_config,
-        **optional_kwargs,
-        **kwargs,
-    )
+        if byo_connection_id:
+            detail = (
+                f"The model '{model}' is not available for connection "
+                f"'{byo_connection_id}'. Check that the bring-your-own-model "
+                "configuration for this connection is correct and that the "
+                "connection exposes this model."
+            )
+        else:
+            detail = (
+                f"The model '{model}' is not available. Verify the model name in "
+                "the agent configuration is correct and that the model is enabled "
+                "for this tenant. If the error persists, contact your administrator."
+            )
+
+        raise AgentStartupError(
+            code=AgentStartupErrorCode.LLM_INVALID_MODEL,
+            title="LLM model not available",
+            detail=detail,
+            category=UiPathErrorCategory.DEPLOYMENT,
+        ) from e
 
 
 def _ensure_trace_context_callback(callbacks: Callbacks) -> list[BaseCallbackHandler]:

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -171,10 +171,8 @@ def get_chat_model(
 
         if byo_connection_id:
             detail = (
-                f"The model '{model}' is not available for connection "
-                f"'{byo_connection_id}'. Check that the bring-your-own-model "
-                "configuration for this connection is correct and that the "
-                "connection exposes this model."
+                f"The model '{model}' is not available. Check that your custom "
+                "Model Configuration is available on this tenant."
             )
         else:
             detail = (

--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -20,6 +20,7 @@ from uipath.llm_client.utils.headers import (
     set_dynamic_request_headers,
 )
 from uipath.platform.chat.llm_trace_context import build_trace_context_headers
+from uipath.runtime.errors import UiPathErrorCategory
 from uipath_langchain_client.base_client import UiPathBaseChatModel
 from uipath_langchain_client.factory import get_chat_model as get_chat_model_factory
 from uipath_langchain_client.settings import (
@@ -27,6 +28,11 @@ from uipath_langchain_client.settings import (
     RoutingMode,
     UiPathBaseSettings,
     VendorType,
+)
+
+from uipath_langchain.agent.exceptions import (
+    AgentStartupError,
+    AgentStartupErrorCode,
 )
 
 
@@ -162,13 +168,6 @@ def get_chat_model(
             **kwargs,
         )
     except ModelNotFoundError as e:
-        from uipath.runtime.errors import UiPathErrorCategory
-
-        from uipath_langchain.agent.exceptions import (
-            AgentStartupError,
-            AgentStartupErrorCode,
-        )
-
         if byo_connection_id:
             detail = (
                 f"The model '{model}' is not available. Check that your custom "

--- a/tests/chat/test_chat_model_factory.py
+++ b/tests/chat/test_chat_model_factory.py
@@ -493,3 +493,55 @@ class TestDefaultMaxRetriesForwarding:
 
         _, kwargs = mock_factory.call_args
         assert kwargs["max_retries"] == 5
+
+
+class TestGetChatModelModelNotFound:
+    """The dispatcher get_chat_model maps a discovery-miss to AgentStartupError."""
+
+    def test_maps_model_not_found_to_agent_startup_error(self, mocker):
+        from uipath.llm_client.utils.exceptions import ModelNotFoundError
+        from uipath.runtime.errors import UiPathErrorCategory
+
+        from uipath_langchain.agent.exceptions import (
+            AgentStartupError,
+            AgentStartupErrorCode,
+        )
+        from uipath_langchain.chat.chat_model_factory import (
+            get_chat_model as dispatch_get_chat_model,
+        )
+
+        mocker.patch(
+            "uipath_langchain.chat.chat_model_factory.get_chat_model_factory",
+            side_effect=ModelNotFoundError("Model gpt-x not found."),
+        )
+
+        with pytest.raises(AgentStartupError) as exc_info:
+            dispatch_get_chat_model("gpt-x", agenthub_config="cfg")
+
+        info = exc_info.value.error_info
+        assert info.code == AgentStartupError.full_code(
+            AgentStartupErrorCode.LLM_INVALID_MODEL
+        )
+        assert info.category == UiPathErrorCategory.DEPLOYMENT
+        assert "gpt-x" in info.detail
+        assert isinstance(exc_info.value.__cause__, ModelNotFoundError)
+
+    def test_byo_connection_included_in_detail(self, mocker):
+        from uipath.llm_client.utils.exceptions import ModelNotFoundError
+
+        from uipath_langchain.agent.exceptions import AgentStartupError
+        from uipath_langchain.chat.chat_model_factory import (
+            get_chat_model as dispatch_get_chat_model,
+        )
+
+        mocker.patch(
+            "uipath_langchain.chat.chat_model_factory.get_chat_model_factory",
+            side_effect=ModelNotFoundError("Model gpt-x not found."),
+        )
+
+        with pytest.raises(AgentStartupError) as exc_info:
+            dispatch_get_chat_model(
+                "gpt-x", byo_connection_id="conn-1", agenthub_config="cfg"
+            )
+
+        assert "conn-1" in exc_info.value.error_info.detail

--- a/tests/chat/test_chat_model_factory.py
+++ b/tests/chat/test_chat_model_factory.py
@@ -498,7 +498,8 @@ class TestDefaultMaxRetriesForwarding:
 class TestGetChatModelModelNotFound:
     """The dispatcher get_chat_model maps a discovery-miss to AgentStartupError."""
 
-    def test_maps_model_not_found_to_agent_startup_error(self, mocker):
+    @pytest.mark.parametrize("byo_connection_id", [None, "conn-1"])
+    def test_maps_model_not_found_to_agent_startup_error(self, mocker, byo_connection_id):
         from uipath.llm_client.utils.exceptions import ModelNotFoundError
         from uipath.runtime.errors import UiPathErrorCategory
 
@@ -516,32 +517,13 @@ class TestGetChatModelModelNotFound:
         )
 
         with pytest.raises(AgentStartupError) as exc_info:
-            dispatch_get_chat_model("gpt-x", agenthub_config="cfg")
+            dispatch_get_chat_model(
+                "gpt-x", byo_connection_id=byo_connection_id, agenthub_config="cfg"
+            )
 
         info = exc_info.value.error_info
         assert info.code == AgentStartupError.full_code(
             AgentStartupErrorCode.LLM_INVALID_MODEL
         )
         assert info.category == UiPathErrorCategory.DEPLOYMENT
-        assert "gpt-x" in info.detail
         assert isinstance(exc_info.value.__cause__, ModelNotFoundError)
-
-    def test_byo_connection_included_in_detail(self, mocker):
-        from uipath.llm_client.utils.exceptions import ModelNotFoundError
-
-        from uipath_langchain.agent.exceptions import AgentStartupError
-        from uipath_langchain.chat.chat_model_factory import (
-            get_chat_model as dispatch_get_chat_model,
-        )
-
-        mocker.patch(
-            "uipath_langchain.chat.chat_model_factory.get_chat_model_factory",
-            side_effect=ModelNotFoundError("Model gpt-x not found."),
-        )
-
-        with pytest.raises(AgentStartupError) as exc_info:
-            dispatch_get_chat_model(
-                "gpt-x", byo_connection_id="conn-1", agenthub_config="cfg"
-            )
-
-        assert "conn-1" in exc_info.value.error_info.detail

--- a/tests/chat/test_chat_model_factory.py
+++ b/tests/chat/test_chat_model_factory.py
@@ -499,7 +499,9 @@ class TestGetChatModelModelNotFound:
     """The dispatcher get_chat_model maps a discovery-miss to AgentStartupError."""
 
     @pytest.mark.parametrize("byo_connection_id", [None, "conn-1"])
-    def test_maps_model_not_found_to_agent_startup_error(self, mocker, byo_connection_id):
+    def test_maps_model_not_found_to_agent_startup_error(
+        self, mocker, byo_connection_id
+    ):
         from uipath.llm_client.utils.exceptions import ModelNotFoundError
         from uipath.runtime.errors import UiPathErrorCategory
 

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.12"
+version = "0.14.13"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4580,14 +4580,14 @@ requires-dist = [
     { name = "rdflib", specifier = ">=7.0.0,<8.0.0" },
     { name = "uipath", specifier = ">=2.13.7,<2.14.0" },
     { name = "uipath-core", specifier = ">=0.5.29,<0.6.0" },
-    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.17.0,<1.18.0" },
-    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.17.0,<1.18.0" },
-    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.17.0,<1.18.0" },
-    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.17.0,<1.18.0" },
-    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.17.0,<1.18.0" },
-    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.17.0,<1.18.0" },
-    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.17.0,<1.18.0" },
-    { name = "uipath-llm-client", specifier = ">=1.17.0,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.17.1,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.17.1,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.17.1,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["fireworks"], marker = "extra == 'fireworks'", specifier = ">=1.17.1,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.17.1,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.17.1,<1.18.0" },
+    { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.17.1,<1.18.0" },
+    { name = "uipath-llm-client", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-platform", specifier = ">=0.2.10,<0.3.0" },
     { name = "uipath-runtime", specifier = ">=0.12.5,<0.13.0" },
 ]
@@ -4611,15 +4611,15 @@ dev = [
 
 [[package]]
 name = "uipath-langchain-client"
-version = "1.17.0"
+version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
     { name = "uipath-llm-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/53/d80c788ae60cceaef25cf892d01fa0a7a3b847a30e99613bef7a438464d6/uipath_langchain_client-1.17.0.tar.gz", hash = "sha256:2699f921c8b7440a44422e72818401d799776b129408b5a4365c321fd57f5ab9", size = 39634, upload-time = "2026-07-17T10:09:54.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/d4/89045b56b1279fb93ce1202b54b50d5f6e2717c790edc2db40486a48d3cd/uipath_langchain_client-1.17.1.tar.gz", hash = "sha256:bebf320bdb6846ce63881a076e84efea916b7c692c736658296ba20c5a0a3865", size = 39707, upload-time = "2026-07-20T08:19:16.216Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/30/225f5bd2ff8dd68acb8ce26288b003389fc5923396147d5a6263eb9e5437/uipath_langchain_client-1.17.0-py3-none-any.whl", hash = "sha256:554d296a2a7765c1d38a252ea52e7d190b22654c37a3f10e72f80ff73f182d78", size = 47613, upload-time = "2026-07-17T10:09:55.526Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b2/f5981e4066f1d1a1da13d50d4be698490d25cff82a68859ab401164e5b51/uipath_langchain_client-1.17.1-py3-none-any.whl", hash = "sha256:3c4b02abfad06ce6a00da31d969f8fca5e8b07eff1e3aef8e57a1b5fcf71f8bb", size = 47614, upload-time = "2026-07-20T08:19:17.192Z" },
 ]
 
 [package.optional-dependencies]
@@ -4656,7 +4656,7 @@ vertexai = [
 
 [[package]]
 name = "uipath-llm-client"
-version = "1.17.0"
+version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4665,9 +4665,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "uipath-platform" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/d1/c89d06261037d3a669f423ab3d0736f15446d63316635d9638ec772b7279/uipath_llm_client-1.17.0.tar.gz", hash = "sha256:d292f88b1248b6d96cffab60ea70ce0b7cebe1c243012f2fc3d5fe3d7aab4c51", size = 12519048, upload-time = "2026-07-17T10:08:17.68Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/16/d2870687326d794481b2949618d26d47e961304bd7ee90afada632733852/uipath_llm_client-1.17.1.tar.gz", hash = "sha256:68ed07fba571a2d402d555dfea230170b8cc3a36dce6158fbcdc703f8ef033a6", size = 12519504, upload-time = "2026-07-20T08:17:48.477Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/d0/70027db0fb2ef3b4a0981f5305a2532ba70f14295c5a3e900c7c71dd6191/uipath_llm_client-1.17.0-py3-none-any.whl", hash = "sha256:bf3828237f89cd38d48ec7ee732e45d461fdce70148141982e66d12785ae0160", size = 70068, upload-time = "2026-07-17T10:08:19.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/56/5bc72e0e45b6e482561425ca587d30aa1dd65e541b63cb50288d0595a731/uipath_llm_client-1.17.1-py3-none-any.whl", hash = "sha256:1d6bb97693d1b32c60c89fa2e939a0886fa67a4a985c6bcd5bdd9c2a6464abca", size = 70354, upload-time = "2026-07-20T08:17:46.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

When a model name isn't returned by the discovery API, `get_model_info` raises `ModelNotFoundError`. Until now `get_chat_model` let it propagate raw, so the runtime showed an opaque exception instead of an actionable message.

This PR catches `ModelNotFoundError` and re-raises it as a structured `AgentStartupError` (**code** `LLM_INVALID_MODEL`, **category** `DEPLOYMENT`). If a `byo_connection_id` is set, the message points to the connection's bring-your-own-model config; otherwise it asks you to check the model name and tenant enablement. The original error is preserved as `__cause__`.

## Changes

- `chat/chat_model_factory.py`: maps `ModelNotFoundError` to `AgentStartupError`. `AgentStartupError` / `UiPathErrorCategory` imported lazily inside the except block to avoid a `chat -> agent` import cycle.
- `pyproject.toml`: `uipath-llm-client` / `uipath-langchain-client` floors to `>=1.17.1,<1.18.0`; version to `0.14.11`.
- `uv.lock`: regenerated (resolves 1.17.1).
- Tests: `TestGetChatModelModelNotFound` covers the mapping, BYO variant, and `__cause__` chain.

## Depends on

`uipath-llm-client` **1.17.1** (adds `ModelNotFoundError` + `UiPathLLMErrorCode.MODEL_NOT_FOUND`). Already published.