### PR TITLE
fix(agent): align ixp extraction tool with the job attachment strategy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.16"
+version = "0.14.17"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/extraction_tool.py
+++ b/src/uipath_langchain/agent/tools/extraction_tool.py
@@ -1,20 +1,29 @@
 """Ixp extraction tool."""
 
-import uuid
-from typing import Any, Optional
+from typing import Any
 
 from langchain.tools import BaseTool
 from langchain_core.messages import ToolCall, ToolMessage
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command, interrupt
-from pydantic import BaseModel, Field
 from uipath.agent.models.agent import AgentIxpExtractionResourceConfig
 from uipath.eval.mocks import mockable
+from uipath.platform.attachments import Attachment
 from uipath.platform.common import DocumentExtraction
 from uipath.platform.documents import ExtractionResponseIXP
 from uipath.platform.errors import EnrichedException
+from uipath.runtime.errors import UiPathErrorCategory
 
-from uipath_langchain.agent.react.job_attachments import raise_for_job_attachment_error
+from uipath_langchain.agent.exceptions import (
+    AgentRuntimeError,
+    AgentRuntimeErrorCode,
+)
+from uipath_langchain.agent.react.job_attachments import (
+    get_job_attachment_paths,
+    get_job_attachments,
+    raise_for_job_attachment_error,
+)
+from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
 from uipath_langchain.agent.react.types import AgentGraphState
 from uipath_langchain.agent.tools.tool_node import (
     ToolWrapperMixin,
@@ -29,54 +38,66 @@ class StructuredToolWithWrapper(StructuredToolWithOutputType, ToolWrapperMixin):
     pass
 
 
-class ExtractionToolInputSchema(BaseModel):
-    """Alias-free mirror of `Attachment` used as the tool's args_schema.
+def _single_attachment_input_schema() -> dict[str, Any]:
+    """Build the one-job-attachment input schema Agent Builder writes."""
+    attachment = Attachment.model_json_schema(by_alias=True)
+    attachment["required"] = ["ID"]
+    attachment["x-uipath-resource-kind"] = "JobAttachment"
+    return {
+        "type": "object",
+        "properties": {
+            "attachment": {
+                "description": "File to extract data from.",
+                "$ref": "#/definitions/job-attachment",
+            }
+        },
+        "required": ["attachment"],
+        "definitions": {"job-attachment": attachment},
+    }
 
-    We don't use `Attachment` directly because its fields carry aliases
-    (`id` -> `ID`, `full_name` -> `FullName`, ...) and LangChain mishandles
-    aliased fields in two places (see PR #796):
 
-    1. `BaseTool._parse_input()` extracts each field with `getattr(model, key)`,
-       where `key` is the alias. For aliases that collide with built-in model
-       attributes (e.g. `schema`), this returns the built-in instead of the
-       field value, so downstream `kwargs.get("id") / kwargs.get("full_name")`
-       came back as `None`.
-    2. `tool_call_schema` rebuilds a subset of the model by copying each field
-       but drops alias and serialization options, so the rebuilt schema no
-       longer matches what the LLM emits.
-
-    Until LangChain fixes both, exposing an alias-free schema with field
-    names matching `Attachment`'s python names sidesteps the issue. Keep the
-    fields here in sync with `Attachment` — the test
-    `test_extraction_tool_has_attachment_input_schema` enforces this.
-    """
-
-    id: uuid.UUID
-    full_name: str
-    mime_type: str
-    metadata: Optional[dict[str, Any]] = Field(None)
+def _create_input_model(input_schema: dict[str, Any]) -> Any:
+    model = create_model(input_schema)
+    if get_job_attachment_paths(model):
+        return model
+    return create_model(_single_attachment_input_schema())
 
 
 def create_ixp_extraction_tool(
     resource: AgentIxpExtractionResourceConfig,
 ) -> StructuredTool:
     """Uses interrupt() to suspend graph execution until data is extracted (handled by runtime)."""
+    from uipath_langchain.agent.wrappers import resolve_job_attachment_args
+
     tool_name: str = sanitize_tool_name(resource.name)
     resource_name = resource.name
     project_name = resource.properties.project_name
     version_tag = resource.properties.version_tag
 
+    input_model: Any = _create_input_model(resource.input_schema)
+
     @mockable(
         name=resource.name,
         description=resource.description,
-        input_schema=ExtractionToolInputSchema.model_json_schema(),
+        input_schema=input_model.model_json_schema(),
         output_schema=ExtractionResponseIXP.model_json_schema(),
         example_calls=resource.properties.example_calls,
     )
-    async def extraction_tool_fn(**kwargs: Any) -> ExtractionResponseIXP:
+    async def extraction_tool_fn(**kwargs: Any) -> dict[str, Any]:
         from uipath.platform import UiPath
 
-        attachment = ExtractionToolInputSchema.model_validate(kwargs)
+        attachments = get_job_attachments(input_model, kwargs)
+        if not attachments:
+            raise AgentRuntimeError(
+                code=AgentRuntimeErrorCode.INVALID_ATTACHMENT_ID,
+                title="Missing job attachment",
+                detail=(
+                    f"Tool '{resource_name}' was called without a job attachment to "
+                    f"extract data from."
+                ),
+                category=UiPathErrorCategory.USER,
+            )
+        attachment = attachments[0]
         uipath = UiPath()
 
         # TODO: current workaround. DocumentExtraction model should support attachment_id and use the
@@ -109,6 +130,10 @@ def create_ixp_extraction_tool(
         call: ToolCall,
         state: AgentGraphState,
     ) -> ToolWrapperReturnType:
+        error = resolve_job_attachment_args(tool, call, state)
+        if error is not None:
+            return error
+
         tool_result = await tool.ainvoke(call["args"])
         data_projection = tool_result["dataProjection"]
         # update the state with extraction response for later reuse in ixpVsEscalation
@@ -129,7 +154,7 @@ def create_ixp_extraction_tool(
     tool = StructuredToolWithWrapper(
         name=tool_name,
         description=resource.description,
-        args_schema=ExtractionToolInputSchema,
+        args_schema=input_model,
         coroutine=extraction_tool_fn,
         output_type=ExtractionResponseIXP,
         metadata={
@@ -137,6 +162,7 @@ def create_ixp_extraction_tool(
             "display_name": resource.name,
             "project_name": project_name,
             "version_tag": version_tag,
+            "args_schema": input_model,
         },
     )
     tool.set_tool_wrappers(awrapper=extraction_tool_wrapper)

--- a/src/uipath_langchain/agent/wrappers/__init__.py
+++ b/src/uipath_langchain/agent/wrappers/__init__.py
@@ -1,5 +1,8 @@
 """Wrappers to add behavior to tools while keeping them graph agnostic."""
 
-from .job_attachment_wrapper import get_job_attachment_wrapper
+from .job_attachment_wrapper import (
+    get_job_attachment_wrapper,
+    resolve_job_attachment_args,
+)
 
-__all__ = ["get_job_attachment_wrapper"]
+__all__ = ["get_job_attachment_wrapper", "resolve_job_attachment_args"]

--- a/src/uipath_langchain/agent/wrappers/job_attachment_wrapper.py
+++ b/src/uipath_langchain/agent/wrappers/job_attachment_wrapper.py
@@ -28,6 +28,35 @@ def _parse(content: str) -> Any:
     return content
 
 
+def resolve_job_attachment_args(
+    tool: BaseTool,
+    call: ToolCall,
+    state: AgentGraphState,
+) -> dict[str, Any] | None:
+    """Replace job attachment ids in a tool call's arguments with full attachment objects.
+
+    Mutates ``call["args"]`` in place. Returns an error dict when a referenced id
+    is not a valid UUID or is absent from state, else None.
+    """
+    input_args = call["args"]
+    modified_input_args = input_args
+
+    schema = None
+    if isinstance(tool.args_schema, type) and issubclass(tool.args_schema, BaseModel):
+        schema = tool.args_schema
+        errors: list[str] = []
+        paths = get_job_attachment_paths(schema)
+        modified_input_args = replace_job_attachment_ids(
+            paths, input_args, state.inner_state.job_attachments, errors
+        )
+
+        if errors:
+            return {"error": "\n".join(errors)}
+
+    call["args"] = coerce_json_strings(modified_input_args, schema)
+    return None
+
+
 def get_job_attachment_wrapper(
     output_type: Any | None = None,
 ) -> AsyncToolWrapperWithState:
@@ -71,24 +100,10 @@ def get_job_attachment_wrapper(
             Command object with tool result message and updated job attachments in inner_state,
             or error dict if attachment validation fails
         """
-        input_args = call["args"]
-        modified_input_args = input_args
+        error = resolve_job_attachment_args(tool, call, state)
+        if error is not None:
+            return error
 
-        schema = None
-        if isinstance(tool.args_schema, type) and issubclass(
-            tool.args_schema, BaseModel
-        ):
-            schema = tool.args_schema
-            errors: list[str] = []
-            paths = get_job_attachment_paths(schema)
-            modified_input_args = replace_job_attachment_ids(
-                paths, input_args, state.inner_state.job_attachments, errors
-            )
-
-            if errors:
-                return {"error": "\n".join(errors)}
-
-        call["args"] = coerce_json_strings(modified_input_args, schema)
         tool_result = await tool.ainvoke(call)
         job_attachments_dict = {}
         if output_type is not None:

--- a/tests/agent/tools/test_extraction_tool.py
+++ b/tests/agent/tools/test_extraction_tool.py
@@ -1,13 +1,26 @@
 """Tests for extraction_tool.py metadata and functionality."""
 
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import httpx
 import pytest
+from langchain_core.messages import ToolCall
+from langgraph.types import Command
+from pydantic import BaseModel
 from uipath.agent.models.agent import (
     AgentIxpExtractionResourceConfig,
     AgentIxpExtractionToolProperties,
+)
+from uipath.eval.mocks._mock_runtime import (
+    clear_execution_context,
+    set_execution_context,
+)
+from uipath.eval.mocks._types import (
+    LLMMockingStrategy,
+    MockingContext,
+    ToolSimulation,
 )
 from uipath.platform.attachments import Attachment
 from uipath.platform.documents import ExtractionResponseIXP
@@ -15,10 +28,87 @@ from uipath.platform.errors import EnrichedException
 from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain.agent.exceptions import AgentRuntimeError
+from uipath_langchain.agent.react.job_attachments import get_job_attachment_paths
+from uipath_langchain.agent.react.types import AgentGraphState, InnerAgentGraphState
 from uipath_langchain.agent.tools.extraction_tool import (
-    ExtractionToolInputSchema,
+    StructuredToolWithWrapper,
     create_ixp_extraction_tool,
 )
+from uipath_langchain.agent.tools.tool_node import AsyncToolWrapperWithState
+
+_ATTACHMENT_ID = "fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f"
+
+_EXTRACTION_RESPONSE: dict[str, Any] = {
+    "extractionResult": {
+        "DocumentId": "doc-1",
+        "ResultsVersion": 1,
+        "ResultsDocument": {},
+    },
+    "projectId": "proj-1",
+    "projectType": "IXP",
+    "tag": "v1.0",
+    "documentTypeId": "invoice",
+    "dataProjection": [
+        {
+            "fieldGroupName": "invoice",
+            "fieldValues": [
+                {
+                    "id": "total",
+                    "name": "Total",
+                    "value": "42.00",
+                    "unformattedValue": "42.00",
+                    "confidence": 0.99,
+                    "ocrConfidence": 0.99,
+                    "type": "Number",
+                }
+            ],
+        }
+    ],
+}
+
+_JOB_ATTACHMENT_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "attachment": {
+            "description": "File to extract data from.",
+            "$ref": "#/definitions/job-attachment",
+        }
+    },
+    "required": ["attachment"],
+    "definitions": {
+        "job-attachment": {
+            "type": "object",
+            "required": ["ID"],
+            "x-uipath-resource-kind": "JobAttachment",
+            "properties": {
+                "ID": {"type": "string", "description": "Orchestrator attachment key"},
+                "FullName": {"type": "string", "description": "File name"},
+                "MimeType": {"type": "string", "description": "The MIME type"},
+                "Metadata": {
+                    "type": "object",
+                    "description": "Dictionary<string, string> of metadata",
+                    "additionalProperties": {"type": "string"},
+                },
+            },
+        }
+    },
+}
+
+
+def _attachment_args(
+    *,
+    attachment_id: str,
+    full_name: str,
+    mime_type: str = "application/pdf",
+) -> dict[str, Any]:
+    """Tool arguments in the shape the job-attachment schema produces."""
+    return {
+        "attachment": {
+            "ID": attachment_id,
+            "FullName": full_name,
+            "MimeType": mime_type,
+        }
+    }
 
 
 def _make_attachment_error(status_code: int, content: bytes) -> EnrichedException:
@@ -46,39 +136,7 @@ class TestExtractionToolMetadata:
         return AgentIxpExtractionResourceConfig(
             name="test_extraction",
             description="Extract data from files",
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "attachment": {
-                        "description": "the file uploaded as attachement",
-                        "$ref": "#/definitions/job-attachment",
-                    }
-                },
-                "required": ["attachment"],
-                "definitions": {
-                    "job-attachment": {
-                        "type": "object",
-                        "required": ["ID"],
-                        "x-uipath-resource-kind": "JobAttachment",
-                        "properties": {
-                            "ID": {
-                                "type": "string",
-                                "description": "Orchestrator attachment key",
-                            },
-                            "FullName": {"type": "string", "description": "File name"},
-                            "MimeType": {
-                                "type": "string",
-                                "description": 'The MIME type of the content, such as "application/json" or "image/png"',
-                            },
-                            "Metadata": {
-                                "type": "object",
-                                "description": "Dictionary<string, string> of metadata",
-                                "additionalProperties": {"type": "string"},
-                            },
-                        },
-                    }
-                },
-            },
+            input_schema=_JOB_ATTACHMENT_INPUT_SCHEMA,
             output_schema={"type": "object", "properties": {}},
             properties=AgentIxpExtractionToolProperties(
                 project_name="TestProject",
@@ -98,17 +156,59 @@ class TestExtractionToolMetadata:
 
         assert tool.description == "Extract data from files"
 
-    def test_extraction_tool_has_attachment_input_schema(self, extraction_resource):
-        """Test that extraction tool's input schema mirrors Attachment fields."""
+    def test_extraction_tool_args_schema_comes_from_the_resource(
+        self, extraction_resource
+    ):
+        """Test that the args schema is generated from the resource input schema."""
         tool = create_ixp_extraction_tool(extraction_resource)
 
-        assert tool.args_schema is ExtractionToolInputSchema
-        schema_fields = ExtractionToolInputSchema.model_fields
-        attachment_fields = Attachment.model_fields
+        args_schema = cast(type[BaseModel], tool.args_schema)
+        assert tool.metadata is not None
+        assert args_schema is tool.metadata["args_schema"]
+        assert set(args_schema.model_fields) == {"attachment"}
+        assert get_job_attachment_paths(args_schema) == ["$.attachment"]
 
-        assert schema_fields.keys() == attachment_fields.keys()
-        for name, attachment_field in attachment_fields.items():
-            assert schema_fields[name].annotation == attachment_field.annotation
+    @pytest.mark.parametrize(
+        "input_schema",
+        [
+            # `uip agent tool add --type ixp` writes an empty schema
+            {"type": "object", "properties": {}},
+            {},
+        ],
+    )
+    def test_extraction_tool_falls_back_when_the_resource_schema_is_empty(
+        self, input_schema
+    ):
+        """A resource without a job attachment must still expose one."""
+        resource = AgentIxpExtractionResourceConfig(
+            name="test_extraction",
+            description="Extract data from files",
+            input_schema=input_schema,
+            output_schema={"type": "object", "properties": {}},
+            properties=AgentIxpExtractionToolProperties(
+                project_name="TestProject", version_tag="v1.0"
+            ),
+        )
+
+        tool = create_ixp_extraction_tool(resource)
+
+        args_schema = cast(type[BaseModel], tool.args_schema)
+        assert get_job_attachment_paths(args_schema) == ["$.attachment"]
+
+    def test_extraction_tool_keeps_attachment_id_a_string(self, extraction_resource):
+        """Test that the id is not coerced into a UUID object."""
+        tool = create_ixp_extraction_tool(extraction_resource)
+        attachment_id = "9b702dc7-4988-4fc0-ba81-08deeaade3da"
+
+        parsed = tool._parse_input(
+            _attachment_args(attachment_id=attachment_id, full_name="PO_234.pdf"),
+            None,
+        )
+
+        assert isinstance(parsed, dict)
+        sent_id = parsed["attachment"].ID
+        assert sent_id == attachment_id
+        assert isinstance(sent_id, str)
 
     def test_extraction_tool_has_extraction_response_output_type(
         self, extraction_resource
@@ -129,34 +229,7 @@ class TestExtractionToolFunctionality:
         return AgentIxpExtractionResourceConfig(
             name="test_extraction",
             description="Extract data from files",
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "attachment": {
-                        "description": "the file uploaded as attachment",
-                        "$ref": "#/definitions/job-attachment",
-                    }
-                },
-                "required": ["attachment"],
-                "definitions": {
-                    "job-attachment": {
-                        "type": "object",
-                        "required": ["ID"],
-                        "x-uipath-resource-kind": "JobAttachment",
-                        "properties": {
-                            "ID": {
-                                "type": "string",
-                                "description": "Orchestrator attachment key",
-                            },
-                            "FullName": {"type": "string", "description": "File name"},
-                            "MimeType": {
-                                "type": "string",
-                                "description": "The MIME type of the content",
-                            },
-                        },
-                    }
-                },
-            },
+            input_schema=_JOB_ATTACHMENT_INPUT_SCHEMA,
             output_schema={"type": "object", "properties": {}},
             properties=AgentIxpExtractionToolProperties(
                 project_name="TestProject",
@@ -181,15 +254,14 @@ class TestExtractionToolFunctionality:
         tool = create_ixp_extraction_tool(extraction_resource)
 
         result = await tool.ainvoke(
-            {
-                "id": "fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f",
-                "full_name": "document.pdf",
-                "mime_type": "application/pdf",
-            }
+            _attachment_args(
+                attachment_id=_ATTACHMENT_ID,
+                full_name="document.pdf",
+            )
         )
 
         mock_client.attachments.download_async.assert_called_once_with(
-            key=UUID("fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f"),
+            key=UUID(_ATTACHMENT_ID),
             destination_path="document.pdf",
         )
 
@@ -211,7 +283,7 @@ class TestExtractionToolFunctionality:
         extraction_resource = AgentIxpExtractionResourceConfig(
             name="test_extraction_v2",
             description="Extract data from files v2",
-            input_schema={"type": "object", "properties": {}},
+            input_schema=_JOB_ATTACHMENT_INPUT_SCHEMA,
             output_schema={"type": "object", "properties": {}},
             properties=AgentIxpExtractionToolProperties(
                 project_name="TestProjectV2",
@@ -229,11 +301,10 @@ class TestExtractionToolFunctionality:
         tool = create_ixp_extraction_tool(extraction_resource)
 
         await tool.ainvoke(
-            {
-                "id": "fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f",
-                "full_name": "document.pdf",
-                "mime_type": "application/pdf",
-            }
+            _attachment_args(
+                attachment_id=_ATTACHMENT_ID,
+                full_name="document.pdf",
+            )
         )
 
         interrupt_arg = mock_interrupt.call_args[0][0]
@@ -253,14 +324,10 @@ class TestExtractionToolFunctionality:
 
         tool = create_ixp_extraction_tool(extraction_resource)
 
+        args = _attachment_args(attachment_id=_ATTACHMENT_ID, full_name="file.pdf")
+
         with pytest.raises(Exception) as exc_info:
-            await tool.ainvoke(
-                {
-                    "id": "fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f",
-                    "full_name": "file.pdf",
-                    "mime_type": "application/pdf",
-                }
-            )
+            await tool.ainvoke(args)
 
         assert "Download failed" in str(exc_info.value)
 
@@ -284,14 +351,10 @@ class TestExtractionToolFunctionality:
 
         tool = create_ixp_extraction_tool(extraction_resource)
 
+        args = _attachment_args(attachment_id=_ATTACHMENT_ID, full_name="file.pdf")
+
         with pytest.raises(AgentRuntimeError) as exc_info:
-            await tool.ainvoke(
-                {
-                    "id": "fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f",
-                    "full_name": "file.pdf",
-                    "mime_type": "application/pdf",
-                }
-            )
+            await tool.ainvoke(args)
 
         assert exc_info.value.error_info.category == UiPathErrorCategory.DEPLOYMENT
         assert "permissions" in exc_info.value.error_info.detail
@@ -313,50 +376,167 @@ class TestExtractionToolFunctionality:
 
         tool = create_ixp_extraction_tool(extraction_resource)
 
+        args = _attachment_args(attachment_id=_ATTACHMENT_ID, full_name="file.pdf")
+
         with pytest.raises(AgentRuntimeError) as exc_info:
-            await tool.ainvoke(
-                {
-                    "id": "fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f",
-                    "full_name": "file.pdf",
-                    "mime_type": "application/pdf",
-                }
-            )
+            await tool.ainvoke(args)
 
         assert exc_info.value.error_info.category == UiPathErrorCategory.SYSTEM
         assert "file.pdf" in exc_info.value.error_info.detail
 
+
+class TestExtractionToolWrapper:
+    """Test the wrapper's job attachment resolution and result handling."""
+
+    @pytest.fixture
+    def extraction_resource(self):
+        """Create a minimal extraction tool resource config."""
+        return AgentIxpExtractionResourceConfig(
+            name="test_extraction",
+            description="Extract data from files",
+            input_schema=_JOB_ATTACHMENT_INPUT_SCHEMA,
+            output_schema={"type": "object", "properties": {}},
+            properties=AgentIxpExtractionToolProperties(
+                project_name="TestProject",
+                version_tag="v1.0",
+            ),
+        )
+
+    @staticmethod
+    def _state(*attachments: Attachment) -> AgentGraphState:
+        return AgentGraphState(
+            messages=[],
+            inner_state=InnerAgentGraphState(
+                job_attachments={str(att.id): att for att in attachments}
+            ),
+        )
+
     @pytest.mark.asyncio
     @patch("uipath.platform.UiPath")
     @patch("uipath_langchain.agent.tools.extraction_tool.interrupt")
-    async def test_extraction_tool_handles_alias_keyed_input(
+    async def test_wrapper_enriches_the_attachment_from_state(
         self, mock_interrupt, mock_uipath_class, extraction_resource
     ):
-        """The LLM emits Attachment fields by alias (ID/FullName/MimeType) — the
-        same shape Attachment.model_dump(by_alias=True) produces. download_async
-        must still be called with the populated UUID, not key=None.
-        """
+        """The model passes only the id; the rest comes from state."""
         mock_client = MagicMock()
         mock_uipath_class.return_value = mock_client
         mock_client.attachments.download_async = AsyncMock(
             return_value="/path/to/document.pdf"
         )
-        mock_interrupt.return_value = {"extracted_data": {"field1": "value1"}}
+        mock_interrupt.return_value = {"dataProjection": {"total": "42"}}
 
-        tool = create_ixp_extraction_tool(extraction_resource)
-
-        attachment = ExtractionToolInputSchema(
-            id=UUID("fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f"),
+        tool = cast(
+            StructuredToolWithWrapper, create_ixp_extraction_tool(extraction_resource)
+        )
+        attachment = Attachment(
+            id=UUID(_ATTACHMENT_ID),
             full_name="document.pdf",
             mime_type="application/pdf",
         )
-        aliased_input = attachment.model_dump()
+        call = {
+            "name": tool.name,
+            "args": {"attachment": {"ID": _ATTACHMENT_ID}},
+            "id": "call-1",
+            "type": "tool_call",
+        }
 
-        await tool.ainvoke(aliased_input)
+        wrapper = cast(AsyncToolWrapperWithState, tool.awrapper)
+        result = await wrapper(tool, cast(ToolCall, call), self._state(attachment))
 
         mock_client.attachments.download_async.assert_called_once_with(
-            key=UUID("fa93f4ca-bd3f-473a-93e5-e6e5b5a8f27f"),
+            key=UUID(_ATTACHMENT_ID),
             destination_path="document.pdf",
         )
+        assert isinstance(result, Command)
+        update = result.update
+        assert isinstance(update, dict)
+        assert update["messages"][0].content == str({"total": "42"})
+        assert update["inner_state"]["tools_storage"] == {
+            "test_extraction": {"dataProjection": {"total": "42"}}
+        }
+
+    @pytest.mark.asyncio
+    async def test_simulated_call_flows_through_the_wrapper(self, extraction_resource):
+        """A simulated tool call must reach the wrapper as plain JSON data."""
+
+        async def fake_generate(llm, messages, **kwargs):
+            return _EXTRACTION_RESPONSE
+
+        tool = cast(
+            StructuredToolWithWrapper, create_ixp_extraction_tool(extraction_resource)
+        )
+        attachment = Attachment(
+            id=UUID(_ATTACHMENT_ID),
+            full_name="document.pdf",
+            mime_type="application/pdf",
+        )
+        call = {
+            "name": tool.name,
+            "args": {"attachment": {"ID": _ATTACHMENT_ID}},
+            "id": "call-1",
+            "type": "tool_call",
+        }
+
+        set_execution_context(
+            MockingContext(
+                strategy=LLMMockingStrategy(
+                    prompt="simulate it",
+                    tools_to_simulate=[ToolSimulation(name="test_extraction")],
+                ),
+                name="run",
+                inputs={},
+            ),
+            MagicMock(),
+            "exec-sim",
+        )
+        try:
+            with (
+                patch("uipath.eval.mocks._llm_mocker.UiPath", MagicMock()),
+                patch(
+                    "uipath.eval.mocks._llm_mocker.UiPathLlmChatService", MagicMock()
+                ),
+                patch(
+                    "uipath.eval.mocks._llm_mocker.generate_structured_output",
+                    fake_generate,
+                ),
+                # a simulated tool must not touch the SDK
+                patch("uipath.platform.UiPath", MagicMock(side_effect=AssertionError)),
+            ):
+                wrapper = cast(AsyncToolWrapperWithState, tool.awrapper)
+                result = await wrapper(
+                    tool, cast(ToolCall, call), self._state(attachment)
+                )
+        finally:
+            clear_execution_context()
+
+        assert isinstance(result, Command)
+        update = result.update
+        assert isinstance(update, dict)
+        # Stored alias-keyed: the shape ixp_escalation_tool re-validates.
+        stored = update["inner_state"]["tools_storage"]["test_extraction"]
+        assert stored["documentTypeId"] == "invoice"
+        assert ExtractionResponseIXP(**stored).data_projection is not None
+
+    @pytest.mark.asyncio
+    async def test_wrapper_errors_when_the_attachment_is_not_in_state(
+        self, extraction_resource
+    ):
+        """An id absent from state is reported instead of reaching the SDK."""
+        tool = cast(
+            StructuredToolWithWrapper, create_ixp_extraction_tool(extraction_resource)
+        )
+        call = {
+            "name": tool.name,
+            "args": {"attachment": {"ID": _ATTACHMENT_ID}},
+            "id": "call-1",
+            "type": "tool_call",
+        }
+
+        wrapper = cast(AsyncToolWrapperWithState, tool.awrapper)
+        result = await wrapper(tool, cast(ToolCall, call), self._state())
+
+        assert isinstance(result, dict)
+        assert _ATTACHMENT_ID in result["error"]
 
 
 class TestExtractionToolNameSanitization:

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-20T22:41:41.618612Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.16"
+version = "0.14.17"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- the ixp extraction tool now generates its args schema from `resource.inputSchema` instead of a hardcoded flat model, so it honours the `job-attachment` `$ref` that agent builder already writes
- the tool call resolves job attachments through the shared helper, so the model passes only the attachment id and the full attachment is filled in from state
- an id that is missing from state is reported back to the model instead of reaching the sdk

## Why

the ixp tool was the only attachment-carrying tool not following the shared strategy. it ignored `resource.inputSchema` entirely, hardcoded an alias-free mirror of `Attachment`, and typed the id as `uuid.UUID`.

that last part broke tool simulation: langchain validates arguments against `args_schema` before invoking the tool, so the tool received a live `UUID` object rather than the string the model emitted, and anything encoding those kwargs with a plain `json.dumps` failed with `Object of type UUID is not JSON serializable`.

`process_tool`, `context_tool`, `deeprag_tool` and `analyze_files_tool` all generate the schema from the resource, keep the id a string, and convert to `uuid.UUID` only at the sdk call site. the ixp tool now does the same, which fixes the serialization failure as a side effect of the alignment rather than as a special case.

the arg-resolution half of `get_job_attachment_wrapper` is extracted as `resolve_job_attachment_args` so the ixp wrapper can reuse it while keeping its own result handling (`tools_storage` plus the `dataProjection` tool message that `ixpVsEscalation` depends on).