### PR TITLE
memory recall derives file-input search keys via space-configured analysis prompts

### DIFF
--- a/src/uipath_langchain/agent/react/agent.py
+++ b/src/uipath_langchain/agent/react/agent.py
@@ -172,7 +172,9 @@ def create_agent(
         )
 
     if memory:
-        memory_recall = create_memory_recall_node(memory, input_schema=input_schema)
+        memory_recall = create_memory_recall_node(
+            memory, input_schema=input_schema, model=model
+        )
         builder.add_node(AgentGraphNode.MEMORY_RECALL, memory_recall)
         builder.add_edge(START, AgentGraphNode.MEMORY_RECALL)
         builder.add_edge(AgentGraphNode.MEMORY_RECALL, AgentGraphNode.INIT)

--- a/src/uipath_langchain/agent/react/memory_node.py
+++ b/src/uipath_langchain/agent/react/memory_node.py
@@ -3,12 +3,22 @@
 Queries the UiPath Memory service (via LLMOps) for similar past episodes
 and stores the server-generated systemPromptInjection in graph state so
 the INIT node can append it to the system prompt.
+
+When a memory space enables file analysis (space-owned settings), the node
+also derives an ephemeral ``fileText_query`` from each key-included attachment
+via one multimodal LLM call per field and searches with that text instead of
+the raw attachment reference. The derived text is query-only — it is never
+persisted and never written back into the agent's input/state, so the ReAct
+loop and the analyze-files tool still receive the full attachment.
 """
 
 import logging
+import time
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Callable
 
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel
 from uipath.platform import UiPath
 from uipath.platform.errors import EnrichedException
@@ -20,10 +30,24 @@ from uipath.platform.memory import (
     SearchSettings,
 )
 
+from ...chat import get_chat_model
+from ...chat.helpers import extract_text_content
+from ..tools.internal_tools.analyze_files_tool import (
+    add_files_to_message,
+    resolve_attachments_to_file_infos,
+)
+from .job_attachments import get_job_attachment_paths
 from .types import MemoryConfig
 from .utils import extract_input_data_from_state
 
 logger = logging.getLogger(__name__)
+
+# Field type prefix used for episodic-memory keyPaths (["agent-input", <field>]).
+_ANALYSIS_FIELD_TYPE = "agent-input"
+# Cap the derived query text so a large document can't blow up the search request.
+_FILE_TEXT_MAX_CHARS = 8000
+
+_UNSET = object()
 
 
 @contextmanager
@@ -32,9 +56,20 @@ def _noop_context():
     yield None
 
 
+def _get_tracer() -> tuple[Any, Any]:
+    """Return ``(tracer, otel_trace)`` or ``(None, None)`` when OTel is unavailable."""
+    try:
+        from opentelemetry import trace as otel_trace
+
+        return otel_trace.get_tracer("uipath_langchain.memory"), otel_trace
+    except ImportError:
+        return None, None
+
+
 def create_memory_recall_node(
     memory_config: MemoryConfig,
     input_schema: type[BaseModel] | None = None,
+    model: BaseChatModel | None = None,
 ):
     """Create an async graph node that retrieves memory injection.
 
