### PR TITLE
docs(samples): list joke-agent samples in samples README

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -15,6 +15,12 @@ This sample shows how to automate Outlook inbox organization with AI-powered rul
 ## [HITL inbox server](hitl-inbox-server)
 This sample demonstrates a FastAPI server for managing human-in-the-loop workflows with job submissions and inbox message approvals.
 
+## [Joke agent](joke-agent)
+This sample demonstrates a LangGraph agent that generates family-friendly jokes on a given topic, showcasing a middleware-based guardrails stack for PII detection, prompt injection prevention, and content validation, with human-in-the-loop escalation when PII is detected in the input.
+
+## [Joke agent (decorator-based guardrails)](joke-agent-decorator)
+This sample shows how to use the unified `@guardrail` decorator to apply guardrails to LLM factories, tools, agent factories, graph nodes, and plain Python functions — without a middleware stack.
+
 ## [Multi agent supervisor, researcher, coder](multi-agent-supervisor-researcher-coder)
 This sample showcases a multi-agent system, involving a supervisor, a researcher, and a coder working in coordination to tackle complex tasks.
 


### PR DESCRIPTION
## What changed?

The `joke-agent` and `joke-agent-decorator` sample directories already exist under `samples/`, but they were not listed in the `samples/README.md` index. This PR adds index entries for both so they are discoverable from the samples overview:

- **Joke agent** — LangGraph agent generating family-friendly jokes, with a middleware-based guardrails stack (PII detection, prompt injection prevention, content validation) and HITL escalation on PII in the input.
- **Joke agent (decorator-based guardrails)** — same use case demonstrating the unified `@guardrail` decorator applied without a middleware stack.

Docs-only change; no code was modified.

## How has this been tested?

Verified the two directories exist on `main` and that the README links resolve to them. Markdown-only change, no automated tests apply.

## Are there any breaking changes?

- [x] None
