### PR TITLE
Resolve A2A and MCP bindings by name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.20"
+version = "0.15.0"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
     "uipath>=2.13.16, <2.14.0",
     "uipath-core>=0.5.29, <0.6.0",
-    "uipath-platform>=0.2.14, <0.3.0",
+    "uipath-platform>=0.2.15, <0.3.0",
     "uipath-runtime>=0.12.5, <0.13.0",
     "uipath-llm-client>=1.17.1, <1.18.0",
     "langgraph>=1.1.8, <2.0.0",

--- a/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
+++ b/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
@@ -78,9 +78,9 @@ class A2aClient:
     pool when done.
     """
 
-    def __init__(self, agent_card: AgentCard, slug: str) -> None:
+    def __init__(self, agent_card: AgentCard, resource_name: str) -> None:
         self._agent_card = agent_card
-        self._slug = slug
+        self._resource_name = resource_name
         self._lock = asyncio.Lock()
         self._client: Client | None = None
         self._http_client: httpx.AsyncClient | None = None
@@ -96,11 +96,12 @@ class A2aClient:
                     sdk = UiPath()
                     folder_path = get_execution_folder_path()
                     agent = await sdk.remote_a2a.retrieve_async(
-                        slug=self._slug, folder_path=folder_path
+                        name=self._resource_name,
+                        folder_path=folder_path,
                     )
                     if not agent.a2a_url:
                         raise ValueError(
-                            f"Remote A2A agent '{self._slug}' has no a2a_url configured"
+                            f"Remote A2A agent '{self._resource_name}' has no a2a_url configured"
                         )
                     self._agent_card.url = agent.a2a_url
 
@@ -404,7 +405,7 @@ def create_a2a_tools_and_clients(
                 default_output_modes=["text/plain"],
             )
 
-        a2a_client = A2aClient(agent_card, resource.slug)
+        a2a_client = A2aClient(agent_card, resource.name)
         tool = _create_a2a_tool(resource, a2a_client, agent_card)
         tools.append(tool)
         clients.append(a2a_client)

--- a/src/uipath_langchain/agent/tools/mcp/mcp_client.py
+++ b/src/uipath_langchain/agent/tools/mcp/mcp_client.py
@@ -82,10 +82,11 @@ class McpClient(UiPathDisposableProtocol):
         """Initialize the MCP tool session.
 
         The MCP server URL and authorization headers are retrieved lazily
-        from the UiPath SDK on first use, using the config's slug and folder_path.
+        from the UiPath SDK on first use, using the config's display name and
+        folder_path.
 
         Args:
-            config: The MCP resource configuration containing slug and folder_path.
+            config: The MCP resource configuration containing name and folder_path.
             timeout: Optional timeout configuration for HTTP requests.
             max_retries: Maximum number of retries on session disconnect errors.
             session_info_factory: Factory for creating SessionInfo instances.
