### PR TITLE
fix: handle invalid integration tool inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.15"
+version = "0.14.16"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/integration_tool.py
+++ b/src/uipath_langchain/agent/tools/integration_tool.py
@@ -42,6 +42,10 @@ _INTEGRATION_ERRORS: dict[tuple[int, str | None], tuple[str, UiPathErrorCategory
         "Integration service returned an error for tool '{tool}': {message}",
         UiPathErrorCategory.USER,
     ),
+    (422, "INVALID_DATA"): (
+        "Integration service returned an error for tool '{tool}': {message}",
+        UiPathErrorCategory.USER,
+    ),
 }
 
 

--- a/src/uipath_langchain/agent/tools/integration_tool.py
+++ b/src/uipath_langchain/agent/tools/integration_tool.py
@@ -299,7 +299,7 @@ def create_integration_tool(
             title="Invalid integration tool path",
             detail=(
                 f"Generated Integration tool '{resource.name}' has an empty "
-                "'toolPath'. Try to remove and add the tool again. If the issue persists contact you Administrator."
+                "'toolPath'. Try to remove and add the tool again. If the issue persists contact your Administrator."
             ),
             category=UiPathErrorCategory.SYSTEM,
         )

--- a/src/uipath_langchain/agent/tools/integration_tool.py
+++ b/src/uipath_langchain/agent/tools/integration_tool.py
@@ -293,6 +293,17 @@ def create_integration_tool(
     resource: AgentIntegrationToolResourceConfig,
 ) -> StructuredTool:
     """Creates a StructuredTool for invoking an Integration Service connector activity."""
