### PR TITLE
feat: add UiPathByoGuardrailMiddleware (BYOG) [AL-512]

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -70,6 +70,7 @@ from uipath.core.guardrails import GuardrailScope
 | `UiPathIntellectualPropertyMiddleware` | AGENT, LLM only | POST only | `entities` |
 | `UiPathLLMAsJudgeMiddleware` | AGENT, LLM, TOOL | PRE / POST / PRE_AND_POST | `guardrail_text`, `model`, `threshold`, `positive_examples`, `negative_examples`, `tools`, `stage` |
 | `UiPathDeterministicGuardrailMiddleware` | TOOL only | PRE / POST / PRE_AND_POST | `tools`, `rules`, `stage` |
+| `UiPathByoGuardrailMiddleware` | AGENT, LLM, TOOL | PRE / POST / PRE_AND_POST | `validator_name`, `connection_id`, `validator_parameters`, `tools`, `stage` |
 
 TOOL scope for `UiPathPIIDetectionMiddleware`, `UiPathHarmfulContentMiddleware`, and `UiPathLLMAsJudgeMiddleware` requires passing `tools=[...]` to restrict `wrap_tool_call` hooks to specific tools.
 
@@ -87,6 +88,7 @@ Additional parameters per class:
 - **`UiPathIntellectualPropertyMiddleware`**: `entities` (list of `IntellectualPropertyEntityType` values).
 - **`UiPathLLMAsJudgeMiddleware`**: `guardrail_text` (required — the plain-language rule the judge evaluates against, ≤ 4000 chars), `model` (required — judge model id, e.g. `"gpt-4o-2024-08-06"`; must be a model your governance policy allows for the LLM-as-judge guardrail — LLM Gateway enforces the permitted list), `threshold` (`0` strictest … `6` most lenient, default `2`), `positive_examples` / `negative_examples` (optional calibration payloads — ≤ 2 each, ≤ 1000 chars each), `tools` (required only when `GuardrailScope.TOOL` is used), `stage`. See the [core guardrails documentation](https://uipath.github.io/uipath-python/core/guardrails/#llm-as-judge) for the full parameter reference.
 - **`UiPathDeterministicGuardrailMiddleware`**: `tools` (required — list of tools to guard), `rules` (list of lambda functions), `stage`.
+- **`UiPathByoGuardrailMiddleware`**: `validator_name` (required — the BYOG configuration's validator name), `connection_id` (recommended — the Integration Service connection id backing the configuration), `validator_parameters` (optional connector-defined parameters, passed through as-is), `tools` (required only when `GuardrailScope.TOOL` is used), `stage`. See [Bring Your Own Guardrail](#bring-your-own-guardrail-byog).
 
 ### Full example
 
@@ -214,6 +216,80 @@ agent = create_agent(
     name="Output transformer",
 ),
 ```
+
+### Bring Your Own Guardrail (BYOG)
+
+`UiPathByoGuardrailMiddleware` runs a **customer-managed** validator instead of a UiPath-managed one — for example a cloud content-safety subscription, a vendor validation service, or a custom Integration Service connector wrapping an internal classifier.
+
+**Admin prerequisite.** An Org Admin first creates the BYOG configuration under **Admin → AI Trust Layer → Guardrails Configurations**: pick a guardrail connector (a UiPath-shipped one or a custom one wrapping your own vendor), create an Integration Service connection with your credentials, and save the configuration with a validator name. If the Guardrails Configurations page is not available, Bring Your Own Guardrail is not enabled on your tenant yet.
+
+The middleware references that configuration by name:
+
+```python
+from uipath.core.guardrails import GuardrailScope
+from uipath_langchain.guardrails import (
+    BlockAction,
+    UiPathByoGuardrailMiddleware,
+)
+
+byog = UiPathByoGuardrailMiddleware(
+    validator_name="my-harmful-content-guardrail",   # the configuration's validator name
+    scopes=[GuardrailScope.AGENT],
+    action=BlockAction(),
+    connection_id="my-byog-guardrail-connection",     # IS connection id
+)
+
+agent = create_agent(model=llm, tools=[...], middleware=[*byog])
+```
+
+To find the `validator_name` and `connection_id`, list the validators available to your tenant:
+
+```bash
+uip agent guardrails list --output json
+```
+
+Your BYOG configurations are listed alongside the built-in validators — so the same validator type can appear more than once, once for the UiPath-managed validator and once per BYOG configuration. Copy the validator name and connection id from your configuration's entry.
+
+Notes:
+
+- **Always pass `connection_id`.** Validator names are unique per connection only; without the id the server picks the first configuration matching the name.
+- **You choose the scopes and stages.** BYOG validators are not scope- or stage-restricted: like the built-in validators they are available on AGENT, LLM and TOOL scope for both PRE and POST, and it is up to you which ones to register. The entry's `AllowedScopes` / `GuardrailStages` in the CLI output confirm what a given validator accepts.
+- **Parameters are connector-defined.** Pass `validator_parameters` as raw parameter values when your connector expects them; there is no static schema on the client. See [Tuning a BYOG validator](#tuning-a-byog-validator) below.
+- **Error semantics.** A removed or disabled configuration, BYOG not being enabled for the tenant, or a vendor failure (with fallback off) returns `PROVIDER_ERROR`/`FEATURE_DISABLED` — the middleware treats these like any non-failed result (fail-open) and logs the details. Fallback to the UiPath-managed validator (`FallbackOnUiPath`) applies only when the configuration's validator type maps to an out-of-the-box validator.
+
+#### Tuning a BYOG validator
+
+`validator_parameters` is forwarded to the guardrail on every evaluation. The parameter **ids, types and allowed values are defined by the guardrail connector**, not by this SDK — read them from the validator's `Parameters` array in `uip agent guardrails list`, which gives each parameter's `Id`, `Type`, whether it is `Required`, its `DefaultValue`, and the applicable `Options` / `KeySource` / `Min` / `Max` / `Step`. Omit the argument to fall back to those `DefaultValue`s.
+
+```python
+from uipath.platform.guardrails import EnumListParameterValue, MapEnumParameterValue
+from uipath_langchain.guardrails.enums import HarmfulContentEntityType
+
+# Example for the Azure Content Safety connector's `harmful_content` validator:
+# select the harm categories and set a per-category severity threshold.
+byog_parameters = [
+    EnumListParameterValue(
+        parameter_type="enum-list",
+        id="harmfulContentEntities",
+        value=[entity.value for entity in HarmfulContentEntityType],
+    ),
+    MapEnumParameterValue(
+        parameter_type="map-enum",
+        id="harmfulContentEntityThresholds",
+        value={entity.value: 4 for entity in HarmfulContentEntityType},
+    ),
+]
+
+byog = UiPathByoGuardrailMiddleware(
+    validator_name="my-harmful-content-guardrail",
+    scopes=[GuardrailScope.AGENT],
+    action=BlockAction(),
+    connection_id="my-byog-guardrail-connection",
+    validator_parameters=byog_parameters,
+)
+```
+
+That connector flags a category when `severity >= threshold` on Azure's 0/2/4/6 scale, so a threshold of `4` lets low-severity (2) content through while still blocking 4 and 6; categories that are not selected are ignored. Other connectors define their own parameters — always read the ids out of `uip agent guardrails list` rather than assuming these ones.
 
 ### Custom middleware hooks
 
@@ -516,6 +592,7 @@ Use **middleware** when you want all guardrail policy in one place alongside a s
 
 - [`samples/joke-agent`](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/joke-agent) — middleware pattern
 - [`samples/joke-agent-decorator`](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/joke-agent-decorator) — decorator pattern
+- [`samples/joke-agent-bring-your-own-guardrail`](https://github.com/UiPath/uipath-langchain-python/tree/main/samples/joke-agent-bring-your-own-guardrail) — Bring Your Own Guardrail (middleware pattern)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.17"
+version = "0.14.18"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/samples/README.md
+++ b/samples/README.md
@@ -21,6 +21,9 @@ This sample demonstrates a LangGraph agent that generates family-friendly jokes 
 ## [Joke agent (decorator-based guardrails)](joke-agent-decorator)
 This sample shows how to use the unified `@guardrail` decorator to apply guardrails to LLM factories, tools, agent factories, graph nodes, and plain Python functions — without a middleware stack.
 
+## [Joke agent (Bring Your Own Guardrail)](joke-agent-bring-your-own-guardrail)
+This sample guards a joke agent with a customer-managed validator (BYOG): your own guardrail vendor connected through Integration Service and referenced by validator name + connection id via `UiPathByoGuardrailMiddleware`.
+
 ## [Multi agent supervisor, researcher, coder](multi-agent-supervisor-researcher-coder)
 This sample showcases a multi-agent system, involving a supervisor, a researcher, and a coder working in coordination to tackle complex tasks.
 

--- a/samples/joke-agent-bring-your-own-guardrail/README.md
+++ b/samples/joke-agent-bring-your-own-guardrail/README.md
@@ -1,0 +1,108 @@
+# Joke Agent — Bring Your Own Guardrail (BYOG)
+
+A minimal starter for using a **customer-managed guardrail** in a coded agent. The agent
+generates a family-friendly joke; every agent input/output (and the tool input) is validated
+by a **BYOG configuration** — your own guardrail vendor connected through Integration
+Service, referenced here purely by validator name + connection id. Credentials never appear
+in this project.
+
+The guardrail can be backed by any vendor your admin configured: a cloud subscription
+(e.g. a content-safety service), a vendor validation platform, or a custom Integration
+Service connector wrapping an internal classifier. The validator name and connection id in
+[graph.py](graph.py) are **placeholders** — substitute your own configuration's values.
+
+## Prerequisites (one-time, Org Admin)
+
+1. Create the BYOG configuration under **Admin → AI Trust Layer → Guardrails
+   Configurations**: pick a guardrail connector, create an Integration Service connection
+   with your vendor credentials, and save the configuration with a validator name.
+   (If the Guardrails Configurations page is not available on your tenant, Bring Your Own
+   Guardrail is not enabled for you yet.)
+2. Find the values this sample needs:
+
+   ```bash
+   uip agent guardrails list --output json
+   ```
+
+   BYOG configurations are listed alongside the built-in validators, so the same validator
+   type may appear more than once — pick your configuration's entry. Copy its validator name
+   → `BYOG_VALIDATOR_NAME` and its connection id → `BYOG_CONNECTION_ID` in [graph.py](graph.py)
+   (both ship as placeholders), and update the `key` / `defaultValue` / `connector` fields in
+   [bindings.json](bindings.json) to match your connection.
+
+> Always pass the connection id: validator names are unique **per connection** only.
+
+## Run it
+
+```bash
+uv sync
+uv run uipath auth          # or populate .env
+uv run uipath run agent '{"topic": "banana"}'
+```
+
+Expected outcomes — the verdicts come from **your configured guardrail vendor**
+(with fallback to the UiPath-managed validator disabled in the configuration used here):
+
+| Input topic | Result |
+|---|---|
+| a topic your guardrail passes (e.g. `"banana"` for a harmful-content validator) | `PASSED` → the agent returns a joke |
+| a topic your guardrail flags | `VALIDATION_FAILED` → `BlockAction` aborts the run with the vendor's verdict details |
+
+What counts as a violation is entirely defined by the validator your admin configured —
+a harmful-content validator flags violent or hateful topics, a PII validator flags personal
+data, a custom classifier applies your own rules.
+
+## Tuning the validator — `validator_parameters`
+
+The middleware accepts an optional `validator_parameters` argument that is forwarded to the
+guardrail on every evaluation:
+
+```python
+*UiPathByoGuardrailMiddleware(
+    validator_name=BYOG_VALIDATOR_NAME,
+    scopes=[GuardrailScope.AGENT],
+    action=BlockAction(),
+    connection_id=BYOG_CONNECTION_ID,
+    validator_parameters=BYOG_VALIDATOR_PARAMETERS,
+)
+```
+
+The parameter **ids, types and allowed values are defined by the guardrail connector**, not
+by this SDK — read them from your validator's `Parameters` array in
+`uip agent guardrails list` and pass the values through as-is. Each parameter there carries
+its `Id`, `Type`, whether it is `Required`, its `DefaultValue`, and the applicable
+`Options` / `KeySource` / `Min` / `Max` / `Step`. Omit the argument to fall back to those
+defaults.
+
+[graph.py](graph.py) carries a commented-out example for the Azure Content Safety
+connector's `harmful_content` validator: it selects the four harm categories and sets a
+per-category severity threshold. That connector flags a category when
+`severity >= threshold` on Azure's 0/2/4/6 scale, so a threshold of `4` lets low-severity
+(2) content through while still blocking 4 and 6, and categories that are not selected are
+ignored. Verified end to end against a live configuration:
+
+| Threshold | low-severity topic (2) | high-severity topic (4) |
+|---|---|---|
+| omitted | blocked | blocked |
+| `4` | passes | blocked |
+| `6` | passes | passes |
+
+## How it works
+
+- `UiPathByoGuardrailMiddleware` builds a guardrail with `validator_type="byo"` plus
+  `byoValidatorName`/`byoConnectionId`, evaluated via
+  `POST /agentsruntime_/api/execution/guardrails/validate`.
+- The Guardrails Service resolves your configuration and invokes the Integration Service
+  connector against your vendor, which returns the verdict.
+- [bindings.json](bindings.json) declares the connection as a solution binding so the
+  connection id can be rebound per environment at deploy time.
+
+## Notes
+
+- **You choose the scopes and stages** — BYOG validators are available on AGENT, LLM and TOOL
+  scope for both PRE and POST, exactly like the built-in ones; this sample registers AGENT
+  and TOOL.
+- A removed or disabled configuration also returns an error result; the middleware fails
+  open and logs the details.
+
+See [docs/guardrails.md](../../docs/guardrails.md) for the full guardrails guide.

--- a/samples/joke-agent-bring-your-own-guardrail/bindings.json
+++ b/samples/joke-agent-bring-your-own-guardrail/bindings.json
@@ -1,0 +1,22 @@
+{
+    "version": "2.0",
+    "resources": [
+        {
+            "resource": "connection",
+            "key": "my-byog-guardrail-connection",
+            "value": {
+                "connectionId": {
+                    "defaultValue": "my-byog-guardrail-connection",
+                    "isExpression": false,
+                    "displayName": "BYOG guardrail connection ID"
+                }
+            },
+            "metadata": {
+                "connector": "uipath-azure-contentsafety-guardrails",
+                "useConnectionService": "true",
+                "bindingsVersion": "2.2",
+                "solutionsSupport": "true"
+            }
+        }
+    ]
+}

--- a/samples/joke-agent-bring-your-own-guardrail/graph.py
+++ b/samples/joke-agent-bring-your-own-guardrail/graph.py
@@ -1,0 +1,167 @@
+"""Joke agent guarded by a Bring Your Own Guardrail (BYOG) configuration.
+
+The agent generates a family-friendly joke, but every agent input and output is
+validated by a *customer-managed* guardrail — your own vendor connected through
+Integration Service and configured by an Org Admin under
+``Admin -> AI Trust Layer -> Guardrails Configurations``. This sample was
+validated against a harmful-content configuration; substitute your own.
+
+The middleware references that configuration by validator name + connection id;
+the credentials never appear in this project.
+"""
+
+from langchain.agents import create_agent
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.constants import END, START
+from langgraph.graph import StateGraph
+from pydantic import BaseModel
+from uipath.core.guardrails import GuardrailScope
+
+from uipath_langchain.chat import UiPathChat
+from uipath_langchain.guardrails import (
+    BlockAction,
+    GuardrailExecutionStage,
+    UiPathByoGuardrailMiddleware,
+)
+
+# The BYOG configuration to use. Both values come from
+# Admin -> AI Trust Layer -> Guardrails Configurations, or from the CLI:
+# `uip agent guardrails list`, which lists your BYOG configurations alongside
+# the built-in validators.
+# Replace them with your own configuration's validator name and connection id.
+# The connection id is also declared as a binding in bindings.json so it can be
+# rebound per environment at deploy time; locally this literal value is used.
+BYOG_VALIDATOR_NAME = "my-harmful-content-guardrail"
+BYOG_CONNECTION_ID = "my-byog-guardrail-connection"
+
+# Optional: `validator_parameters` tunes the validator per run.
+#
+# The parameter ids, types and allowed values are defined by the guardrail
+# *connector*, not by this SDK — read them from the validator's `Parameters`
+# array in `uip agent guardrails list` (each entry carries its `Id`, `Type`,
+# `Required`, `DefaultValue` and any `Options`/`KeySource`/`Min`/`Max`/`Step`)
+# and pass the values through as-is. Omit the argument to fall back to those
+# defaults.
+#
+# The example below is for the Azure Content Safety connector's `harmful_content`
+# validator: it selects the four categories explicitly and flags a category when
+# `severity >= threshold` on Azure's 0/2/4/6 scale, so a threshold of 4 lets
+# low-severity (2) content through while still blocking 4 and 6. Categories that
+# are not selected are ignored.
+#
+#     from uipath.platform.guardrails import (
+#         EnumListParameterValue,
+#         MapEnumParameterValue,
+#     )
+#     from uipath_langchain.guardrails.enums import HarmfulContentEntityType
+#
+#     HARMFUL_CONTENT_SEVERITY_THRESHOLD = 4
+#
+#     BYOG_VALIDATOR_PARAMETERS = [
+#         EnumListParameterValue(
+#             parameter_type="enum-list",
+#             id="harmfulContentEntities",
+#             value=[entity.value for entity in HarmfulContentEntityType],
+#         ),
+#         MapEnumParameterValue(
+#             parameter_type="map-enum",
+#             id="harmfulContentEntityThresholds",
+#             value={
+#                 entity.value: HARMFUL_CONTENT_SEVERITY_THRESHOLD
+#                 for entity in HarmfulContentEntityType
+#             },
+#         ),
+#     ]
+#
+# ...then pass `validator_parameters=BYOG_VALIDATOR_PARAMETERS` to the middleware.
+
+
+class Input(BaseModel):
+    """Input schema for the joke agent."""
+
+    topic: str
+
+
+class Output(BaseModel):
+    """Output schema for the joke agent."""
+
+    joke: str
+
+
+llm = UiPathChat(model="gpt-4o-2024-08-06", temperature=0.7)
+
+
+@tool
+def analyze_joke_syntax(joke: str) -> str:
+    """Analyze the syntax of a joke by counting words and letters.
+
+    Args:
+        joke: The joke text to analyze
+
+    Returns:
+        A string with the analysis results showing word count and letter count
+    """
+    words = joke.split()
+    letter_count = sum(1 for char in joke if char.isalpha())
+    return f"Words number: {len(words)}\nLetters: {letter_count}"
+
+
+SYSTEM_PROMPT = """You are an AI assistant designed to generate family-friendly jokes.
+
+1. Generate a family-friendly joke based on the given topic.
+2. Use the analyze_joke_syntax tool to analyze the joke's syntax.
+3. Ensure your output includes the joke.
+
+Remember to always include the 'joke' property in your output."""
+
+agent = create_agent(
+    model=llm,
+    tools=[analyze_joke_syntax],
+    system_prompt=SYSTEM_PROMPT,
+    middleware=[
+        # Customer-managed harmful-content guardrail (BYOG). PRE_AND_POST on
+        # AGENT scope: the requested topic is validated before the LLM runs and
+        # the produced joke is validated before it is returned. On a violation
+        # BlockAction aborts the run with the vendor's verdict details.
+        *UiPathByoGuardrailMiddleware(
+            validator_name=BYOG_VALIDATOR_NAME,
+            scopes=[GuardrailScope.AGENT],
+            action=BlockAction(),
+            connection_id=BYOG_CONNECTION_ID,
+            # Optionally add validator_parameters=... — see the example above.
+            stage=GuardrailExecutionStage.PRE_AND_POST,
+            name="BYOG Harmful Content",
+        ),
+        # The same configuration can also guard individual tools:
+        *UiPathByoGuardrailMiddleware(
+            validator_name=BYOG_VALIDATOR_NAME,
+            scopes=[GuardrailScope.TOOL],
+            action=BlockAction(),
+            connection_id=BYOG_CONNECTION_ID,
+            tools=[analyze_joke_syntax],
+            stage=GuardrailExecutionStage.PRE,
+            name="BYOG Tool Harmful Content",
+        ),
+    ],
+)
+
+
+async def joke_node(state: Input) -> Output:
+    """Convert topic to messages, call agent, and extract joke."""
+    messages = [
+        HumanMessage(
+            content=f"Generate a family-friendly joke based on the topic: {state.topic}"
+        )
+    ]
+    result = await agent.ainvoke({"messages": messages})
+    joke = result["messages"][-1].content
+    return Output(joke=joke)
+
+
+builder = StateGraph(Input, input_schema=Input, output_schema=Output)
+builder.add_node("joke", joke_node)
+builder.add_edge(START, "joke")
+builder.add_edge("joke", END)
+
+graph = builder.compile()

--- a/samples/joke-agent-bring-your-own-guardrail/langgraph.json
+++ b/samples/joke-agent-bring-your-own-guardrail/langgraph.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": ["."],
+  "graphs": {
+    "agent": "./graph.py:graph"
+  },
+  "env": ".env"
+}

--- a/samples/joke-agent-bring-your-own-guardrail/pyproject.toml
+++ b/samples/joke-agent-bring-your-own-guardrail/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "joke-agent-bring-your-own-guardrail"
+version = "0.0.1"
+description = "Joke agent guarded by a Bring Your Own Guardrail (BYOG) harmful-content configuration"
+authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
+requires-python = ">=3.11"
+dependencies = [
+    "uipath-langchain>=0.14.5, <0.15.0",
+    "uipath>=2.13.7, <2.14.0",
+]
+
+[dependency-groups]
+dev = [
+    "uipath-dev",
+]

--- a/samples/joke-agent-bring-your-own-guardrail/uipath.json
+++ b/samples/joke-agent-bring-your-own-guardrail/uipath.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://cloud.uipath.com/draft/2024-12/uipath",
+  "runtimeOptions": {
+    "isConversational": false
+  },
+  "packOptions": {
+    "fileExtensionsIncluded": [],
+    "filesIncluded": [],
+    "filesExcluded": [],
+    "directoriesExcluded": [],
+    "includeUvLock": true
+  },
+  "functions": {}
+}

--- a/src/uipath_langchain/guardrails/__init__.py
+++ b/src/uipath_langchain/guardrails/__init__.py
@@ -34,6 +34,7 @@ from uipath.platform.guardrails.decorators import (
 from ._langchain_adapter import LangChainGuardrailAdapter
 from .escalate_action import EscalateAction
 from .middlewares import (
+    UiPathByoGuardrailMiddleware,
     UiPathDeterministicGuardrailMiddleware,
     UiPathHarmfulContentMiddleware,
     UiPathIntellectualPropertyMiddleware,
@@ -81,6 +82,7 @@ __all__ = [
     "GuardrailTargetAdapter",
     "register_guardrail_adapter",
     # Middlewares
+    "UiPathByoGuardrailMiddleware",
     "UiPathHarmfulContentMiddleware",
     "UiPathIntellectualPropertyMiddleware",
     "UiPathLLMAsJudgeMiddleware",

--- a/src/uipath_langchain/guardrails/middlewares/__init__.py
+++ b/src/uipath_langchain/guardrails/middlewares/__init__.py
@@ -1,5 +1,6 @@
 """Guardrail middlewares for LangChain agents."""
 
+from .byo import UiPathByoGuardrailMiddleware
 from .deterministic import (
     RuleFunction,
     UiPathDeterministicGuardrailMiddleware,
@@ -13,6 +14,7 @@ from .user_prompt_attacks import UiPathUserPromptAttacksMiddleware
 
 __all__ = [
     "RuleFunction",
+    "UiPathByoGuardrailMiddleware",
     "UiPathDeterministicGuardrailMiddleware",
     "UiPathHarmfulContentMiddleware",
     "UiPathIntellectualPropertyMiddleware",

--- a/src/uipath_langchain/guardrails/middlewares/_base.py
+++ b/src/uipath_langchain/guardrails/middlewares/_base.py
@@ -4,7 +4,7 @@ import ast
 import asyncio
 import json
 import logging
-from typing import Any, Sequence
+from typing import Any, Literal, Sequence
 
 from langchain.agents.middleware import (
     AgentMiddleware,
@@ -48,6 +48,10 @@ from ._utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+#: ``$guardrailType`` discriminator for built-in validator guardrails. Typed as
+#: a ``Literal`` so it satisfies ``BuiltInValidatorGuardrail.guardrail_type``.
+BUILT_IN_VALIDATOR_GUARDRAIL_TYPE: Literal["builtInValidator"] = "builtInValidator"
 
 
 def _get_tool_message_content(result: ToolMessage | Command[Any]) -> Any:

--- a/src/uipath_langchain/guardrails/middlewares/byo.py
+++ b/src/uipath_langchain/guardrails/middlewares/byo.py
@@ -1,0 +1,179 @@
+"""Bring Your Own Guardrail (BYOG) middleware."""
+
+import logging
+from typing import Any, Sequence
+from uuid import uuid4
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.tools import BaseTool
+from uipath.core.guardrails import GuardrailSelector
+from uipath.platform.guardrails import (
+    BuiltInValidatorGuardrail,
+    GuardrailScope,
+)
+from uipath.platform.guardrails.guardrails import (
+    BYO_VALIDATOR_TYPE,
+    ValidatorParameter,
+)
+
+from ..enums import GuardrailExecutionStage
+from ..models import GuardrailAction
+from ._base import (
+    BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
+    BuiltInGuardrailMiddlewareMixin,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class UiPathByoGuardrailMiddleware(BuiltInGuardrailMiddlewareMixin):
+    """Middleware for Bring Your Own Guardrail (BYOG) validations.
+
+    BYOG lets an organization plug its own safety validator (e.g. a cloud
+    content-safety subscription, a vendor validation service, or a custom
+    Integration Service connector) into UiPath guardrails. An admin first
+    creates the configuration under ``Admin -> AI Trust Layer -> Guardrails
+    Configurations``; this middleware then references it by its validator name
+    and (recommended) Integration Service connection id.
+
+    Example:
+        ```python
+        from langchain.agents import create_agent
+        from langchain_core.tools import tool
+        from uipath.core.guardrails import GuardrailScope
+        from uipath_langchain.guardrails import (
+            BlockAction,
+            UiPathByoGuardrailMiddleware,
+        )
+
+        @tool
+        def analyze_joke_syntax(joke: str) -> str:
+            \"\"\"Analyze the syntax of a joke.\"\"\"
+            return f"Words: {len(joke.split())}"
+
+        # Customer-managed guardrail on agent input/output
+        middleware_agent = UiPathByoGuardrailMiddleware(
+            validator_name="my-harmful-content-guardrail",
+            scopes=[GuardrailScope.AGENT],
+            action=BlockAction(),
+            connection_id="my-byog-guardrail-connection",
+        )
+
+        # Same configuration applied to a specific tool
+        middleware_tool = UiPathByoGuardrailMiddleware(
+            validator_name="my-harmful-content-guardrail",
+            scopes=[GuardrailScope.TOOL],
+            action=BlockAction(),
+            connection_id="my-byog-guardrail-connection",
+            tools=[analyze_joke_syntax],
+        )
+
+        agent = create_agent(
+            model=llm,
+            tools=[analyze_joke_syntax],
+            middleware=[*middleware_agent, *middleware_tool],
+        )
+        ```
+
+    Args:
+        validator_name: The BYOG configuration's validator name
+            (``byoValidatorName``), as shown in Admin -> AI Trust Layer ->
+            Guardrails Configurations or by ``uip agent guardrails list``.
+        scopes: List of scopes where the guardrail applies (Agent, LLM, Tool).
+            BYOG validators are not scope-restricted -- all three scopes are
+            available, as with the built-in validators.
+        action: Action to take when the validation fails (LogAction,
+            BlockAction, EscalateAction, or a custom GuardrailAction).
+        connection_id: Optional Integration Service connection id backing the
+            BYOG configuration. Strongly recommended: validator names are only
+            unique per connection, so omitting it lets the server pick the
+            first configuration matching the name.
+        validator_parameters: Optional list of validator parameters. BYO
+            parameter schemas are connector-defined, so values are passed
+            through as-is; read the ids and allowed values from the
+            validator's ``Parameters`` in ``uip agent guardrails list``.
+        tools: Required when TOOL scope is specified. List of tool names or
+            tool objects to apply the guardrail to. Must contain at least one
+            tool. Can be a mix of strings (tool names) or BaseTool objects.
+            If TOOL scope is not specified, this parameter is ignored.
+        stage: Optional execution stage controlling when the guardrail runs.
+            ``PRE`` evaluates before the target executes (registers only the
+            ``before_*`` hook), ``POST`` evaluates after (only the ``after_*``
+            hook), and ``PRE_AND_POST`` evaluates both. Applies to all scopes
+            (Agent, LLM, Tool). Defaults to ``GuardrailExecutionStage.PRE_AND_POST``.
+        name: Optional name for the guardrail (defaults to
+            ``BYO Guardrail (<validator_name>)``).
+        description: Optional description for the guardrail.
+        enabled_for_evals: Whether this guardrail is enabled for evaluation
+            scenarios. Defaults to True.
+    """
+
+    def __init__(
+        self,
+        validator_name: str,
+        scopes: Sequence[GuardrailScope],
+        action: GuardrailAction,
+        *,
+        connection_id: str | None = None,
+        validator_parameters: Sequence[ValidatorParameter] | None = None,
+        tools: Sequence[str | BaseTool] | None = None,
+        stage: GuardrailExecutionStage = GuardrailExecutionStage.PRE_AND_POST,
+        name: str | None = None,
+        description: str | None = None,
+        enabled_for_evals: bool = True,
+    ):
+        """Initialize Bring Your Own Guardrail middleware."""
+        if not validator_name or not validator_name.strip():
+            raise ValueError("validator_name must be a non-empty string")
+        if not scopes:
+            raise ValueError("At least one scope must be specified")
+        if not isinstance(action, GuardrailAction):
+            raise ValueError("action must be an instance of GuardrailAction")
+        if not isinstance(enabled_for_evals, bool):
+            raise ValueError("enabled_for_evals must be a boolean")
+
+        self._tool_names = self._resolve_tool_names(tools)
+        scopes_list = list(scopes)
+        self._require_tools_for_tool_scope(scopes_list)
+
+        self.scopes = scopes_list
+        self.action = action
+        self.validator_name = validator_name
+        self.connection_id = connection_id
+        self.validator_parameters = list(validator_parameters or [])
+        self._tool_stage = stage
+        self._name = name or f"BYO Guardrail ({validator_name})"
+        self.enabled_for_evals = enabled_for_evals
+        self._description = (
+            description or f"Bring Your Own Guardrail validation '{validator_name}'"
+        )
+
+        self._guardrail = self._create_guardrail()
+        self._middleware_instances = self._create_middleware_instances()
+
+    def _create_middleware_instances(self) -> list[AgentMiddleware]:
+        """Create scope-gated middleware instances (see ``_build_scope_instances``)."""
+        return self._build_scope_instances(self._name.replace(" ", "_"))
+
+    def __iter__(self):
+        """Make the class iterable to return middleware instances."""
+        return iter(self._middleware_instances)
+
+    def _create_guardrail(self) -> BuiltInValidatorGuardrail:
+        """Create BuiltInValidatorGuardrail from configuration."""
+        selector_kwargs: dict[str, Any] = {"scopes": self.scopes}
+        if GuardrailScope.TOOL in self.scopes:
+            selector_kwargs["match_names"] = self._tool_names
+
+        return BuiltInValidatorGuardrail(
+            id=str(uuid4()),
+            name=self._name,
+            description=self._description,
+            enabled_for_evals=self.enabled_for_evals,
+            selector=GuardrailSelector(**selector_kwargs),
+            guardrail_type=BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
+            validator_type=BYO_VALIDATOR_TYPE,
+            validator_parameters=self.validator_parameters,
+            byo_validator_name=self.validator_name,
+            byo_connection_id=self.connection_id,
+        )

--- a/src/uipath_langchain/guardrails/middlewares/harmful_content.py
+++ b/src/uipath_langchain/guardrails/middlewares/harmful_content.py
@@ -16,7 +16,10 @@ from uipath.platform.guardrails import (
 
 from ..enums import GuardrailExecutionStage
 from ..models import GuardrailAction, HarmfulContentEntity
-from ._base import BuiltInGuardrailMiddlewareMixin
+from ._base import (
+    BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
+    BuiltInGuardrailMiddlewareMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +117,7 @@ class UiPathHarmfulContentMiddleware(BuiltInGuardrailMiddlewareMixin):
             description=self._description,
             enabled_for_evals=self.enabled_for_evals,
             selector=GuardrailSelector(**selector_kwargs),
-            guardrail_type="builtInValidator",
+            guardrail_type=BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
             validator_type="harmful_content",
             validator_parameters=validator_parameters,
         )

--- a/src/uipath_langchain/guardrails/middlewares/intellectual_property.py
+++ b/src/uipath_langchain/guardrails/middlewares/intellectual_property.py
@@ -14,7 +14,10 @@ from uipath.platform.guardrails import (
 
 from ..enums import GuardrailExecutionStage
 from ..models import GuardrailAction
-from ._base import BuiltInGuardrailMiddlewareMixin
+from ._base import (
+    BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
+    BuiltInGuardrailMiddlewareMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +121,7 @@ class UiPathIntellectualPropertyMiddleware(BuiltInGuardrailMiddlewareMixin):
             description=self._description,
             enabled_for_evals=self.enabled_for_evals,
             selector=GuardrailSelector(scopes=self.scopes),
-            guardrail_type="builtInValidator",
+            guardrail_type=BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
             validator_type="intellectual_property",
             validator_parameters=validator_parameters,
         )

--- a/src/uipath_langchain/guardrails/middlewares/llm_as_judge.py
+++ b/src/uipath_langchain/guardrails/middlewares/llm_as_judge.py
@@ -21,7 +21,10 @@ from uipath.platform.guardrails.guardrails import (
 
 from ..enums import GuardrailExecutionStage
 from ..models import GuardrailAction
-from ._base import BuiltInGuardrailMiddlewareMixin
+from ._base import (
+    BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
+    BuiltInGuardrailMiddlewareMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -206,7 +209,7 @@ class UiPathLLMAsJudgeMiddleware(BuiltInGuardrailMiddlewareMixin):
             description=self._description,
             enabled_for_evals=self.enabled_for_evals,
             selector=GuardrailSelector(**selector_kwargs),
-            guardrail_type="builtInValidator",
+            guardrail_type=BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
             validator_type="llm_as_judge",
             validator_parameters=validator_parameters,
         )

--- a/src/uipath_langchain/guardrails/middlewares/pii_detection.py
+++ b/src/uipath_langchain/guardrails/middlewares/pii_detection.py
@@ -16,7 +16,10 @@ from uipath.platform.guardrails import (
 
 from ..enums import GuardrailExecutionStage
 from ..models import GuardrailAction, PIIDetectionEntity
-from ._base import BuiltInGuardrailMiddlewareMixin
+from ._base import (
+    BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
+    BuiltInGuardrailMiddlewareMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +167,7 @@ class UiPathPIIDetectionMiddleware(BuiltInGuardrailMiddlewareMixin):
             description=self._description,
             enabled_for_evals=self.enabled_for_evals,
             selector=GuardrailSelector(**selector_kwargs),
-            guardrail_type="builtInValidator",
+            guardrail_type=BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
             validator_type="pii_detection",
             validator_parameters=validator_parameters,
         )

--- a/src/uipath_langchain/guardrails/middlewares/prompt_injection.py
+++ b/src/uipath_langchain/guardrails/middlewares/prompt_injection.py
@@ -11,7 +11,10 @@ from uipath.platform.guardrails.guardrails import NumberParameterValue
 
 from ..enums import GuardrailExecutionStage
 from ..models import GuardrailAction
-from ._base import BuiltInGuardrailMiddlewareMixin
+from ._base import (
+    BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
+    BuiltInGuardrailMiddlewareMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +114,7 @@ class UiPathPromptInjectionMiddleware(BuiltInGuardrailMiddlewareMixin):
             description=self._description,
             enabled_for_evals=self.enabled_for_evals,
             selector=GuardrailSelector(scopes=self.scopes),
-            guardrail_type="builtInValidator",
+            guardrail_type=BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
             validator_type="prompt_injection",
             validator_parameters=validator_parameters,
         )

--- a/src/uipath_langchain/guardrails/middlewares/user_prompt_attacks.py
+++ b/src/uipath_langchain/guardrails/middlewares/user_prompt_attacks.py
@@ -10,7 +10,10 @@ from uipath.platform.guardrails import BuiltInValidatorGuardrail, GuardrailScope
 
 from ..enums import GuardrailExecutionStage
 from ..models import GuardrailAction
-from ._base import BuiltInGuardrailMiddlewareMixin
+from ._base import (
+    BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
+    BuiltInGuardrailMiddlewareMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +83,7 @@ class UiPathUserPromptAttacksMiddleware(BuiltInGuardrailMiddlewareMixin):
             description=self._description,
             enabled_for_evals=self.enabled_for_evals,
             selector=GuardrailSelector(scopes=self.scopes),
-            guardrail_type="builtInValidator",
+            guardrail_type=BUILT_IN_VALIDATOR_GUARDRAIL_TYPE,
             validator_type="user_prompt_attacks",
             validator_parameters=[],
         )

--- a/tests/guardrails/middlewares/test_byo.py
+++ b/tests/guardrails/middlewares/test_byo.py
@@ -1,0 +1,243 @@
+"""Tests for ``UiPathByoGuardrailMiddleware`` (Bring Your Own Guardrail).
+
+BYOG guardrails reference an admin-created configuration by validator name
+(plus an optional Integration Service connection id). These tests pin:
+- the ``BuiltInValidatorGuardrail`` the middleware constructs (``validator_type
+  == "byo"`` sentinel + ``byoValidatorName``/``byoConnectionId`` aliases),
+- constructor validation,
+- hook wiring parity with the other built-in middlewares (scopes x stage),
+- that the evaluation path forwards the BYO guardrail to the service and that
+  ``BlockAction`` raises on ``VALIDATION_FAILED``.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from uipath.core.guardrails import (
+    GuardrailValidationResult,
+    GuardrailValidationResultType,
+)
+from uipath.platform.guardrails import GuardrailScope
+from uipath.platform.guardrails.decorators import BlockAction, LogAction
+from uipath.platform.guardrails.decorators._exceptions import GuardrailBlockException
+from uipath.platform.guardrails.guardrails import (
+    BYO_VALIDATOR_TYPE,
+    NumberParameterValue,
+)
+
+from uipath_langchain.guardrails.enums import GuardrailExecutionStage
+from uipath_langchain.guardrails.middlewares import UiPathByoGuardrailMiddleware
+
+_LOG = LogAction()
+_BLOCK = BlockAction()
+
+_VALIDATOR_NAME = "byog-harmful-content"
+_CONNECTION_ID = "24887687-6ed1-4fe2-9b87-087ffb232682"
+
+
+def _hook_names(middleware: Iterable[Any]) -> list[str]:
+    """Return the ``name`` attribute of each AgentMiddleware instance."""
+    return [inst.name for inst in middleware]
+
+
+def _byo(**overrides: Any) -> UiPathByoGuardrailMiddleware:
+    kwargs: dict[str, Any] = {
+        "validator_name": _VALIDATOR_NAME,
+        "scopes": [GuardrailScope.AGENT],
+        "action": _LOG,
+    }
+    kwargs.update(overrides)
+    return UiPathByoGuardrailMiddleware(**kwargs)
+
+
+class TestByoGuardrailConstruction:
+    """The constructed guardrail carries the BYO sentinel and reference fields."""
+
+    def test_guardrail_uses_byo_sentinel_validator_type(self) -> None:
+        middleware = _byo()
+        assert middleware._guardrail.validator_type == BYO_VALIDATOR_TYPE
+
+    def test_guardrail_carries_validator_name_and_connection_id(self) -> None:
+        middleware = _byo(connection_id=_CONNECTION_ID)
+        assert middleware._guardrail.byo_validator_name == _VALIDATOR_NAME
+        assert middleware._guardrail.byo_connection_id == _CONNECTION_ID
+
+    def test_connection_id_defaults_to_none(self) -> None:
+        middleware = _byo()
+        assert middleware._guardrail.byo_connection_id is None
+
+    def test_aliases_serialize_for_the_wire(self) -> None:
+        middleware = _byo(connection_id=_CONNECTION_ID)
+        dumped = middleware._guardrail.model_dump(by_alias=True)
+        assert dumped["validatorType"] == "byo"
+        assert dumped["byoValidatorName"] == _VALIDATOR_NAME
+        assert dumped["byoConnectionId"] == _CONNECTION_ID
+        assert dumped["$guardrailType"] == "builtInValidator"
+
+    def test_validator_parameters_pass_through(self) -> None:
+        parameter = NumberParameterValue(
+            parameter_type="number", id="threshold", value=0.7
+        )
+        middleware = _byo(validator_parameters=[parameter])
+        assert middleware._guardrail.validator_parameters == [parameter]
+
+    def test_validator_parameters_default_empty(self) -> None:
+        middleware = _byo()
+        assert middleware._guardrail.validator_parameters == []
+
+    def test_default_name_and_description_include_validator_name(self) -> None:
+        middleware = _byo()
+        assert _VALIDATOR_NAME in middleware._guardrail.name
+        assert middleware._guardrail.description is not None
+        assert _VALIDATOR_NAME in middleware._guardrail.description
+
+    def test_explicit_name_and_description_win(self) -> None:
+        middleware = _byo(name="My Guardrail", description="My description")
+        assert middleware._guardrail.name == "My Guardrail"
+        assert middleware._guardrail.description == "My description"
+
+    def test_tool_scope_sets_selector_match_names(self) -> None:
+        middleware = _byo(
+            scopes=[GuardrailScope.TOOL],
+            tools=["my_tool"],
+        )
+        assert middleware._guardrail.selector is not None
+        assert middleware._guardrail.selector.match_names == ["my_tool"]
+
+
+class TestByoGuardrailValidation:
+    """Constructor validation errors."""
+
+    def test_empty_validator_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="validator_name"):
+            _byo(validator_name="")
+
+    def test_whitespace_validator_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="validator_name"):
+            _byo(validator_name="   ")
+
+    def test_empty_scopes_raises(self) -> None:
+        with pytest.raises(ValueError, match="scope"):
+            _byo(scopes=[])
+
+    def test_non_action_raises(self) -> None:
+        with pytest.raises(ValueError, match="action"):
+            _byo(action="not-an-action")
+
+    def test_tool_scope_without_tools_raises(self) -> None:
+        with pytest.raises(ValueError, match="Tool scope"):
+            _byo(scopes=[GuardrailScope.TOOL])
+
+    def test_non_bool_enabled_for_evals_raises(self) -> None:
+        with pytest.raises(ValueError, match="enabled_for_evals"):
+            _byo(enabled_for_evals="yes")
+
+
+class TestByoGuardrailHookWiring:
+    """Scopes x stage produce the same hooks as the other built-in middlewares."""
+
+    def test_agent_pre_registers_only_before_agent(self) -> None:
+        names = _hook_names(
+            _byo(name="BYO Guardrail", stage=GuardrailExecutionStage.PRE)
+        )
+        assert names == ["BYO_Guardrail_before_agent"]
+
+    def test_agent_post_registers_only_after_agent(self) -> None:
+        names = _hook_names(
+            _byo(name="BYO Guardrail", stage=GuardrailExecutionStage.POST)
+        )
+        assert names == ["BYO_Guardrail_after_agent"]
+
+    def test_agent_pre_and_post_registers_both(self) -> None:
+        names = _hook_names(_byo(name="BYO Guardrail"))
+        assert sorted(names) == [
+            "BYO_Guardrail_after_agent",
+            "BYO_Guardrail_before_agent",
+        ]
+
+    def test_llm_pre_registers_only_before_model(self) -> None:
+        names = _hook_names(
+            _byo(
+                name="BYO Guardrail",
+                scopes=[GuardrailScope.LLM],
+                stage=GuardrailExecutionStage.PRE,
+            )
+        )
+        assert names == ["BYO_Guardrail_before_model"]
+
+    def test_llm_post_registers_only_after_model(self) -> None:
+        names = _hook_names(
+            _byo(
+                name="BYO Guardrail",
+                scopes=[GuardrailScope.LLM],
+                stage=GuardrailExecutionStage.POST,
+            )
+        )
+        assert names == ["BYO_Guardrail_after_model"]
+
+    def test_tool_scope_registers_one_wrap_tool_call_hook(self) -> None:
+        names = _hook_names(_byo(scopes=[GuardrailScope.TOOL], tools=["my_tool"]))
+        assert len(names) == 1, f"Expected 1 hook, got: {names}"
+        assert "wrap_tool_call" in names[0]
+
+    def test_all_scopes_register_five_hooks(self) -> None:
+        names = _hook_names(
+            _byo(
+                scopes=[
+                    GuardrailScope.AGENT,
+                    GuardrailScope.LLM,
+                    GuardrailScope.TOOL,
+                ],
+                tools=["my_tool"],
+            )
+        )
+        assert len(names) == 5
+        assert sum(1 for n in names if "before" in n) == 2
+        assert sum(1 for n in names if "after" in n) == 2
+        assert sum(1 for n in names if "wrap_tool_call" in n) == 1
+
+
+class TestByoGuardrailEvaluationPath:
+    """The evaluation path forwards the BYO guardrail to the service."""
+
+    def _passed(self) -> GuardrailValidationResult:
+        return GuardrailValidationResult(
+            result=GuardrailValidationResultType.PASSED, reason=""
+        )
+
+    def _failed(self) -> GuardrailValidationResult:
+        return GuardrailValidationResult(
+            result=GuardrailValidationResultType.VALIDATION_FAILED,
+            reason="Harmful content detected",
+        )
+
+    def test_evaluate_forwards_byo_guardrail_to_service(self) -> None:
+        middleware = _byo(connection_id=_CONNECTION_ID)
+        mock_uipath = MagicMock()
+        mock_uipath.guardrails.evaluate_guardrail.return_value = self._passed()
+        middleware._uipath = mock_uipath
+
+        result = middleware._evaluate_guardrail("some input")
+
+        assert result.result == GuardrailValidationResultType.PASSED
+        mock_uipath.guardrails.evaluate_guardrail.assert_called_once()
+        input_data, guardrail = mock_uipath.guardrails.evaluate_guardrail.call_args[0]
+        assert input_data == "some input"
+        assert guardrail.validator_type == BYO_VALIDATOR_TYPE
+        assert guardrail.byo_validator_name == _VALIDATOR_NAME
+        assert guardrail.byo_connection_id == _CONNECTION_ID
+
+    def test_block_action_raises_on_validation_failed(self) -> None:
+        middleware = _byo(action=_BLOCK)
+        with pytest.raises(GuardrailBlockException):
+            middleware._handle_validation_result(self._failed(), "bad input")
+
+    def test_log_action_returns_none_on_validation_failed(self) -> None:
+        middleware = _byo(action=_LOG)
+        assert middleware._handle_validation_result(self._failed(), "bad input") is None
+
+    def test_no_action_on_passed(self) -> None:
+        middleware = _byo(action=_BLOCK)
+        assert middleware._handle_validation_result(self._passed(), "input") is None

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.17"
+version = "0.14.18"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## What changed?

Adds **Bring Your Own Guardrail (BYOG)** support for coded agents — middleware flavor.

**New middleware**

- **`UiPathByoGuardrailMiddleware`** (`src/uipath_langchain/guardrails/middlewares/byo.py`): runs a customer-managed validator (a cloud content-safety subscription, a vendor validation service, or a custom Integration Service connector) configured under **Admin → AI Trust Layer → Guardrails Configurations**. References the configuration by `validator_name` (`byoValidatorName`) + recommended `connection_id`, and builds a `builtInValidator` guardrail with `validator_type="byo"` — reusing the shared `BuiltInGuardrailMiddlewareMixin` hook wiring unchanged (scopes × stage, tool `match_names`, `asyncio.to_thread` offload, exception routing). No changes to the mixin itself.
- `validator_parameters` is an optional passthrough of raw `ValidatorParameter` values, because BYO parameter schemas are defined by the connector. Scopes and stages are developer-supplied: BYOG validators are **not** scope- or stage-restricted, so all three scopes and both stages are available exactly as for the built-in validators.
- Exports from `uipath_langchain.guardrails` and `.middlewares`.

**Small refactor across existing middlewares** (review feedback)

- Extracted `BUILT_IN_VALIDATOR_GUARDRAIL_TYPE` in `middlewares/_base.py` and used it in **all 7** built-in middlewares in place of the repeated `"builtInValidator"` literal. It is typed `Literal["builtInValidator"]` because `GuardrailType.BUILT_IN_VALIDATOR.value` is typed `str` and does not satisfy the model's `Literal` field under mypy.

**Docs & sample**

- `docs/guardrails.md`: new "Bring Your Own Guardrail (BYOG)" section (admin prerequisite, config lookup, error semantics) plus a "Tuning a BYOG validator" subsection covering `validator_parameters`.
- New starter sample `samples/joke-agent-bring-your-own-guardrail/` — joke agent guarded on AGENT (PRE+POST) and TOOL (PRE) scopes, `bindings.json` declaring the IS connection for per-environment rebinding, and a README covering setup, tuning and expected outcomes. All identifiers are **placeholders** (`my-harmful-content-guardrail`, `my-byog-guardrail-connection`, public `uipath-azure-contentsafety-guardrails` connector key), following the `bring-your-own-model` sample convention; the Azure Content Safety parameter example ships commented out so the sample stays vendor-neutral.

**Review feedback addressed** (@valentinabojan)

- **Discovery via the CLI, not the API.** `uip agent guardrails list` replaces the raw `GET agents_/api/designer/byog-guardrails?includeConnectionDetails=true` everywhere (docs, sample README, sample `graph.py`). BYOG configurations are listed alongside the built-in validators, which the docs now call out so the duplicate validator type is not confusing.
- **Parameters discovery via the same command.** The `validator_parameters` guidance now points at the entry's `Parameters` array and names the fields you read from it (`Id`, `Type`, `Required`, `DefaultValue`, `Options`, `KeySource`, `Min`, `Max`, `Step`) instead of "your configuration's validator definition". This also replaced a guess: the previous text said omitting the argument uses "whatever the connector applies by default, which may be its strictest setting" — the definition reports a concrete `DefaultValue`, so the docs now say that.
- **Scopes/stages claim corrected.** The PR previously stated that the connector declares which scopes/stages a validator supports and that an unsupported one surfaces as `PROVIDER_ERROR`. That was wrong. Removed from `docs/guardrails.md`, the sample README, and the `UiPathByoGuardrailMiddleware` docstring, and replaced with the correct behaviour — the developer chooses. The `list` output confirms it: the BYO-backed `harmful_content` entry returns `AllowedScopes: [Agent, Llm, Tool]` with `PreExecution`+`PostExecution` on all three.
- **Removed the "decorator flavor ships separately" note** from the docs and sample README (release sequencing), and softened the neighbouring feature-flag mention to "BYOG not enabled for the tenant".

> ⚠️ **Depends on a CLI follow-up.** The discovery instructions assume the BYOG entries in `uip agent guardrails list` carry the configuration's own validator name and its connection id. Today's output shows `"Validator": "harmful_content"` (the validator *type*) and no connection id, so until that CLI change lands, take both values from **Admin → AI Trust Layer → Guardrails Configurations**.

**Release**

- Version bump to **0.14.18** with `uv.lock` synced. (0.14.17 was taken by #1012 and is published on PyPI; #1014 follows at 0.14.19.)

The decorator flavor is independent and ships separately: `ByoValidator` in UiPath/uipath-python#1833 and its LangChain wiring in #1014.

## How has this been tested?

- `tests/guardrails/middlewares/test_byo.py` — **26 new unit tests**: guardrail construction (`byo` sentinel, `byoValidatorName`/`byoConnectionId` alias serialization, parameter passthrough, defaults), constructor validation errors, hook wiring parity (scopes × stage → `before_*`/`after_*`/`wrap_tool_call`), and the evaluation path (BYO fields reach `evaluate_guardrail`; `BlockAction` raises on `VALIDATION_FAILED`). Wire-payload coverage already exists in `uipath-python`'s `test_guardrails_service.py`, so it is not duplicated here.
- Full suite green; `ruff check`, `ruff format --check`, `mypy` clean; `uv lock --check` clean. Every `python` fence in the BYOG docs section is compile-checked and its imports verified to resolve (the middleware constructs from the documented snippet).
- **Live E2E on alpha** (`AdminStudioTest`) against a real BYOG harmful-content configuration backed by a customer Azure Content Safety connector with `fallbackOnUiPath=false`, via `uipath run` on the new sample. Three `guardrails/validate` calls per run, matching the sample's two registrations (agent PRE, tool PRE, agent POST):
  - benign topic → PASSED → joke returned ✅
  - harmful topic → blocked at `BYOG_Harmful_Content_before_agent`, before the LLM is called, with the vendor verdict *"Harmful content detected: Violence (severity 4)"* ✅
- `validator_parameters` verified across three threshold settings on the same prompts, confirming the connector honours the values rather than merely accepting them:

  | per-category threshold | low-severity topic (2) | high-severity topic (4) |
  |---|---|---|
  | omitted | blocked | blocked |
  | `4` | passes | blocked |
  | `6` | passes | passes |

> Note: since the committed sample now carries placeholder identifiers, running it requires substituting your own configuration's validator name and connection id (same as the `bring-your-own-model` sample).

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] None
- [ ] DB migrations
- [ ] API removals

Purely additive: one new exported middleware class, one new internal constant, plus docs/sample. The `BUILT_IN_VALIDATOR_GUARDRAIL_TYPE` refactor is behaviour-preserving (same string value, now typed). Server-side, BYOG evaluation availability is controlled by the tenant's AI Trust Layer configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