@@ -44,10 +79,32 @@ def create_memory_recall_node(
 
     Args:
         memory_config: Memory configuration with space ID and search settings.
+        input_schema: The agent's input schema, used to locate attachment fields.
+        model: The agent's chat model. Required for file-key analysis; when
+            ``None`` the file-analysis pre-step is skipped entirely (today's
+            text-only recall behavior).
 
     Returns:
         An async callable suitable for ``builder.add_node()``.
     """
+
+    # Per-run caches on the node closure (fetched at most once).
+    _settings_cache: list[Any] = [_UNSET]
+    _analysis_model_cache: list[Any] = [_UNSET]
+
+    async def _get_settings() -> dict[str, Any] | None:
+        if _settings_cache[0] is _UNSET:
+            _settings_cache[0] = await _fetch_space_settings(
+                memory_config.memory_space_id
+            )
+        return _settings_cache[0]
+
+    def _get_analysis_model(settings: dict[str, Any]) -> BaseChatModel:
+        if _analysis_model_cache[0] is _UNSET:
+            _analysis_model_cache[0] = _build_analysis_model(
+                model, settings.get("analysisModel")
+            )
+        return _analysis_model_cache[0]
 
     async def memory_recall_node(state: Any) -> dict[str, Any]:
         input_model = input_schema if input_schema is not None else BaseModel
@@ -56,8 +113,33 @@ def create_memory_recall_node(
             logger.debug("Memory recall: no user inputs found in state")
             return {}
 
+        tracer, otel_trace = _get_tracer()
+
+        # File-key analysis pre-step (query-side, ephemeral). Soft-fails to the
+        # text-only behavior on any error. Never mutates state/input — only the
+        # local search arguments are substituted.
+        search_arguments = input_arguments
+        if model is not None:
+            settings = await _get_settings()
+            if settings:
+                analyzed, skipped = await _analyze_file_fields_for_search(
+                    input_arguments=input_arguments,
+                    input_model=input_model,
+                    settings=settings,
+                    field_weights=memory_config.field_weights or None,
+                    build_analysis_model=lambda: _get_analysis_model(settings),
+                    tracer=tracer,
+                )
+                if analyzed or skipped:
+                    search_arguments = dict(input_arguments)
+                    search_arguments.update(analyzed)
+                    for field in skipped:
+                        # Enabled file field with no usable analysis text: drop it
+                        # entirely rather than searching on the raw attachment ref.
+                        search_arguments.pop(field, None)
+
         fields = _build_search_fields(
-            input_arguments, field_weights=memory_config.field_weights or None
+            search_arguments, field_weights=memory_config.field_weights or None
         )
         if not fields:
             logger.debug(
@@ -82,13 +164,6 @@ def create_memory_recall_node(
         # "Apply dynamic few shot" appear in the Execution Trace with
         # correct timing. The LlmOpsHttpExporter picks these up.
         injection = ""
-        try:
-            from opentelemetry import trace as otel_trace
-
-            tracer = otel_trace.get_tracer("uipath_langchain.memory")
-        except ImportError:
-            tracer = None
-            otel_trace = None  # type: ignore[assignment]
 
         # Span attribute keys matching what the LlmOpsHttpExporter and
         # Studio UI expect. "openinference.span.kind" sets SpanType.
@@ -198,6 +273,247 @@ def create_memory_recall_node(
         return {"inner_state": {"memory_injection": injection}}
 
     return memory_recall_node
+
+
+async def _fetch_space_settings(space_id: str) -> dict[str, Any] | None:
+    """Fetch a memory space's settings from LLMOps.
+
+    Uses the SDK's low-level API client so we get bearer auth, org/tenant
+    scoping and retries for free (no SDK release needed). Soft-fails to ``None``
+    on any error so recall proceeds with no file analysis (today's behavior).
+    """
+    try:
+        sdk = UiPath()
+        response = await sdk.api_client.request_async(
+            "GET",
+            f"/llmopstenant_/api/Memory/{space_id}/settings",
+            include_folder_headers=True,
+        )
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        logger.warning(
+            "Memory file-analysis: failed to fetch space settings for '%s': %s",
+            space_id,
+            repr(e),
+        )
+        return None
+
+
+def _build_analysis_model(
+    agent_model: BaseChatModel, analysis_model_name: str | None
+) -> BaseChatModel:
+    """Build the (non-streaming) model used for file-key analysis.
+
+    Prefers the space-pinned ``analysisModel`` so the query side matches the
+    ingest side (symmetry: same prompt + same model in, same key out). Falls
+    back to a non-streaming copy of the agent's own model if the pinned model
+    cannot be constructed.
+    """
+    if analysis_model_name:
+        try:
+            fresh = get_chat_model(analysis_model_name)
+            return fresh.model_copy(update={"disable_streaming": True})
+        except Exception as e:
+            logger.warning(
+                "Memory file-analysis: could not build analysis model '%s' (%s); "
+                "falling back to the agent model. "
+                "TODO(POC): honor settings.analysisModel for symmetry.",
+                analysis_model_name,
+                repr(e),
+            )
+    return agent_model.model_copy(update={"disable_streaming": True})
+
+
+def _top_level_attachment_fields(model: type[BaseModel]) -> set[str]:
+    """Return the names of top-level attachment fields (single or list) in ``model``.
+
+    Scope is intentionally limited to flat memory keyPaths: only ``$.field`` and
+    ``$.field[*]`` qualify; nested/array-of-object paths are out of scope.
+    """
+    fields: set[str] = set()
+    for path in get_job_attachment_paths(model):
+        name = _top_level_attachment_field(path)
+        if name:
+            fields.add(name)
+    return fields
+
+
+def _top_level_attachment_field(json_path: str) -> str | None:
+    """Extract the field name from a top-level attachment JSONPath, else ``None``.
+
+    ``$.doc`` -> ``"doc"``; ``$.docs[*]`` -> ``"docs"``; nested paths such as
+    ``$.a.b`` or ``$.a[*][*]`` return ``None``.
+    """
+    if not json_path.startswith("$."):
+        return None
+    rest = json_path[2:]
+    if rest.endswith("[*]"):
+        rest = rest[:-3]
+    if not rest or "." in rest or "[" in rest:
+        return None
+    return rest
+
+
+def _enabled_file_prompts(
+    settings: dict[str, Any], field_weights: dict[str, float] | None
+) -> dict[str, str]:
+    """Map field name -> analysis prompt for enabled, in-scope fileAnalysis entries.
+
+    Only entries that are enabled, carry a flat ``["agent-input", field]`` keyPath
+    with a non-empty prompt, and target a field the recall search actually uses
+    (present in ``field_weights``) are returned.
+    """
+    result: dict[str, str] = {}
+    for entry in settings.get("fileAnalysis") or []:
+        if not entry.get("enabled"):
+            continue
+        key_path = entry.get("keyPath") or []
+        if len(key_path) != 2 or key_path[0] != _ANALYSIS_FIELD_TYPE:
+            continue
+        field = key_path[1]
+        prompt = entry.get("analysisPrompt") or ""
+        if not prompt:
+            continue
+        if field_weights and field not in field_weights:
+            continue
+        result[field] = prompt
+    return result
+
+
+def _normalize_attachment_items(value: Any) -> list[Any]:
+    """Normalize a single attachment or a list of attachments to a list of truthy items."""
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    return [item for item in items if item]
+
+
+def _render_analysis_prompt(prompt: str, agent_prompt_reference: str | None) -> str:
+    """Fill the ``{FILE}`` and ``{AGENT_PROMPT}`` placeholders in an analysis prompt.
+
+    ``{FILE}`` always becomes "the attached file". ``{AGENT_PROMPT}`` becomes the
+    space's agent-prompt reference when present, otherwise it is removed.
+    """
+    rendered = prompt.replace("{FILE}", "the attached file")
+    rendered = rendered.replace("{AGENT_PROMPT}", agent_prompt_reference or "")
+    return rendered
+
+
+async def _analyze_file_fields_for_search(
+    *,
+    input_arguments: dict[str, Any],
+    input_model: type[BaseModel],
+    settings: dict[str, Any],
+    field_weights: dict[str, float] | None,
+    build_analysis_model: Callable[[], BaseChatModel],
+    tracer: Any,
+) -> tuple[dict[str, str], set[str]]:
+    """Derive ephemeral query text for key-included attachment fields.
+
+    Returns ``(analyzed, skipped)`` where ``analyzed`` maps a field name to its
+    derived text and ``skipped`` is the set of enabled file fields that produced
+    no usable text (and must be dropped from the search entirely). Each field is
+    soft-failed independently — an error on one never aborts the others.
+    """
+    enabled_prompts = _enabled_file_prompts(settings, field_weights)
+    if not enabled_prompts:
+        return {}, set()
+
+    attachment_fields = _top_level_attachment_fields(input_model)
+    candidates = {
+        field: prompt
+        for field, prompt in enabled_prompts.items()
+        if field in attachment_fields
+    }
+    if not candidates:
+        return {}, set()
+
+    analysis_model = build_analysis_model()
+    agent_prompt_reference = settings.get("agentPromptReference")
+
+    analyzed: dict[str, str] = {}
+    skipped: set[str] = set()
+    for field, prompt in candidates.items():
+        items = _normalize_attachment_items(input_arguments.get(field))
+        if not items:
+            # Field declared but no attachment supplied this run — nothing to do;
+            # leave it to the normal (empty) filtering rather than skip-listing it.
+            continue
+        try:
+            text = await _analyze_single_field(
+                field=field,
+                prompt=prompt,
+                items=items,
+                agent_prompt_reference=agent_prompt_reference,
+                analysis_model=analysis_model,
+                memory_space_id=str(settings.get("memorySpaceId") or ""),
+                tracer=tracer,
+            )
+        except Exception as e:
+            logger.warning(
+                "Memory file-analysis: skipping field '%s': %s", field, repr(e)
+            )
+            skipped.add(field)
+            continue
+        if text:
+            analyzed[field] = text
+        else:
+            skipped.add(field)
+
+    return analyzed, skipped
+
+
+async def _analyze_single_field(
+    *,
+    field: str,
+    prompt: str,
+    items: list[Any],
+    agent_prompt_reference: str | None,
+    analysis_model: BaseChatModel,
+    memory_space_id: str,
+    tracer: Any,
+) -> str:
+    """Run one multimodal analysis call for a single attachment field.
+
+    Returns the derived text (stripped and truncated), or ``""`` when there is
+    nothing usable to search on.
+    """
+    file_infos = await resolve_attachments_to_file_infos(items)
+    if not file_infos:
+        return ""
+
+    # TODO(POC): PII-mask via PiiMasker before the LLM call — files are sent to
+    # the gateway unmasked in the POC (same posture as the analyze-files tool
+    # without a policy). Must mask identically to the ingest side before GA.
+    system_prompt = _render_analysis_prompt(prompt, agent_prompt_reference)
+    human_message = await add_files_to_message(HumanMessage(content=""), file_infos)
+    messages = [SystemMessage(content=system_prompt), human_message]
+
+    span_ctx = (
+        tracer.start_as_current_span(
+            "Analyze file for memory key",
+            attributes={
+                "uipath.custom_instrumentation": True,
+                "memoryKeyField": field,
+                "memorySpaceId": memory_space_id,
+            },
+        )
+        if tracer
+        else _noop_context()
+    )
+
+    start = time.perf_counter()
+    with span_ctx as span:
+        try:
+            result = await analysis_model.ainvoke(messages)
+        finally:
+            if span is not None and hasattr(span, "set_attribute"):
+                span.set_attribute("durationMs", (time.perf_counter() - start) * 1000.0)
+
+    # The trace carries only the raw attachment ref (via the agent input) — never
+    # the derived text — so we deliberately do NOT stamp fileText on the span.
+    return extract_text_content(result).strip()[:_FILE_TEXT_MAX_CHARS]
 
 
 def _build_search_fields(

--- a/src/uipath_langchain/agent/react/memory_node.py
+++ b/src/uipath_langchain/agent/react/memory_node.py
@@ -15,7 +15,7 @@ loop and the analyze-files tool still receive the full attachment.
 import logging
 import time
 from contextlib import contextmanager
-from typing import Any, Callable
+from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -46,8 +46,11 @@ logger = logging.getLogger(__name__)
 _ANALYSIS_FIELD_TYPE = "agent-input"
 # Cap the derived query text so a large document can't blow up the search request.
 _FILE_TEXT_MAX_CHARS = 8000
-
-_UNSET = object()
+# Bound the recall-time analysis LLM call. It runs before the agent's first step,
+# so an unbounded call (get_chat_model defaults to 895s x 5 attempts) could stall
+# the whole run. On timeout the field soft-fails and is skipped, not fatal.
+_ANALYSIS_TIMEOUT_SECONDS = 120.0
+_ANALYSIS_MAX_RETRIES = 2
 
 
 @contextmanager
@@ -88,24 +91,6 @@ def create_memory_recall_node(
         An async callable suitable for ``builder.add_node()``.
     """
 
-    # Per-run caches on the node closure (fetched at most once).
-    _settings_cache: list[Any] = [_UNSET]
-    _analysis_model_cache: list[Any] = [_UNSET]
-
-    async def _get_settings() -> dict[str, Any] | None:
-        if _settings_cache[0] is _UNSET:
-            _settings_cache[0] = await _fetch_space_settings(
-                memory_config.memory_space_id
-            )
-        return _settings_cache[0]
-
-    def _get_analysis_model(settings: dict[str, Any]) -> BaseChatModel:
-        if _analysis_model_cache[0] is _UNSET:
-            _analysis_model_cache[0] = _build_analysis_model(
-                model, settings.get("analysisModel")
-            )
-        return _analysis_model_cache[0]
-
     async def memory_recall_node(state: Any) -> dict[str, Any]:
         input_model = input_schema if input_schema is not None else BaseModel
         input_arguments = extract_input_data_from_state(state, input_model)
@@ -117,17 +102,27 @@ def create_memory_recall_node(
 
         # File-key analysis pre-step (query-side, ephemeral). Soft-fails to the
         # text-only behavior on any error. Never mutates state/input — only the
-        # local search arguments are substituted.
+        # local search arguments are substituted. Settings are fetched live so an
+        # edit to the space's analysis prompt takes effect on the next run.
         search_arguments = input_arguments
         if model is not None:
-            settings = await _get_settings()
+            # Only agents that declare attachment fields can carry file keys.
+            # Compute that from the schema first (pure, no I/O) and skip the
+            # settings GET entirely for text-only agents, so their recall stays
+            # byte-identical to the pre-file-analysis behavior (no extra HTTP call).
+            attachment_fields = _top_level_attachment_fields(input_model)
+            settings = (
+                await _fetch_space_settings(memory_config.memory_space_id)
+                if attachment_fields
+                else None
+            )
             if settings:
                 analyzed, skipped = await _analyze_file_fields_for_search(
                     input_arguments=input_arguments,
-                    input_model=input_model,
+                    attachment_fields=attachment_fields,
                     settings=settings,
                     field_weights=memory_config.field_weights or None,
-                    build_analysis_model=lambda: _get_analysis_model(settings),
+                    agent_model=model,
                     tracer=tracer,
                 )
                 if analyzed or skipped:
@@ -312,7 +307,11 @@ def _build_analysis_model(
     """
     if analysis_model_name:
         try:
-            fresh = get_chat_model(analysis_model_name)
+            fresh = get_chat_model(
+                analysis_model_name,
+                timeout=_ANALYSIS_TIMEOUT_SECONDS,
+                max_retries=_ANALYSIS_MAX_RETRIES,
+            )
             return fresh.model_copy(update={"disable_streaming": True})
         except Exception as e:
             logger.warning(
@@ -403,10 +402,10 @@ def _render_analysis_prompt(prompt: str, agent_prompt_reference: str | None) -> 
 async def _analyze_file_fields_for_search(
     *,
     input_arguments: dict[str, Any],
-    input_model: type[BaseModel],
+    attachment_fields: set[str],
     settings: dict[str, Any],
     field_weights: dict[str, float] | None,
-    build_analysis_model: Callable[[], BaseChatModel],
+    agent_model: BaseChatModel,
     tracer: Any,
 ) -> tuple[dict[str, str], set[str]]:
     """Derive ephemeral query text for key-included attachment fields.
@@ -415,12 +414,14 @@ async def _analyze_file_fields_for_search(
     derived text and ``skipped`` is the set of enabled file fields that produced
     no usable text (and must be dropped from the search entirely). Each field is
     soft-failed independently — an error on one never aborts the others.
+
+    ``attachment_fields`` is the set of top-level attachment field names in the
+    agent's input schema, computed once by the caller.
     """
     enabled_prompts = _enabled_file_prompts(settings, field_weights)
     if not enabled_prompts:
         return {}, set()
 
-    attachment_fields = _top_level_attachment_fields(input_model)
     candidates = {
         field: prompt
         for field, prompt in enabled_prompts.items()
@@ -429,7 +430,7 @@ async def _analyze_file_fields_for_search(
     if not candidates:
         return {}, set()
 
-    analysis_model = build_analysis_model()
+    analysis_model = _build_analysis_model(agent_model, settings.get("analysisModel"))
     agent_prompt_reference = settings.get("agentPromptReference")
 
     analyzed: dict[str, str] = {}

--- a/src/uipath_langchain/agent/react/memory_node.py
+++ b/src/uipath_langchain/agent/react/memory_node.py
@@ -110,7 +110,11 @@ def create_memory_recall_node(
             # Compute that from the schema first (pure, no I/O) and skip the
             # settings GET entirely for text-only agents, so their recall stays
             # byte-identical to the pre-file-analysis behavior (no extra HTTP call).
+            # Fields excluded from the memory key (not in field_weights) can never
+            # be analyzed either, so they don't justify the fetch.
             attachment_fields = _top_level_attachment_fields(input_model)
+            if memory_config.field_weights:
+                attachment_fields &= set(memory_config.field_weights)
             settings = (
                 await _fetch_space_settings(memory_config.memory_space_id)
                 if attachment_fields
@@ -316,8 +320,8 @@ def _build_analysis_model(
         except Exception as e:
             logger.warning(
                 "Memory file-analysis: could not build analysis model '%s' (%s); "
-                "falling back to the agent model. "
-                "TODO(POC): honor settings.analysisModel for symmetry.",
+                "falling back to a non-streaming copy of the agent model — "
+                "ingest/query key symmetry is degraded for this run.",
                 analysis_model_name,
                 repr(e),
             )

--- a/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
@@ -374,13 +374,29 @@ def create_analyze_file_tool(
     return tool
 
 
-async def _resolve_job_attachment_arguments(
+def _attachment_field(attachment: Any, name: str) -> Any:
+    """Read an attachment field by its canonical name (``ID``/``FullName``/``MimeType``).
+
+    Supports both mapping-shaped attachments (plain dicts with those keys, as
+    produced by ``model_dump`` on the generated input model) and attribute-shaped
+    objects (the coerced input-model instances the analyze-files tool receives, or
+    a ``SimpleNamespace``). This lets the analyze-files tool and the memory
+    file-key recall path share one resolver.
+    """
+    if isinstance(attachment, dict):
+        return attachment.get(name)
+    return getattr(attachment, name, None)
+
+
+async def resolve_attachments_to_file_infos(
     attachments: list[Any],
 ) -> list[FileInfo]:
     """Resolve job attachments to FileInfo objects.
 
     Args:
-        attachments: List of job attachment objects (dynamically typed from schema)
+        attachments: List of job attachments, each either a mapping with
+            ``ID``/``FullName``/``MimeType`` keys or an object exposing those as
+            attributes.
 
     Returns:
         List of FileInfo objects with blob URIs for each attachment
@@ -389,12 +405,12 @@ async def _resolve_job_attachment_arguments(
     file_infos: list[FileInfo] = []
 
     for attachment in attachments:
-        # Access using Pydantic field aliases (ID, FullName, MimeType)
-        # These are dynamically created from the JSON schema
-        attachment_id_value = getattr(attachment, "ID", None)
+        # Access using the Pydantic field aliases (ID, FullName, MimeType) that
+        # are dynamically created from the JSON schema, or the equivalent dict keys.
+        attachment_id_value = _attachment_field(attachment, "ID")
         if attachment_id_value is None:
             continue
-        attachment_name = getattr(attachment, "FullName", None) or "<unknown>"
+        attachment_name = _attachment_field(attachment, "FullName") or "<unknown>"
 
         try:
             attachment_id = uuid.UUID(attachment_id_value)
@@ -420,7 +436,7 @@ async def _resolve_job_attachment_arguments(
             )
             raise
 
-        input_mime_type = getattr(attachment, "MimeType", None)
+        input_mime_type = _attachment_field(attachment, "MimeType")
         mime_type = (
             input_mime_type
             if input_mime_type
@@ -436,6 +452,13 @@ async def _resolve_job_attachment_arguments(
         file_infos.append(file_info)
 
     return file_infos
+
+
+async def _resolve_job_attachment_arguments(
+    attachments: list[Any],
+) -> list[FileInfo]:
+    """Backwards-compatible wrapper around :func:`resolve_attachments_to_file_infos`."""
+    return await resolve_attachments_to_file_infos(attachments)
 
 
 async def add_files_to_message(

--- a/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
@@ -401,7 +401,7 @@ async def resolve_attachments_to_file_infos(
     Returns:
         List of FileInfo objects with blob URIs for each attachment
     """
-    client = UiPath()
+    client: UiPath | None = None
     file_infos: list[FileInfo] = []
 
     for attachment in attachments:
@@ -410,6 +410,9 @@ async def resolve_attachments_to_file_infos(
         attachment_id_value = _attachment_field(attachment, "ID")
         if attachment_id_value is None:
             continue
+        # Construct the platform client only once a resolvable attachment exists —
+        # memory recall may call this per field, often with nothing to resolve.
+        client = client or UiPath()
         attachment_name = _attachment_field(attachment, "FullName") or "<unknown>"
 
         try:

--- a/tests/agent/react/test_memory_node.py
+++ b/tests/agent/react/test_memory_node.py
@@ -14,9 +14,12 @@ from uipath_langchain.agent.multimodal import FileInfo
 from uipath_langchain.agent.react.agent import create_agent
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
 from uipath_langchain.agent.react.memory_node import (
+    _ANALYSIS_MAX_RETRIES,
+    _ANALYSIS_TIMEOUT_SECONDS,
     _build_analysis_model,
     _build_search_fields,
     _enabled_file_prompts,
+    _fetch_space_settings,
     _normalize_attachment_items,
     _render_analysis_prompt,
     _top_level_attachment_field,
@@ -316,7 +319,11 @@ class TestBuildAnalysisModel:
         agent_model = MagicMock(spec=BaseChatModel)
 
         assert _build_analysis_model(agent_model, "gpt-4o") == "pinned"
-        get_chat_model.assert_called_once_with("gpt-4o")
+        get_chat_model.assert_called_once_with(
+            "gpt-4o",
+            timeout=_ANALYSIS_TIMEOUT_SECONDS,
+            max_retries=_ANALYSIS_MAX_RETRIES,
+        )
         agent_model.model_copy.assert_not_called()
 
     @patch("uipath_langchain.agent.react.memory_node.get_chat_model")
@@ -586,6 +593,36 @@ class TestMemoryRecallFileAnalysis:
         assert result["inner_state"]["memory_injection"] == "INJECTION"
 
     @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_unresolvable_attachment_skips_field(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        uipath_cls: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = _file_settings()
+        resolve.return_value = []  # nothing resolvable → no file to analyze
+        search = _mock_search(uipath_cls)
+        model = _make_analysis_model("SHOULD NOT RUN")
+
+        await self._node(config, model)(self._state())
+
+        # no files means no LLM call and the field is dropped, not sent as raw ref
+        model.ainvoke.assert_not_awaited()
+        values = _field_values(search.await_args.kwargs["request"])
+        assert ("agent-input", "invoiceDocument") not in values
+        assert values[("agent-input", "vendorName")] == "Acme"
+
+    @pytest.mark.asyncio
     @patch("uipath_langchain.agent.react.memory_node.get_chat_model")
     @patch("uipath_langchain.agent.react.memory_node.UiPath")
     @patch(
@@ -622,7 +659,11 @@ class TestMemoryRecallFileAnalysis:
 
         await self._node(config, agent_model)(self._state())
 
-        get_chat_model.assert_called_once_with("gpt-4o")
+        get_chat_model.assert_called_once_with(
+            "gpt-4o",
+            timeout=_ANALYSIS_TIMEOUT_SECONDS,
+            max_retries=_ANALYSIS_MAX_RETRIES,
+        )
         pinned.ainvoke.assert_awaited_once()
         agent_model.ainvoke.assert_not_awaited()
         values = _field_values(search.await_args.kwargs["request"])
@@ -694,3 +735,80 @@ class TestMemoryRecallFileAnalysis:
 
         fetch.assert_not_awaited()
         resolve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_text_only_agent_skips_settings_fetch(
+        self,
+        fetch: AsyncMock,
+        uipath_cls: MagicMock,
+    ) -> None:
+        # An agent whose input schema declares no attachment fields must not pay
+        # the settings GET, even with a model available — recall stays
+        # byte-identical to the pre-file-analysis behavior.
+        _mock_search(uipath_cls)
+        config = MemoryConfig(memory_space_id="space-123", field_weights={"topic": 1.0})
+        node = create_memory_recall_node(
+            config, input_schema=_TopicInput, model=_make_analysis_model("x")
+        )
+
+        result = await node(_make_state(topic="python"))
+
+        fetch.assert_not_awaited()
+        assert result["inner_state"]["memory_injection"] == "INJECTION"
+
+
+class TestFetchSpaceSettings:
+    """Direct coverage of the settings GET soft-fail paths."""
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    async def test_success_returns_json(self, uipath_cls: MagicMock) -> None:
+        sdk = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"memorySpaceId": "space-123"}
+        sdk.api_client.request_async = AsyncMock(return_value=response)
+        uipath_cls.return_value = sdk
+
+        result = await _fetch_space_settings("space-123")
+
+        assert result == {"memorySpaceId": "space-123"}
+        args, kwargs = sdk.api_client.request_async.await_args
+        assert args[0] == "GET"
+        assert args[1] == "/llmopstenant_/api/Memory/space-123/settings"
+        assert kwargs["include_folder_headers"] is True
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    async def test_http_error_returns_none(self, uipath_cls: MagicMock) -> None:
+        sdk = MagicMock()
+        response = MagicMock()
+        response.raise_for_status.side_effect = RuntimeError("500 server error")
+        sdk.api_client.request_async = AsyncMock(return_value=response)
+        uipath_cls.return_value = sdk
+
+        assert await _fetch_space_settings("space-123") is None
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    async def test_malformed_json_returns_none(self, uipath_cls: MagicMock) -> None:
+        sdk = MagicMock()
+        response = MagicMock()
+        response.json.side_effect = ValueError("not json")
+        sdk.api_client.request_async = AsyncMock(return_value=response)
+        uipath_cls.return_value = sdk
+
+        assert await _fetch_space_settings("space-123") is None
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    async def test_request_exception_returns_none(self, uipath_cls: MagicMock) -> None:
+        sdk = MagicMock()
+        sdk.api_client.request_async = AsyncMock(side_effect=RuntimeError("boom"))
+        uipath_cls.return_value = sdk
+
+        assert await _fetch_space_settings("space-123") is None

--- a/tests/agent/react/test_memory_node.py
+++ b/tests/agent/react/test_memory_node.py
@@ -385,6 +385,31 @@ class TestMemoryRecallFileAnalysis:
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.react.memory_node.UiPath")
     @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_settings_fetch_skipped_when_attachment_not_in_key(
+        self,
+        fetch: AsyncMock,
+        uipath_cls: MagicMock,
+    ) -> None:
+        # The attachment field is excluded from the memory key (field_weights),
+        # so it can never be analyzed — the settings GET must not fire at all.
+        config = MemoryConfig(
+            memory_space_id="space-123",
+            field_weights={"vendorName": 1.0},
+        )
+        _mock_search(uipath_cls)
+        model = _make_analysis_model("TEXT")
+
+        await self._node(config, model)(self._state())
+
+        fetch.assert_not_awaited()
+        model.ainvoke.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
         "uipath_langchain.agent.react.memory_node.add_files_to_message",
         new_callable=AsyncMock,
     )

--- a/tests/agent/react/test_memory_node.py
+++ b/tests/agent/react/test_memory_node.py
@@ -359,6 +359,11 @@ def _field_values(request: Any) -> dict[tuple[str, ...], str]:
     return {tuple(f.key_path): f.value for f in request.fields}
 
 
+def _search_request(search: AsyncMock) -> Any:
+    assert search.await_args is not None
+    return search.await_args.kwargs["request"]
+
+
 class TestMemoryRecallFileAnalysis:
     """Query-side file-key analysis: derive ephemeral text and search on it."""
 
@@ -410,7 +415,7 @@ class TestMemoryRecallFileAnalysis:
         state = self._state()
         result = await self._node(config, model)(state)
 
-        request = search.await_args.kwargs["request"]
+        request = _search_request(search)
         values = _field_values(request)
         assert values[("agent-input", "invoiceDocument")] == "INVOICE SUMMARY"
         assert values[("agent-input", "vendorName")] == "Acme"
@@ -487,7 +492,7 @@ class TestMemoryRecallFileAnalysis:
 
         model.ainvoke.assert_not_awaited()
         resolve.assert_not_awaited()
-        values = _field_values(search.await_args.kwargs["request"])
+        values = _field_values(_search_request(search))
         # falls back to today's behavior: the raw attachment ref is searched
         assert (
             "11111111-1111-1111-1111-111111111111"
@@ -519,7 +524,7 @@ class TestMemoryRecallFileAnalysis:
 
         model.ainvoke.assert_not_awaited()
         resolve.assert_not_awaited()
-        values = _field_values(search.await_args.kwargs["request"])
+        values = _field_values(_search_request(search))
         assert (
             "11111111-1111-1111-1111-111111111111"
             in values[("agent-input", "invoiceDocument")]
@@ -557,7 +562,7 @@ class TestMemoryRecallFileAnalysis:
 
         await self._node(config, model)(self._state())
 
-        values = _field_values(search.await_args.kwargs["request"])
+        values = _field_values(_search_request(search))
         # enabled file field with no usable text is dropped, never sent as raw ref
         assert ("agent-input", "invoiceDocument") not in values
         assert values[("agent-input", "vendorName")] == "Acme"
@@ -586,7 +591,7 @@ class TestMemoryRecallFileAnalysis:
 
         result = await self._node(config, model)(self._state())
 
-        values = _field_values(search.await_args.kwargs["request"])
+        values = _field_values(_search_request(search))
         assert ("agent-input", "invoiceDocument") not in values
         assert values[("agent-input", "vendorName")] == "Acme"
         # node still returns the recall injection despite the per-field failure
@@ -618,7 +623,7 @@ class TestMemoryRecallFileAnalysis:
 
         # no files means no LLM call and the field is dropped, not sent as raw ref
         model.ainvoke.assert_not_awaited()
-        values = _field_values(search.await_args.kwargs["request"])
+        values = _field_values(_search_request(search))
         assert ("agent-input", "invoiceDocument") not in values
         assert values[("agent-input", "vendorName")] == "Acme"
 
@@ -666,7 +671,7 @@ class TestMemoryRecallFileAnalysis:
         )
         pinned.ainvoke.assert_awaited_once()
         agent_model.ainvoke.assert_not_awaited()
-        values = _field_values(search.await_args.kwargs["request"])
+        values = _field_values(_search_request(search))
         assert values[("agent-input", "invoiceDocument")] == "PINNED TEXT"
 
     @pytest.mark.asyncio
@@ -705,7 +710,7 @@ class TestMemoryRecallFileAnalysis:
         await self._node(config, agent_model)(self._state())
 
         agent_model.ainvoke.assert_awaited_once()
-        values = _field_values(search.await_args.kwargs["request"])
+        values = _field_values(_search_request(search))
         assert values[("agent-input", "invoiceDocument")] == "AGENT TEXT"
 
     @pytest.mark.asyncio

--- a/tests/agent/react/test_memory_node.py
+++ b/tests/agent/react/test_memory_node.py
@@ -1,24 +1,84 @@
 """Tests for memory recall node and memory integration in create_agent."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.runnables.graph import Edge
 from langgraph.graph import StateGraph
 from pydantic import BaseModel, Field
 
+from uipath_langchain.agent.multimodal import FileInfo
 from uipath_langchain.agent.react.agent import create_agent
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
 from uipath_langchain.agent.react.memory_node import (
+    _build_analysis_model,
     _build_search_fields,
+    _enabled_file_prompts,
+    _normalize_attachment_items,
+    _render_analysis_prompt,
+    _top_level_attachment_field,
+    _top_level_attachment_fields,
     create_memory_recall_node,
 )
 from uipath_langchain.agent.react.types import (
     AgentGraphNode,
     MemoryConfig,
 )
+
+
+def _attachment_input_model() -> type[BaseModel]:
+    """Build an input model with a top-level attachment field and a text field."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "vendorName": {"type": "string"},
+            "invoiceDocument": {"$ref": "#/$defs/job-attachment"},
+        },
+        "$defs": {
+            "job-attachment": {
+                "type": "object",
+                "x-uipath-ref-type": "job-attachment",
+                "properties": {
+                    "ID": {"type": "string"},
+                    "FullName": {"type": "string"},
+                    "MimeType": {"type": "string"},
+                },
+            }
+        },
+    }
+    return create_model(schema)
+
+
+_ATTACHMENT_DICT = {
+    "ID": "11111111-1111-1111-1111-111111111111",
+    "FullName": "invoice.pdf",
+    "MimeType": "application/pdf",
+}
+
+
+def _file_settings(
+    *,
+    enabled: bool = True,
+    analysis_prompt: str = "Summarize {FILE} for {AGENT_PROMPT}",
+    agent_prompt_reference: str | None = "You triage invoices.",
+    analysis_model: str | None = None,
+    key_field: str = "invoiceDocument",
+) -> dict[str, Any]:
+    return {
+        "memorySpaceId": "space-123",
+        "agentPromptReference": agent_prompt_reference,
+        "analysisModel": analysis_model,
+        "fileAnalysis": [
+            {
+                "keyPath": ["agent-input", key_field],
+                "enabled": enabled,
+                "analysisPrompt": analysis_prompt,
+            }
+        ],
+    }
 
 
 class _TopicInput(BaseModel):
@@ -149,3 +209,488 @@ class TestCreateAgentWithMemory:
         graph = result.compile().get_graph()
         assert AgentGraphNode.MEMORY_RECALL not in graph.nodes
         assert Edge("__start__", AgentGraphNode.INIT) in graph.edges
+
+
+class TestTopLevelAttachmentField:
+    def test_single(self) -> None:
+        assert _top_level_attachment_field("$.doc") == "doc"
+
+    def test_list(self) -> None:
+        assert _top_level_attachment_field("$.docs[*]") == "docs"
+
+    def test_nested_single_out_of_scope(self) -> None:
+        assert _top_level_attachment_field("$.a.b") is None
+
+    def test_nested_array_out_of_scope(self) -> None:
+        assert _top_level_attachment_field("$.a[*][*]") is None
+
+    def test_non_dollar_prefix(self) -> None:
+        assert _top_level_attachment_field("doc") is None
+
+    def test_fields_from_input_model(self) -> None:
+        assert _top_level_attachment_fields(_attachment_input_model()) == {
+            "invoiceDocument"
+        }
+
+
+class TestEnabledFilePrompts:
+    def test_enabled_valid(self) -> None:
+        result = _enabled_file_prompts(_file_settings(), {"invoiceDocument": 1.0})
+        assert result == {"invoiceDocument": "Summarize {FILE} for {AGENT_PROMPT}"}
+
+    def test_disabled_excluded(self) -> None:
+        assert _enabled_file_prompts(_file_settings(enabled=False), None) == {}
+
+    def test_wrong_key_path_prefix_excluded(self) -> None:
+        settings = _file_settings()
+        settings["fileAnalysis"][0]["keyPath"] = ["tool-output", "invoiceDocument"]
+        assert _enabled_file_prompts(settings, None) == {}
+
+    def test_wrong_key_path_length_excluded(self) -> None:
+        settings = _file_settings()
+        settings["fileAnalysis"][0]["keyPath"] = ["agent-input"]
+        assert _enabled_file_prompts(settings, None) == {}
+
+    def test_empty_prompt_excluded(self) -> None:
+        settings = _file_settings()
+        settings["fileAnalysis"][0]["analysisPrompt"] = ""
+        assert _enabled_file_prompts(settings, None) == {}
+
+    def test_field_not_in_weights_excluded(self) -> None:
+        assert _enabled_file_prompts(_file_settings(), {"vendorName": 1.0}) == {}
+
+    def test_no_weights_includes_all(self) -> None:
+        assert _enabled_file_prompts(_file_settings(), None) == {
+            "invoiceDocument": "Summarize {FILE} for {AGENT_PROMPT}"
+        }
+
+    def test_missing_file_analysis_key(self) -> None:
+        assert _enabled_file_prompts({"memorySpaceId": "x"}, None) == {}
+
+
+class TestNormalizeAttachmentItems:
+    def test_none(self) -> None:
+        assert _normalize_attachment_items(None) == []
+
+    def test_single_dict(self) -> None:
+        assert _normalize_attachment_items({"ID": "1"}) == [{"ID": "1"}]
+
+    def test_list_filters_falsy(self) -> None:
+        assert _normalize_attachment_items([{"ID": "1"}, None, {}]) == [{"ID": "1"}]
+
+    def test_empty_list(self) -> None:
+        assert _normalize_attachment_items([]) == []
+
+
+class TestRenderAnalysisPrompt:
+    def test_both_placeholders(self) -> None:
+        assert (
+            _render_analysis_prompt("Read {FILE} as {AGENT_PROMPT}", "an agent")
+            == "Read the attached file as an agent"
+        )
+
+    def test_agent_prompt_absent_removed(self) -> None:
+        assert (
+            _render_analysis_prompt("Read {FILE} as {AGENT_PROMPT}", None)
+            == "Read the attached file as "
+        )
+
+    def test_no_placeholders(self) -> None:
+        assert _render_analysis_prompt("Read it", "x") == "Read it"
+
+
+class TestBuildAnalysisModel:
+    def test_no_name_copies_agent_model(self) -> None:
+        agent_model = MagicMock(spec=BaseChatModel)
+        agent_model.model_copy = Mock(return_value="copied")
+        assert _build_analysis_model(agent_model, None) == "copied"
+        agent_model.model_copy.assert_called_once_with(
+            update={"disable_streaming": True}
+        )
+
+    @patch("uipath_langchain.agent.react.memory_node.get_chat_model")
+    def test_name_builds_pinned_model(self, get_chat_model: MagicMock) -> None:
+        fresh = MagicMock(spec=BaseChatModel)
+        fresh.model_copy = Mock(return_value="pinned")
+        get_chat_model.return_value = fresh
+        agent_model = MagicMock(spec=BaseChatModel)
+
+        assert _build_analysis_model(agent_model, "gpt-4o") == "pinned"
+        get_chat_model.assert_called_once_with("gpt-4o")
+        agent_model.model_copy.assert_not_called()
+
+    @patch("uipath_langchain.agent.react.memory_node.get_chat_model")
+    def test_name_build_failure_falls_back(self, get_chat_model: MagicMock) -> None:
+        get_chat_model.side_effect = RuntimeError("no such model")
+        agent_model = MagicMock(spec=BaseChatModel)
+        agent_model.model_copy = Mock(return_value="fallback")
+
+        assert _build_analysis_model(agent_model, "bad") == "fallback"
+        agent_model.model_copy.assert_called_once_with(
+            update={"disable_streaming": True}
+        )
+
+
+def _make_analysis_model(text: str) -> MagicMock:
+    model = MagicMock(spec=BaseChatModel)
+    model.ainvoke = AsyncMock(return_value=AIMessage(content=text))
+    model.model_copy = Mock(return_value=model)
+    return model
+
+
+def _mock_search(uipath_cls: MagicMock) -> AsyncMock:
+    sdk = MagicMock()
+    response = MagicMock()
+    response.results = [MagicMock()]
+    response.system_prompt_injection = "INJECTION"
+    sdk.memory.search_async = AsyncMock(return_value=response)
+    uipath_cls.return_value = sdk
+    return sdk.memory.search_async
+
+
+def _field_values(request: Any) -> dict[tuple[str, ...], str]:
+    return {tuple(f.key_path): f.value for f in request.fields}
+
+
+class TestMemoryRecallFileAnalysis:
+    """Query-side file-key analysis: derive ephemeral text and search on it."""
+
+    @pytest.fixture
+    def config(self) -> MemoryConfig:
+        return MemoryConfig(
+            memory_space_id="space-123",
+            field_weights={"invoiceDocument": 1.0, "vendorName": 1.0},
+        )
+
+    def _node(self, config: MemoryConfig, model: MagicMock) -> Any:
+        return create_memory_recall_node(
+            config, input_schema=_attachment_input_model(), model=model
+        )
+
+    def _state(self) -> dict[str, Any]:
+        return _make_state(vendorName="Acme", invoiceDocument=dict(_ATTACHMENT_DICT))
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.add_files_to_message",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_substitutes_derived_text_into_search_field(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        add_files: AsyncMock,
+        uipath_cls: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = _file_settings()
+        resolve.return_value = [
+            FileInfo(url="u", name="invoice.pdf", mime_type="application/pdf")
+        ]
+        add_files.return_value = HumanMessage(content="<file>")
+        search = _mock_search(uipath_cls)
+        model = _make_analysis_model("INVOICE SUMMARY")
+
+        state = self._state()
+        result = await self._node(config, model)(state)
+
+        request = search.await_args.kwargs["request"]
+        values = _field_values(request)
+        assert values[("agent-input", "invoiceDocument")] == "INVOICE SUMMARY"
+        assert values[("agent-input", "vendorName")] == "Acme"
+
+        model.ainvoke.assert_awaited_once()
+        system_message = model.ainvoke.await_args[0][0][0]
+        assert isinstance(system_message, SystemMessage)
+        assert (
+            system_message.content
+            == "Summarize the attached file for You triage invoices."
+        )
+
+        # state / agent input must keep the RAW attachment ref (never mutated)
+        assert state["invoiceDocument"] == _ATTACHMENT_DICT
+        assert result["inner_state"]["memory_injection"] == "INJECTION"
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.add_files_to_message",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_agent_prompt_absent_renders_empty(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        add_files: AsyncMock,
+        uipath_cls: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = _file_settings(agent_prompt_reference=None)
+        resolve.return_value = [
+            FileInfo(url="u", name="invoice.pdf", mime_type="application/pdf")
+        ]
+        add_files.return_value = HumanMessage(content="<file>")
+        _mock_search(uipath_cls)
+        model = _make_analysis_model("TEXT")
+
+        await self._node(config, model)(self._state())
+
+        system_message = model.ainvoke.await_args[0][0][0]
+        assert system_message.content == "Summarize the attached file for "
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_settings_fetch_failure_skips_analysis(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        uipath_cls: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = None
+        search = _mock_search(uipath_cls)
+        model = _make_analysis_model("SHOULD NOT RUN")
+
+        await self._node(config, model)(self._state())
+
+        model.ainvoke.assert_not_awaited()
+        resolve.assert_not_awaited()
+        values = _field_values(search.await_args.kwargs["request"])
+        # falls back to today's behavior: the raw attachment ref is searched
+        assert (
+            "11111111-1111-1111-1111-111111111111"
+            in values[("agent-input", "invoiceDocument")]
+        )
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_disabled_field_untouched(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        uipath_cls: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = _file_settings(enabled=False)
+        search = _mock_search(uipath_cls)
+        model = _make_analysis_model("SHOULD NOT RUN")
+
+        await self._node(config, model)(self._state())
+
+        model.ainvoke.assert_not_awaited()
+        resolve.assert_not_awaited()
+        values = _field_values(search.await_args.kwargs["request"])
+        assert (
+            "11111111-1111-1111-1111-111111111111"
+            in values[("agent-input", "invoiceDocument")]
+        )
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.add_files_to_message",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_empty_output_skips_field_entirely(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        add_files: AsyncMock,
+        uipath_cls: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = _file_settings()
+        resolve.return_value = [
+            FileInfo(url="u", name="invoice.pdf", mime_type="application/pdf")
+        ]
+        add_files.return_value = HumanMessage(content="<file>")
+        search = _mock_search(uipath_cls)
+        model = _make_analysis_model("   ")  # whitespace only
+
+        await self._node(config, model)(self._state())
+
+        values = _field_values(search.await_args.kwargs["request"])
+        # enabled file field with no usable text is dropped, never sent as raw ref
+        assert ("agent-input", "invoiceDocument") not in values
+        assert values[("agent-input", "vendorName")] == "Acme"
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_analysis_exception_skips_field(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        uipath_cls: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = _file_settings()
+        resolve.side_effect = RuntimeError("resolve boom")
+        search = _mock_search(uipath_cls)
+        model = _make_analysis_model("unused")
+
+        result = await self._node(config, model)(self._state())
+
+        values = _field_values(search.await_args.kwargs["request"])
+        assert ("agent-input", "invoiceDocument") not in values
+        assert values[("agent-input", "vendorName")] == "Acme"
+        # node still returns the recall injection despite the per-field failure
+        assert result["inner_state"]["memory_injection"] == "INJECTION"
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.get_chat_model")
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.add_files_to_message",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_analysis_model_pinned_from_settings(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        add_files: AsyncMock,
+        uipath_cls: MagicMock,
+        get_chat_model: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = _file_settings(analysis_model="gpt-4o")
+        resolve.return_value = [
+            FileInfo(url="u", name="invoice.pdf", mime_type="application/pdf")
+        ]
+        add_files.return_value = HumanMessage(content="<file>")
+        search = _mock_search(uipath_cls)
+
+        pinned = _make_analysis_model("PINNED TEXT")
+        get_chat_model.return_value = pinned
+        agent_model = _make_analysis_model("AGENT TEXT")
+
+        await self._node(config, agent_model)(self._state())
+
+        get_chat_model.assert_called_once_with("gpt-4o")
+        pinned.ainvoke.assert_awaited_once()
+        agent_model.ainvoke.assert_not_awaited()
+        values = _field_values(search.await_args.kwargs["request"])
+        assert values[("agent-input", "invoiceDocument")] == "PINNED TEXT"
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.get_chat_model")
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.add_files_to_message",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_analysis_model_falls_back_to_agent_model(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        add_files: AsyncMock,
+        uipath_cls: MagicMock,
+        get_chat_model: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        fetch.return_value = _file_settings(analysis_model="unavailable")
+        resolve.return_value = [
+            FileInfo(url="u", name="invoice.pdf", mime_type="application/pdf")
+        ]
+        add_files.return_value = HumanMessage(content="<file>")
+        search = _mock_search(uipath_cls)
+        get_chat_model.side_effect = RuntimeError("model not found")
+        agent_model = _make_analysis_model("AGENT TEXT")
+
+        await self._node(config, agent_model)(self._state())
+
+        agent_model.ainvoke.assert_awaited_once()
+        values = _field_values(search.await_args.kwargs["request"])
+        assert values[("agent-input", "invoiceDocument")] == "AGENT TEXT"
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.react.memory_node.UiPath")
+    @patch(
+        "uipath_langchain.agent.react.memory_node.resolve_attachments_to_file_infos",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "uipath_langchain.agent.react.memory_node._fetch_space_settings",
+        new_callable=AsyncMock,
+    )
+    async def test_no_model_skips_analysis(
+        self,
+        fetch: AsyncMock,
+        resolve: AsyncMock,
+        uipath_cls: MagicMock,
+        config: MemoryConfig,
+    ) -> None:
+        # model=None → file analysis pre-step is skipped, settings never fetched
+        _mock_search(uipath_cls)
+        node = create_memory_recall_node(
+            config, input_schema=_attachment_input_model(), model=None
+        )
+
+        await node(self._state())
+
+        fetch.assert_not_awaited()
+        resolve.assert_not_awaited()

--- a/tests/agent/tools/internal_tools/test_analyze_files_tool.py
+++ b/tests/agent/tools/internal_tools/test_analyze_files_tool.py
@@ -30,6 +30,7 @@ from uipath_langchain.agent.tools.internal_tools.analyze_files_tool import (
     _is_pii_scope_for_files,
     _resolve_job_attachment_arguments,
     create_analyze_file_tool,
+    resolve_attachments_to_file_infos,
 )
 
 
@@ -628,6 +629,40 @@ class TestResolveJobAttachmentArguments:
         assert exc_info.value.error_info.category == UiPathErrorCategory.DEPLOYMENT
         assert "permissions" in exc_info.value.error_info.detail
         assert "document.pdf" in exc_info.value.error_info.detail
+
+    async def test_resolve_accepts_dict_shaped_attachments(self, mock_uipath_client):
+        """The memory file-key path passes plain dicts (model_dump output)."""
+        attachment_id = uuid.uuid4()
+        attachment = {
+            "ID": str(attachment_id),
+            "FullName": "invoice.pdf",
+            "MimeType": "application/pdf",
+        }
+        mock_uipath_client.attachments.get_blob_file_access_uri_async = AsyncMock(
+            return_value=MockBlobInfo(
+                uri="https://blob.storage.com/files/invoice.pdf", name="invoice.pdf"
+            )
+        )
+
+        result = await resolve_attachments_to_file_infos([attachment])
+
+        assert len(result) == 1
+        assert result[0].url == "https://blob.storage.com/files/invoice.pdf"
+        assert result[0].mime_type == "application/pdf"
+        mock_uipath_client.attachments.get_blob_file_access_uri_async.assert_called_once_with(
+            key=attachment_id
+        )
+
+    async def test_resolve_dict_without_id_skips(self, mock_uipath_client):
+        """A dict attachment missing the ID key is skipped, not errored."""
+        mock_uipath_client.attachments.get_blob_file_access_uri_async = AsyncMock()
+
+        result = await resolve_attachments_to_file_infos(
+            [{"FullName": "x.pdf", "MimeType": "application/pdf"}]
+        )
+
+        assert result == []
+        mock_uipath_client.attachments.get_blob_file_access_uri_async.assert_not_called()
 
     async def test_resolve_attachments_mixed_valid_and_invalid(
         self, mock_uipath_client


### PR DESCRIPTION
## Summary

**Why:** file/attachment inputs are useless as episodic-memory search keys today — `_build_search_fields` sends `str(attachment_dict)`, so file-centric agents get no semantic recall. This PR is the query half of the memory file-key POC: at MEMORY_RECALL, each key-enabled attachment field is analyzed with a space-configured multimodal prompt, and the derived text is used as the SearchField value (ephemerally — never persisted, and the raw attachment keeps flowing to the agent loop and tools unchanged).

Backend half (settings schema + ingest-time analysis, must merge/deploy first): UiPath/llm-observability#2748

## Behavior

- Only runs when the agent declares top-level attachment input fields (text-only agents are byte-identical to before — zero extra HTTP)
- Fetches space settings live (`GET /llmopstenant_/api/Memory/{id}/settings` via `UiPath().api_client` — no SDK release needed): per-field `{FILE}` analysis prompts, `{AGENT_PROMPT}` reference, pinned `analysisModel`
- One bounded multimodal call per enabled field (120s timeout, 2 retries); reuses the analyze-files internals (`resolve_attachments_to_file_infos` refactored public, dict + object shapes)
- Every failure path soft-fails per field (settings error, unresolvable attachment, LLM error, empty output → field skipped) — recall never breaks the run
- Child OTel span "Analyze file for memory key" (`uipath.custom_instrumentation`); no fileText on any span attribute

## Testing

`uv run pytest tests/agent` → 1448 passed; ruff + mypy clean on changed files; `memory_node.py` coverage 95%. State-mutation test asserts the raw attachment survives in graph state.

## Known POC gaps (in-code TODOs)

- PII masking before the LLM call skipped (mirror of the llmops-side TODO — must mask identically on both sides before GA)
- Derived query text is visible in the existing few-shot search `request` span attribute (same posture as raw text fields today) — pre-GA redaction decision needed
- Fallback path (unset/unbuildable `analysisModel`) inherits the agent model's own timeout — bound before GA

🤖 Generated with [Claude Code](https://claude.com/claude-code)