### PR TITLE
Bump version to 0.14.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.14"
+version = "0.14.15"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-20T22:41:41.618612Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.14"
+version = "0.14.15"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
Version bump only. `0.14.14` was published by #962 **before** #1001 merged, so the memory-recall file-input search-key derivation (#1001) is currently unreleased on main. Merging this publishes it as `0.14.15` via CD.

Follow-up: bump the exact `uipath-langchain==` pin in uipath-agents-python once `0.14.15` is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)