@@ -152,7 +153,7 @@ class McpClient(UiPathDisposableProtocol):
         """
         folder_path = get_execution_folder_path()
         logger.debug(
-            f"Initializing MCP client for '{self._config.slug}' "
+            f"Initializing MCP client for '{self._config.name}' "
             f"in folder '{folder_path}'"
         )
 
@@ -162,11 +163,12 @@ class McpClient(UiPathDisposableProtocol):
         # Retrieve MCP server URL from SDK
         sdk = UiPath()
         mcp_server = await sdk.mcp.retrieve_async(
-            slug=self._config.slug, folder_path=folder_path
+            name=self._config.name,
+            folder_path=folder_path,
         )
 
         if mcp_server.mcp_url is None:
-            raise ValueError(f"MCP server '{self._config.slug}' has no URL configured")
+            raise ValueError(f"MCP server '{self._config.name}' has no URL configured")
 
         self._url = mcp_server.mcp_url
         self._headers = {"Authorization": f"Bearer {sdk._config.secret}"}

--- a/tests/agent/tools/test_a2a_tool.py
+++ b/tests/agent/tools/test_a2a_tool.py
@@ -84,8 +84,7 @@ def test_create_tools_builds_one_client_per_enabled_resource() -> None:
 
     assert len(tools) == 1
     assert len(clients) == 1
-    # The client carries the slug used to resolve the proxy URL at runtime.
-    assert clients[0]._slug == "remote-agent-slug"
+    assert clients[0]._resource_name == "remote-agent"
     # The card is built from the cached card; the URL is not yet resolved.
     assert clients[0]._agent_card.name == "Remote Agent"
 
@@ -96,7 +95,7 @@ def test_create_tools_builds_default_card_without_cached_card() -> None:
     tools, clients = create_a2a_tools_and_clients([resource])
 
     assert len(tools) == 1
-    assert clients[0]._slug == "remote-agent-slug"
+    assert clients[0]._resource_name == "remote-agent"
     assert clients[0]._agent_card.name == "remote-agent"
 
 
@@ -114,8 +113,13 @@ class _FakeRemoteA2aService:
         self._a2a_url = a2a_url
         self.calls: list[tuple[str, str | None]] = []
 
-    async def retrieve_async(self, *, slug: str, folder_path: str | None):
-        self.calls.append((slug, folder_path))
+    async def retrieve_async(
+        self,
+        *,
+        name: str,
+        folder_path: str | None,
+    ):
+        self.calls.append((name, folder_path))
         return SimpleNamespace(a2a_url=self._a2a_url)
 
 
@@ -125,7 +129,7 @@ class _FakeSdk:
         self._config = SimpleNamespace(secret="token")
 
 
-def _patch_runtime(monkeypatch: pytest.MonkeyPatch, sdk: _FakeSdk) -> dict[str, Any]:
+def _patch_runtime(monkeypatch: pytest.MonkeyPatch, sdk: Any) -> dict[str, Any]:
     """Patch the SDK, folder-path resolver, and A2A client factory."""
     import uipath.platform as uipath_platform
     from a2a.client import ClientFactory
@@ -158,14 +162,14 @@ async def test_client_resolves_proxy_url_via_retrieve(
         default_input_modes=["text/plain"],
         default_output_modes=["text/plain"],
     )
-    client = A2aClient(card, slug="remote-agent-slug")
+    client = A2aClient(card, resource_name="Remote Agent")
 
     result = await client.get()
 
     assert result is handles["connected"]
     # URL resolved from the retrieved agent's a2a_url, not the cached card URL.
     assert card.url == PROXY_URL
-    assert sdk.remote_a2a.calls == [("remote-agent-slug", "Shared")]
+    assert sdk.remote_a2a.calls == [("Remote Agent", "Shared")]
 
     await client.dispose()
 
@@ -186,7 +190,7 @@ async def test_client_raises_when_agent_has_no_proxy_url(
         default_input_modes=["text/plain"],
         default_output_modes=["text/plain"],
     )
-    client = A2aClient(card, slug="remote-agent-slug")
+    client = A2aClient(card, resource_name="Remote Agent")
 
     with pytest.raises(ValueError, match="has no a2a_url"):
         await client.get()

--- a/tests/agent/tools/test_mcp/test_mcp_client.py
+++ b/tests/agent/tools/test_mcp/test_mcp_client.py
@@ -849,10 +849,10 @@ class TestMcpClient:
     @pytest.mark.asyncio
     @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Shared/TestFolder"})
     @patch("httpx.AsyncClient")
-    async def test_retrieve_async_uses_execution_folder_path(
+    async def test_retrieve_async_uses_name_and_execution_folder_path(
         self, mock_async_client_class, mcp_resource_config
     ):
-        """Test that retrieve_async is called with folder_path from the execution environment."""
+        """Test that name resolution receives both identities and the execution folder."""
         mock_sdk = MagicMock()
         mock_server = MagicMock()
         mock_server.mcp_url = "https://test.uipath.com/mcp"
@@ -876,7 +876,8 @@ class TestMcpClient:
             await session.call_tool("test_tool", {"query": "test"})
 
         mock_sdk.mcp.retrieve_async.assert_called_once_with(
-            slug="test-server", folder_path="/Shared/TestFolder"
+            name="test_server",
+            folder_path="/Shared/TestFolder",
         )
 
         await session.dispose()

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.20"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4588,7 +4588,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-llm-client", specifier = ">=1.17.1,<1.18.0" },
-    { name = "uipath-platform", specifier = ">=0.2.14,<0.3.0" },
+    { name = "uipath-platform", specifier = ">=0.2.15,<0.3.0" },
     { name = "uipath-runtime", specifier = ">=0.12.5,<0.13.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
@@ -4672,7 +4672,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.14"
+version = "0.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4683,9 +4683,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/9e/3ce60d85bdc41f1b92da67587c9c15cea87a35cfbf83b9925b3a8235f819/uipath_platform-0.2.14.tar.gz", hash = "sha256:5a0b69308000e9f38068555cda370641b06a066e6461365d3e67fe13bc965195", size = 430287, upload-time = "2026-07-30T07:20:45.469Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/06/8097ed899d07c4ca420666d06380f86e4d6e2478bf6b190f406bd7cfcaca/uipath_platform-0.2.15.tar.gz", hash = "sha256:8552acf2fa754e189c67decab4a8fd1c572c96c13d8222606534b1a94fefdce1", size = 434549, upload-time = "2026-07-31T11:11:00.768Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/08/4f83d0668f08bafce29a0aa9418c924eea8c6490e76e6860431515c122fe/uipath_platform-0.2.14-py3-none-any.whl", hash = "sha256:77a042ca36a4dcfe44ddd0d98627878e8d6e83dd1dd3e33fd418ef491fd0c9bc", size = 283175, upload-time = "2026-07-30T07:20:43.793Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7239f40748ad5c799f1ae6e85fe8b95749a3773ad253855f066d9fede8ad/uipath_platform-0.2.15-py3-none-any.whl", hash = "sha256:6c043471e4688f8ce5a5c29e5176f2e2ea041a316c07b32de3db616b9e83a4ae", size = 285580, upload-time = "2026-07-31T11:10:59.04Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Resolve Unified Runtime MCP and remote A2A resources by display name through the SDK `name=` lookup.
- Preserve execution-folder routing and lazy URL resolution while switching resource identifiers to display names.
- Require the released `uipath-platform>=0.2.15,<0.3.0`, bump `uipath-langchain` to `0.15.0`, and refresh the lockfile.
- Update focused MCP and A2A tool coverage.