+    if not resource.properties.tool_path.strip():
+        raise AgentStartupError(
+            code=AgentStartupErrorCode.INVALID_TOOL_CONFIG,
+            title="Invalid integration tool path",
+            detail=(
+                f"Generated Integration tool '{resource.name}' has an empty "
+                "'toolPath'. Try to remove and add the tool again. If the issue persists contact you Administrator."
+            ),
+            category=UiPathErrorCategory.SYSTEM,
+        )
+
     tool_name: str = sanitize_tool_name(resource.name)
     if resource.properties.connection.id is None:
         raise AgentStartupError(

--- a/tests/agent/tools/test_integration_tool.py
+++ b/tests/agent/tools/test_integration_tool.py
@@ -21,6 +21,7 @@ from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
     AgentRuntimeErrorCode,
     AgentStartupError,
+    AgentStartupErrorCode,
 )
 from uipath_langchain.agent.tools.integration_tool import (
     _is_param_name_to_jsonpath,
@@ -888,6 +889,32 @@ class TestCreateIntegrationToolWithArgumentProperties:
 
         assert isinstance(tool, StructuredToolWithArgumentProperties)
         assert tool.argument_properties == {}
+
+    @patch("uipath_langchain.agent.tools.integration_tool.UiPath")
+    @pytest.mark.parametrize("tool_path", ["", " \t\n"])
+    def test_empty_tool_path_fails_before_sdk_construction(
+        self, mock_uipath_cls, resource_factory, tool_path
+    ):
+        resource = resource_factory(tool_path=tool_path)
+
+        with pytest.raises(AgentStartupError) as exc_info:
+            create_integration_tool(resource)
+
+        assert exc_info.value.error_info.code == AgentStartupError.full_code(
+            AgentStartupErrorCode.INVALID_TOOL_CONFIG
+        )
+        assert resource.name in exc_info.value.error_info.detail
+        assert "toolPath" in exc_info.value.error_info.detail
+        mock_uipath_cls.assert_not_called()
+
+    @patch("uipath_langchain.agent.tools.integration_tool.UiPath")
+    def test_non_empty_tool_path_is_accepted(self, mock_uipath_cls, resource_factory):
+        resource = resource_factory(tool_path="/api/test")
+
+        tool = create_integration_tool(resource)
+
+        assert isinstance(tool, StructuredToolWithArgumentProperties)
+        mock_uipath_cls.assert_called_once_with()
 
 
 class TestParseIsParamName:

--- a/tests/agent/tools/test_integration_tool.py
+++ b/tests/agent/tools/test_integration_tool.py
@@ -1,5 +1,6 @@
 """Tests for integration_tool.py module."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -1014,7 +1015,43 @@ class TestIntegrationToolErrorHandling:
 
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.tools.integration_tool.UiPath")
-    async def test_non_400_enriched_exception_propagates(
+    async def test_422_raises_agent_runtime_error_with_user_category_and_detail(
+        self, mock_uipath_cls, resource, make_enriched_exception
+    ):
+        provider_message = (
+            "errorCode - INVALID_DATA, message - The data is invalid due to "
+            "validation restrictions, errors - [{fieldName=/contactId, "
+            "errorType=invalid, errorMessage=}]"
+        )
+        mock_sdk = MagicMock()
+        mock_sdk.connections.invoke_activity_async = AsyncMock(
+            side_effect=make_enriched_exception(
+                422,
+                json.dumps(
+                    {
+                        "providerErrorCode": "INVALID_DATA",
+                        "providerMessage": provider_message,
+                    }
+                ),
+                "https://cloud.uipath.com/test/elements_/v3/element/instances/1/create_ticket",
+            )
+        )
+        mock_uipath_cls.return_value = mock_sdk
+
+        tool = create_integration_tool(resource)
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            await tool.ainvoke({"query": "test"})
+        assert exc_info.value.error_info.code == AgentRuntimeError.full_code(
+            AgentRuntimeErrorCode.HTTP_ERROR
+        )
+        assert exc_info.value.error_info.status == 422
+        assert provider_message in exc_info.value.error_info.detail
+        assert "/contactId" in exc_info.value.error_info.detail
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.tools.integration_tool.UiPath")
+    async def test_500_enriched_exception_propagates(
         self, mock_uipath_cls, resource, make_enriched_exception
     ):
         original = make_enriched_exception(500, "Internal Server Error")
@@ -1024,8 +1061,34 @@ class TestIntegrationToolErrorHandling:
 
         tool = create_integration_tool(resource)
 
-        with pytest.raises(EnrichedException):
+        with pytest.raises(EnrichedException) as exc_info:
             await tool.ainvoke({"query": "test"})
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio
+    @patch("uipath_langchain.agent.tools.integration_tool.UiPath")
+    async def test_non_validation_422_enriched_exception_propagates(
+        self, mock_uipath_cls, resource, make_enriched_exception
+    ):
+        original = make_enriched_exception(
+            422,
+            json.dumps(
+                {
+                    "providerErrorCode": "CONNECTOR_ERROR",
+                    "providerMessage": "The connector could not process the request.",
+                }
+            ),
+            "https://cloud.uipath.com/test/elements_/v3/element/instances/1/action",
+        )
+        mock_sdk = MagicMock()
+        mock_sdk.connections.invoke_activity_async = AsyncMock(side_effect=original)
+        mock_uipath_cls.return_value = mock_sdk
+
+        tool = create_integration_tool(resource)
+
+        with pytest.raises(EnrichedException) as exc_info:
+            await tool.ainvoke({"query": "test"})
+        assert exc_info.value is original
 
     @pytest.mark.asyncio
     @patch("uipath_langchain.agent.tools.integration_tool.UiPath")

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.15"
+version = "0.14.16"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- categorize Integration Service 422 INVALID_DATA responses as User errors while preserving provider details
- reject generated integration tools with empty toolPath values before SDK construction
- bump uipath-langchain from 0.14.15 to 0.14.16

## Why

Two production failures were falling through as Unknown errors. Connector field validation was not mapped by its semantic error code, and generated tools with an empty activity path reached the Integration Service base endpoint and failed with HTTP 405.

The 422 mapping is intentionally limited to INVALID_DATA; unrelated 422 responses continue to propagate unchanged.