### PR TITLE
fix: accept job attachment Metadata as nested model instance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.10"
+version = "0.14.11"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/job_attachments.py
+++ b/src/uipath_langchain/agent/react/job_attachments.py
@@ -71,6 +71,14 @@ def get_job_attachments(
     for att in job_attachments:
         if not att:
             continue
+        # Tool arguments are coerced into a generated input model, so an
+        # extracted attachment (and its nested fields, e.g. Metadata) may be a
+        # Pydantic model instance rather than plain data. model_validate with
+        # from_attributes does not recursively coerce nested models to dicts, so
+        # a valid Metadata map arriving as a sub-model would be rejected as "not
+        # a dictionary". Materialize the model to plain data first.
+        if isinstance(att, BaseModel):
+            att = att.model_dump(by_alias=True)
         try:
             attachment = Attachment.model_validate(att, from_attributes=True)
         except ValidationError as e:

--- a/tests/agent/react/test_job_attachments.py
+++ b/tests/agent/react/test_job_attachments.py
@@ -530,6 +530,57 @@ class TestGetJobAttachments:
         assert str(result[0].id) == valid_uuid
         assert result[0].full_name == "model-dump.pdf"
 
+    def test_accepts_attachment_field_as_nested_model_instance(self):
+        """Regression: at runtime tool args are coerced into the generated input
+        model, so an attachment arrives as a model instance whose ``Metadata``
+        object is a nested sub-model (``DynamicType_*``), not a dict. This must
+        not raise (previously failed with "Input should be a valid dictionary").
+        """
+        schema = {
+            "type": "object",
+            "properties": {"newArgument": {"$ref": "#/definitions/job-attachment"}},
+            "definitions": {
+                "job-attachment": {
+                    "type": "object",
+                    "x-uipath-resource-kind": "JobAttachment",
+                    "required": ["ID"],
+                    "properties": {
+                        "ID": {"type": "string"},
+                        "FullName": {"type": "string"},
+                        "MimeType": {"type": "string"},
+                        "Metadata": {
+                            "type": "object",
+                            "additionalProperties": {"type": "string"},
+                        },
+                    },
+                }
+            },
+        }
+        model = create_model(schema)
+        valid_uuid = "550e8400-e29b-41d4-a716-446655440500"
+
+        # Coerce raw input through the generated model exactly as the runtime
+        # does, then pass it inside kwargs (a dict holding a model instance) as
+        # process_tool_fn does. Metadata is now a nested model, not a dict.
+        validated: Any = model.model_validate(
+            {
+                "newArgument": {
+                    "ID": valid_uuid,
+                    "FullName": "workbook.xlsx",
+                    "MimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "Metadata": {"size": "38472"},
+                }
+            }
+        )
+        assert isinstance(validated.newArgument.Metadata, BaseModel)
+        kwargs = {"newArgument": validated.newArgument}
+
+        result = get_job_attachments(model, kwargs)
+
+        assert len(result) == 1
+        assert str(result[0].id) == valid_uuid
+        assert result[0].metadata == {"size": "38472"}
+
     def test_raises_system_error_with_field_on_invalid_attachment_shape(self):
         """A valid-UUID attachment missing a required field fails loud as SYSTEM,
         naming the offending field in a human-readable message."""

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.10"
+version = "0.14.11"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Problem

Agents that pass a job attachment to a process tool fail with:

> Invalid job attachment — 'Metadata': Input should be a valid dictionary
> (`AGENT_RUNTIME.OUTPUT_VALIDATION_ERROR`)

even when the attachment's `Metadata` is a valid string-to-string map (e.g. `{"size": "50999"}`).

## Root cause

Tool arguments are coerced into the generated input model, so an extracted attachment — and its nested `Metadata` object — reaches `get_job_attachments` as a Pydantic **model instance** (`DynamicType_*`), not plain data. `Attachment.model_validate(att, from_attributes=True)` does not recursively coerce nested models into dicts, so the sub-model `Metadata` is rejected against the SDK's `dict[str, Any]` field.

`extract_values_by_paths` only calls `model_dump()` when the *top-level* object is a model; in the process-tool path the top level is a `kwargs` dict whose value is the model, so the nested model survives.

## Fix

Materialize a model-instance attachment to plain data via `model_dump(by_alias=True)` before validating. This normalizes nested sub-models back to dicts and keeps the SDK `Attachment.metadata: dict[str, Any]` contract intact (no `uipath-platform` change needed).

- Behavior is unchanged for the plain-dict path (every other caller); only inputs that were **already crashing** now succeed.
- Added a regression test reproducing the runtime shape (nested `Metadata` sub-model inside `kwargs`); it fails without the fix with the exact production error and passes with it.
- Validated end-to-end against a local robot: the previously-failing attachment job now runs successfully.

Bumps version to 0.14.11.