### PR TITLE
feat(chat): forgiving string coercion for vendor_type/api_flavor in get_chat_model

### DIFF
--- a/src/uipath_langchain/chat/chat_model_factory.py
+++ b/src/uipath_langchain/chat/chat_model_factory.py
@@ -10,7 +10,8 @@ passed through as the ``use_new_llm_clients`` argument of :func:`get_chat_model`
   before the ``uipath_langchain_client`` migration.
 """
 
-from typing import Any, Final
+from enum import Enum
+from typing import Any, Final, TypeVar
 
 from langchain_core.callbacks import BaseCallbackHandler, Callbacks
 from langchain_core.language_models import BaseChatModel
@@ -96,9 +97,16 @@ def get_chat_model(
         byo_connection_id: Optional Integration Service connection ID.
         client_settings: Overrides the default ``uipath_langchain_client`` settings.
         routing_mode: ``PASSTHROUGH`` (vendor-specific) or ``NORMALIZED``.
+            Strings are accepted and matched forgivingly (case-insensitive,
+            ``-``/``_`` interchangeable).
         vendor_type: Filter models by vendor; auto-detected when omitted.
+            Strings are accepted and matched forgivingly against member names
+            and values (e.g. ``"awsbedrock"``, ``"AWSBedrock"``,
+            ``"aws_bedrock"``).
         api_flavor: Vendor-specific API flavor (e.g. OpenAI Responses, Bedrock
-            Converse). Auto-detected when omitted.
+            Converse). Auto-detected when omitted. Strings are accepted and
+            matched forgivingly (e.g. ``"anthropic_messages"``,
+            ``"AnthropicMessages"``, ``"chat-completions"``).
         custom_class: Custom ``UiPathBaseChatModel`` subclass to instantiate
             instead of the auto-detected one.
         temperature: Sampling temperature. Defaults to 0.0. Pass ``None`` to
@@ -125,7 +133,15 @@ def get_chat_model(
 
     Returns:
         A configured ``BaseChatModel`` instance.
+
+    Raises:
+        ValueError: If ``routing_mode``, ``vendor_type``, or ``api_flavor`` is
+            a string that matches no enum member.
     """
+    routing_mode = _coerce_enum(routing_mode, RoutingMode)
+    vendor_type = _coerce_enum(vendor_type, VendorType)
+    api_flavor = _coerce_enum(api_flavor, ApiFlavor)
+
     # Always inject trace context headers per-request via a dynamic-headers
     # callback.  For the new path the UiPathHttpxClient reads the ContextVar
     # set by the callback; for the legacy path the callback is a no-op but
@@ -186,6 +202,43 @@ def get_chat_model(
             detail=detail,
             category=UiPathErrorCategory.DEPLOYMENT,
         ) from e
+
+
+_E = TypeVar("_E", bound=Enum)
+
+
+def _coerce_enum(value: "_E | str | None", enum_cls: type[_E]) -> "_E | None":
+    """Coerce a string to an ``enum_cls`` member, forgiving spelling variants.
+
+    Matching is case-insensitive against both member names and values, with
+    hyphens and underscores treated as interchangeable — so ``"AWSBedrock"``,
+    ``"aws_bedrock"``, and ``"awsbedrock"`` all resolve to
+    ``VendorType.AWSBEDROCK``, and ``"anthropic_messages"`` resolves to
+    ``ApiFlavor.ANTHROPIC_MESSAGES`` (value ``"AnthropicMessages"``).
+
+    Args:
+        value: An enum member (returned as-is), a string naming one, or None
+            (returned as-is).
+        enum_cls: The target enum class.
+
+    Returns:
+        The resolved enum member, or ``None`` when ``value`` is ``None``.
+
+    Raises:
+        ValueError: If ``value`` is a string that matches no member.
+    """
+    if value is None or isinstance(value, enum_cls):
+        return value
+    key = str(value).strip().lower().replace("-", "").replace("_", "")
+    for member in enum_cls:
+        candidates = {
+            member.name.lower().replace("_", ""),
+            str(member.value).lower().replace("-", "").replace("_", ""),
+        }
+        if key in candidates:
+            return member
+    valid = [str(m.value) for m in enum_cls]
+    raise ValueError(f"Unknown {enum_cls.__name__} {value!r}. Valid values: {valid}")
 
 
 def _ensure_trace_context_callback(callbacks: Callbacks) -> list[BaseCallbackHandler]:

--- a/tests/chat/test_chat_model_factory_coercion.py
+++ b/tests/chat/test_chat_model_factory_coercion.py
@@ -1,0 +1,107 @@
+"""Tests for forgiving enum coercion in chat/chat_model_factory.get_chat_model."""
+
+from unittest.mock import patch
+
+import pytest
+from uipath_langchain_client.settings import ApiFlavor, RoutingMode, VendorType
+
+from uipath_langchain.chat.chat_model_factory import _coerce_enum, get_chat_model
+
+
+class TestCoerceEnum:
+    """Test cases for the _coerce_enum helper."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["awsbedrock", "AWSBedrock", "AWS_BEDROCK", "aws-bedrock", " awsbedrock "],
+    )
+    def test_vendor_spelling_variants(self, raw):
+        assert _coerce_enum(raw, VendorType) is VendorType.AWSBEDROCK
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "AnthropicMessages",
+            "anthropic_messages",
+            "ANTHROPIC-MESSAGES",
+            "anthropicmessages",
+        ],
+    )
+    def test_flavor_spelling_variants(self, raw):
+        assert _coerce_enum(raw, ApiFlavor) is ApiFlavor.ANTHROPIC_MESSAGES
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("chat_completions", ApiFlavor.CHAT_COMPLETIONS),
+            ("chat-completions", ApiFlavor.CHAT_COMPLETIONS),
+            ("CONVERSE", ApiFlavor.CONVERSE),
+            ("generate_content", ApiFlavor.GENERATE_CONTENT),
+            ("responses", ApiFlavor.RESPONSES),
+            ("invoke", ApiFlavor.INVOKE),
+        ],
+    )
+    def test_flavor_values(self, raw, expected):
+        assert _coerce_enum(raw, ApiFlavor) is expected
+
+    def test_enum_member_passes_through(self):
+        assert _coerce_enum(VendorType.OPENAI, VendorType) is VendorType.OPENAI
+
+    def test_none_passes_through(self):
+        assert _coerce_enum(None, ApiFlavor) is None
+
+    def test_unknown_string_raises_with_valid_values(self):
+        with pytest.raises(ValueError) as exc_info:
+            _coerce_enum("nonsense", ApiFlavor)
+        message = str(exc_info.value)
+        assert "nonsense" in message
+        assert "converse" in message  # lists valid values
+
+
+class TestGetChatModelCoercion:
+    """get_chat_model forwards coerced enum members to the client factory."""
+
+    def _capture(self, **call_kwargs):
+        captured = {}
+
+        def fake_factory(model, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+        with patch(
+            "uipath_langchain.chat.chat_model_factory.get_chat_model_factory",
+            side_effect=fake_factory,
+        ):
+            get_chat_model("some-model", **call_kwargs)
+        return captured
+
+    def test_string_vendor_and_flavor_are_coerced(self):
+        captured = self._capture(
+            vendor_type="AWSBedrock", api_flavor="anthropic_messages"
+        )
+        assert captured["vendor_type"] is VendorType.AWSBEDROCK
+        assert captured["api_flavor"] is ApiFlavor.ANTHROPIC_MESSAGES
+
+    def test_string_routing_mode_is_coerced(self):
+        captured = self._capture(routing_mode="NORMALIZED")
+        assert captured["routing_mode"] is RoutingMode.NORMALIZED
+
+    def test_enum_arguments_pass_through_unchanged(self):
+        captured = self._capture(
+            vendor_type=VendorType.VERTEXAI, api_flavor=ApiFlavor.GENERATE_CONTENT
+        )
+        assert captured["vendor_type"] is VendorType.VERTEXAI
+        assert captured["api_flavor"] is ApiFlavor.GENERATE_CONTENT
+
+    def test_omitted_vendor_and_flavor_stay_none(self):
+        captured = self._capture()
+        assert captured["vendor_type"] is None
+        assert captured["api_flavor"] is None
+
+    def test_invalid_flavor_raises_before_factory_call(self):
+        with patch(
+            "uipath_langchain.chat.chat_model_factory.get_chat_model_factory"
+        ) as factory:
+            with pytest.raises(ValueError, match="Unknown ApiFlavor"):
+                get_chat_model("some-model", api_flavor="not-a-flavor")
+            factory.assert_not_called()


### PR DESCRIPTION
## What

`get_chat_model` documents `vendor_type: VendorType | str | None`, `api_flavor: ApiFlavor | str | None`, and `routing_mode: RoutingMode | str` — but string handling downstream is strict exact-value enum matching:

| input | before | after |
|---|---|---|
| `"awsbedrock"` | ✅ | ✅ |
| `"AWSBedrock"` | ❌ rejected | ✅ `VendorType.AWSBEDROCK` |
| `"CONVERSE"` | ❌ rejected | ✅ `ApiFlavor.CONVERSE` |
| `"anthropic_messages"` | ❌ rejected (must spell `AnthropicMessages`) | ✅ `ApiFlavor.ANTHROPIC_MESSAGES` |
| `"not-a-flavor"` | opaque downstream failure | `ValueError` listing the valid values, raised **before** any factory call |

The wrapper now resolves string inputs case-insensitively against both member **names** and **values**, treating `-`/`_` as interchangeable. Enum members and `None` pass through unchanged — fully backward compatible (only previously-failing inputs change behavior).

## Why

Callers supplying the API flavor as a string (config files, CI workflow inputs — e.g. the model-onboarding testcase's `vendor:flavor` path syntax in #1009) shouldn't need to know that Bedrock's Anthropic flavor is spelled `AnthropicMessages` while everything else is kebab-case.

## Tests

`tests/chat/test_chat_model_factory_coercion.py` — 23 tests: spelling variants per enum, pass-through of members/None, forwarding into the client factory (patched), and the early `ValueError` with valid values listed. Ruff clean; pre-existing collection errors in `tests/chat/` (missing optional `bedrock` extras in a non-`--all-extras` venv) are unrelated and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)