### PR TITLE
feat: enforce configurable tool timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.14.16"
+version = "0.14.17"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/_utils/durable_interrupt/decorator.py
+++ b/src/uipath_langchain/_utils/durable_interrupt/decorator.py
@@ -33,11 +33,13 @@ index in sync with LangGraph's own ``interrupt_counter``.
 import asyncio
 import contextvars
 import functools
-from typing import Any, Callable, TypeVar
+from datetime import UTC, datetime, timedelta
+from typing import Any, Callable, TypeVar, overload
 
 from langgraph._internal._constants import CONFIG_KEY_SCRATCHPAD
 from langgraph.config import get_config
 from langgraph.types import interrupt
+from uipath.platform.common import WaitUntil, assert_no_timeout
 
 from .skip_interrupt import SkipInterruptValue
 
@@ -94,7 +96,34 @@ def _inject_resume(scratchpad: Any, value: Any) -> Any:
     return value
 
 
-def durable_interrupt(fn: F) -> F:
+def _interrupt_with_timeout(value: Any, timeout: int | None) -> Any:
+    """Interrupt with an optional timeout expressed in milliseconds."""
+    if timeout is None or timeout <= 0:
+        return interrupt(value)
+
+    resume_time = datetime.now(UTC) + timedelta(milliseconds=timeout)
+    return assert_no_timeout(interrupt([value, WaitUntil(resume_time=resume_time)]))
+
+
+def _resume_interrupt(timeout: int | None) -> Any:
+    """Resume an interrupt and raise when its configured timer completed first."""
+    result = interrupt(None)
+    if timeout is None or timeout <= 0:
+        return result
+    return assert_no_timeout(result)
+
+
+@overload
+def durable_interrupt(fn: F, *, timeout: int | None = None) -> F: ...
+
+
+@overload
+def durable_interrupt(*, timeout: int | None = None) -> Callable[[F], F]: ...
+
+
+def durable_interrupt(
+    fn: F | None = None, *, timeout: int | None = None
+) -> F | Callable[[F], F]:
     """Decorator that executes a side-effecting function exactly once and interrupts.
 
     On first execution the body runs and its return value is passed to
@@ -110,9 +139,10 @@ def durable_interrupt(fn: F) -> F:
     decorator that enforces the pairing contract.  Works correctly in both
     parent graphs and subgraphs.
 
-    Supports both sync and async functions::
+    Supports both sync and async functions. Pass ``timeout`` in milliseconds
+    to resume on either the operation or a ``WaitUntil`` timer::
 
-        @durable_interrupt
+        @durable_interrupt(timeout=60_000)
         async def create_task():
             return await client.tasks.create_async(...)
 
@@ -126,28 +156,33 @@ def durable_interrupt(fn: F) -> F:
         result = create_task_sync()
     """
 
-    if asyncio.iscoroutinefunction(fn):
+    def decorate(func: F) -> F:
+        if asyncio.iscoroutinefunction(func):
 
-        @functools.wraps(fn)
-        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            @functools.wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                scratchpad, idx = _next_durable_index()
+                if _is_resumed(scratchpad, idx):
+                    return _resume_interrupt(timeout)
+                result = await func(*args, **kwargs)
+                if isinstance(result, SkipInterruptValue):
+                    return _inject_resume(scratchpad, result.resume_value)
+                return _interrupt_with_timeout(result, timeout)
+
+            return async_wrapper  # type: ignore[return-value]
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             scratchpad, idx = _next_durable_index()
             if _is_resumed(scratchpad, idx):
-                return interrupt(None)
-            result = await fn(*args, **kwargs)
+                return _resume_interrupt(timeout)
+            result = func(*args, **kwargs)
             if isinstance(result, SkipInterruptValue):
                 return _inject_resume(scratchpad, result.resume_value)
-            return interrupt(result)
+            return _interrupt_with_timeout(result, timeout)
 
-        return async_wrapper  # type: ignore[return-value]
+        return sync_wrapper  # type: ignore[return-value]
 
-    @functools.wraps(fn)
-    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
-        scratchpad, idx = _next_durable_index()
-        if _is_resumed(scratchpad, idx):
-            return interrupt(None)
-        result = fn(*args, **kwargs)
-        if isinstance(result, SkipInterruptValue):
-            return _inject_resume(scratchpad, result.resume_value)
-        return interrupt(result)
-
-    return sync_wrapper  # type: ignore[return-value]
+    if fn is None:
+        return decorate
+    return decorate(fn)

--- a/src/uipath_langchain/agent/tools/extraction_tool.py
+++ b/src/uipath_langchain/agent/tools/extraction_tool.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 from langchain.tools import BaseTool
 from langchain_core.messages import ToolCall, ToolMessage
 from langchain_core.tools import StructuredTool
-from langgraph.types import Command, interrupt
+from langgraph.types import Command
 from pydantic import BaseModel, Field
 from uipath.agent.models.agent import AgentIxpExtractionResourceConfig
 from uipath.eval.mocks import mockable
@@ -14,6 +14,7 @@ from uipath.platform.common import DocumentExtraction
 from uipath.platform.documents import ExtractionResponseIXP
 from uipath.platform.errors import EnrichedException
 
+from uipath_langchain._utils.durable_interrupt import durable_interrupt
 from uipath_langchain.agent.react.job_attachments import raise_for_job_attachment_error
 from uipath_langchain.agent.react.types import AgentGraphState
 from uipath_langchain.agent.tools.tool_node import (
@@ -94,13 +95,16 @@ def create_ixp_extraction_tool(
                 attachment_id=attachment.id,
             )
             raise
-        document_extraction_response = interrupt(
-            DocumentExtraction(
+
+        @durable_interrupt(timeout=resource.settings.timeout)
+        async def extract_document() -> Any:
+            return DocumentExtraction(
                 project_name=project_name,
                 tag=version_tag,
                 file_path=attachment_local_file_path,
             )
-        )
+
+        document_extraction_response = await extract_document()
 
         return document_extraction_response
 

--- a/src/uipath_langchain/agent/tools/internal_tools/batch_transform_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/batch_transform_tool.py
@@ -67,6 +67,7 @@ def create_batch_transform_tool(
     tool_name = sanitize_tool_name(resource.name)
     properties = resource.properties
     settings = properties.settings
+    operation_timeout = resource.settings.timeout if resource.settings else None
 
     # Extract settings
     query_setting = settings.query
@@ -130,7 +131,7 @@ def create_batch_transform_tool(
             example_calls=[],  # Examples cannot be provided for internal tools
         )
         async def invoke_batch_transform(**_tool_kwargs: Any):
-            @durable_interrupt
+            @durable_interrupt(timeout=operation_timeout)
             async def create_ephemeral_index():
                 uipath = UiPath()
                 ephemeral_index = (
@@ -150,7 +151,7 @@ def create_batch_transform_tool(
             else:
                 ephemeral_index = index_result
 
-            @durable_interrupt
+            @durable_interrupt(timeout=operation_timeout)
             async def create_batch_transform():
                 return CreateBatchTransform(
                     name=f"task-{uuid.uuid4()}",

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -65,6 +65,7 @@ def create_deeprag_tool(
     tool_name = sanitize_tool_name(resource.name)
     properties = resource.properties
     settings = properties.settings
+    operation_timeout = resource.settings.timeout if resource.settings else None
 
     # Extract settings
     query_setting = settings.query
@@ -114,7 +115,7 @@ def create_deeprag_tool(
             example_calls=[],  # Examples cannot be provided for internal tools
         )
         async def invoke_deeprag(**_tool_kwargs: Any):
-            @durable_interrupt
+            @durable_interrupt(timeout=operation_timeout)
             async def create_ephemeral_index():
                 uipath = UiPath()
                 ephemeral_index = (
@@ -134,7 +135,7 @@ def create_deeprag_tool(
             else:
                 ephemeral_index = index_result
 
-            @durable_interrupt
+            @durable_interrupt(timeout=operation_timeout)
             async def create_deeprag():
                 return CreateDeepRag(
                     name=f"task-{uuid.uuid4()}",

--- a/src/uipath_langchain/agent/tools/process_tool.py
+++ b/src/uipath_langchain/agent/tools/process_tool.py
@@ -75,7 +75,7 @@ def create_process_tool(
             parent_span_id = _span_context.pop("parent_span_id", None)
             parent_operation_id = _bts_context.pop("parent_operation_id", None)
 
-            @durable_interrupt
+            @durable_interrupt(timeout=resource.settings.timeout)
             async def start_job():
                 client = UiPath()
                 try:

--- a/src/uipath_langchain/agent/tools/tool_node.py
+++ b/src/uipath_langchain/agent/tools/tool_node.py
@@ -10,6 +10,7 @@ from langgraph._internal._runnable import RunnableCallable
 from langgraph.errors import GraphBubbleUp
 from langgraph.types import Command
 from pydantic import BaseModel
+from uipath.platform.common import UiPathTimeoutError
 from uipath.platform.resume_triggers import is_no_content_marker
 from uipath.runtime.errors import UiPathErrorCategory
 
@@ -251,15 +252,16 @@ def _wrap_tool_error_handling(
 ) -> RunnableCallable:
     """Wrap a tool node to catch errors and return them as ToolMessages, rather than failing the entire graph execution.
 
-    Catch and re-raise GraphBubbleUp, since LangGraph uses exceptions for interrupt control flow.
-    This is so we don't swallow expected interrupts as tool errors.
+    Catch and re-raise GraphBubbleUp, since LangGraph uses exceptions for interrupt
+    control flow. Also re-raise UiPathTimeoutError so a configured operation timeout
+    fails the agent instead of being returned to the model as a tool result.
     (https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/)
     """
 
     def _func(state: AgentGraphState) -> OutputType:
         try:
             return tool_node.invoke(state)
-        except GraphBubbleUp:
+        except (GraphBubbleUp, UiPathTimeoutError):
             raise
         except Exception as e:
             result = _get_tool_error_result(e, state, tool_name)
@@ -270,7 +272,7 @@ def _wrap_tool_error_handling(
     async def _afunc(state: AgentGraphState) -> OutputType:
         try:
             return await tool_node.ainvoke(state)
-        except GraphBubbleUp:
+        except (GraphBubbleUp, UiPathTimeoutError):
             raise
         except Exception as e:
             result = _get_tool_error_result(e, state, tool_name)

--- a/tests/agent/tools/internal_tools/test_batch_transform_tool.py
+++ b/tests/agent/tools/internal_tools/test_batch_transform_tool.py
@@ -13,11 +13,13 @@ from uipath.agent.models.agent import (
     AgentInternalBatchTransformToolProperties,
     AgentInternalToolResourceConfig,
     AgentInternalToolType,
+    AgentToolSettings,
     BatchTransformFileExtension,
     BatchTransformFileExtensionSetting,
     BatchTransformWebSearchGrounding,
     BatchTransformWebSearchGroundingSetting,
 )
+from uipath.platform.common import WaitUntil
 from uipath.platform.context_grounding.context_grounding_index import (
     ContextGroundingIndex,
 )
@@ -165,7 +167,8 @@ class TestCreateBatchTransformTool:
         resource_config_static,
         mock_llm,
     ):
-        """Test Batch Transform tool with static query when index is immediately ready."""
+        """Test Batch Transform uses a composite interrupt when timeout is configured."""
+        resource_config_static.settings = AgentToolSettings(timeout=60_000)
         # Setup mocks
         mock_uipath = AsyncMock()
         mock_uipath_class.return_value = mock_uipath
@@ -208,6 +211,10 @@ class TestCreateBatchTransformTool:
 
         assert tool.coroutine is not None
         result = await tool.coroutine(attachment=mock_attachment)
+
+        interrupt_value = mock_interrupt.call_args.args[0]
+        assert isinstance(interrupt_value, list)
+        assert isinstance(interrupt_value[1], WaitUntil)
 
         # Verify result contains attachment info
         assert result == {

--- a/tests/agent/tools/internal_tools/test_deeprag_tool.py
+++ b/tests/agent/tools/internal_tools/test_deeprag_tool.py
@@ -12,11 +12,13 @@ from uipath.agent.models.agent import (
     AgentInternalDeepRagToolProperties,
     AgentInternalToolResourceConfig,
     AgentInternalToolType,
+    AgentToolSettings,
     CitationMode,
     DeepRagCitationModeSetting,
     DeepRagFileExtension,
     DeepRagFileExtensionSetting,
 )
+from uipath.platform.common import WaitUntil
 from uipath.platform.context_grounding.context_grounding_index import (
     ContextGroundingIndex,
 )
@@ -136,7 +138,8 @@ class TestCreateDeepRagTool:
         resource_config_static,
         mock_llm,
     ):
-        """Test DeepRAG tool with static query when index is immediately ready."""
+        """Test DeepRAG uses a composite interrupt when timeout is configured."""
+        resource_config_static.settings = AgentToolSettings(timeout=60_000)
         # Setup mocks
         mock_uipath = AsyncMock()
         mock_uipath_class.return_value = mock_uipath
@@ -188,6 +191,9 @@ class TestCreateDeepRagTool:
 
         # Only create_deeprag calls interrupt(); index was instant-resumed
         assert mock_interrupt.call_count == 1
+        interrupt_value = mock_interrupt.call_args.args[0]
+        assert isinstance(interrupt_value, list)
+        assert isinstance(interrupt_value[1], WaitUntil)
 
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"

--- a/tests/agent/tools/test_durable_interrupt.py
+++ b/tests/agent/tools/test_durable_interrupt.py
@@ -1,11 +1,14 @@
 """Tests for the durable_interrupt decorator."""
 
 from collections.abc import Generator
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langgraph._internal._constants import CONFIG_KEY_SCRATCHPAD
+from uipath.core.triggers import UIPATH_METADATA_KEY
+from uipath.platform.common import UiPathTimeoutError, WaitUntil
 
 from uipath_langchain._utils.durable_interrupt import (
     _durable_state,
@@ -117,6 +120,76 @@ class TestAsyncResumeExecution:
 
         mock_interrupt.assert_called_once_with(None)
         assert result == "resume-value"
+
+
+class TestTimeout:
+    """Configured timeouts use a composite interrupt and reject timer resumes."""
+
+    @patch(PATCH_INTERRUPT)
+    @patch(PATCH_GET_CONFIG)
+    async def test_async_first_execution_adds_wait_until(
+        self, mock_get_config: MagicMock, mock_interrupt: MagicMock
+    ) -> None:
+        scratchpad = FakeScratchpad(resume=[])
+        mock_get_config.return_value = _make_config(scratchpad)
+        mock_interrupt.side_effect = lambda value: value
+        before = datetime.now(UTC)
+
+        @durable_interrupt(timeout=60_000)
+        async def start_job() -> dict[str, str]:
+            return {"wait": "job-123"}
+
+        result = await start_job()
+
+        interrupt_value = mock_interrupt.call_args.args[0]
+        assert interrupt_value[0] == {"wait": "job-123"}
+        assert isinstance(interrupt_value[1], WaitUntil)
+        assert interrupt_value[1].resume_time >= before
+        assert result is interrupt_value
+
+    @patch(PATCH_INTERRUPT)
+    @patch(PATCH_GET_CONFIG)
+    def test_sync_first_execution_adds_wait_until(
+        self, mock_get_config: MagicMock, mock_interrupt: MagicMock
+    ) -> None:
+        scratchpad = FakeScratchpad(resume=[])
+        mock_get_config.return_value = _make_config(scratchpad)
+        mock_interrupt.side_effect = lambda value: value
+
+        @durable_interrupt(timeout=30_000)
+        def create_task() -> str:
+            return "task-123"
+
+        result = create_task()
+
+        interrupt_value = mock_interrupt.call_args.args[0]
+        assert interrupt_value[0] == "task-123"
+        assert isinstance(interrupt_value[1], WaitUntil)
+        assert result is interrupt_value
+
+    @patch(PATCH_INTERRUPT)
+    @patch(PATCH_GET_CONFIG)
+    async def test_timeout_resume_raises(
+        self, mock_get_config: MagicMock, mock_interrupt: MagicMock
+    ) -> None:
+        scratchpad = FakeScratchpad(resume=["timer-result"])
+        mock_get_config.return_value = _make_config(scratchpad)
+        timeout_result = {
+            UIPATH_METADATA_KEY: {
+                "triggerType": "Timer",
+                "triggerName": "Timer",
+            }
+        }
+        mock_interrupt.return_value = timeout_result
+
+        @durable_interrupt(timeout=30_000)
+        async def start_job() -> str:
+            return "should-not-reach"
+
+        with pytest.raises(UiPathTimeoutError) as exc_info:
+            await start_job()
+
+        assert exc_info.value.value is timeout_result
 
 
 class TestSyncFirstExecution:

--- a/tests/agent/tools/test_extraction_tool.py
+++ b/tests/agent/tools/test_extraction_tool.py
@@ -8,8 +8,10 @@ import pytest
 from uipath.agent.models.agent import (
     AgentIxpExtractionResourceConfig,
     AgentIxpExtractionToolProperties,
+    AgentToolSettings,
 )
 from uipath.platform.attachments import Attachment
+from uipath.platform.common import WaitUntil
 from uipath.platform.documents import ExtractionResponseIXP
 from uipath.platform.errors import EnrichedException
 from uipath.runtime.errors import UiPathErrorCategory
@@ -166,11 +168,12 @@ class TestExtractionToolFunctionality:
 
     @pytest.mark.asyncio
     @patch("uipath.platform.UiPath")
-    @patch("uipath_langchain.agent.tools.extraction_tool.interrupt")
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     async def test_extraction_tool_downloads_attachment_and_calls_interrupt(
         self, mock_interrupt, mock_uipath_class, extraction_resource
     ):
-        """Test that extraction tool downloads attachment and calls interrupt with correct params."""
+        """Test extraction adds WaitUntil when a timeout is configured."""
+        extraction_resource.settings = AgentToolSettings(timeout=60_000)
         mock_client = MagicMock()
         mock_uipath_class.return_value = mock_client
         mock_client.attachments.download_async = AsyncMock(
@@ -194,16 +197,19 @@ class TestExtractionToolFunctionality:
         )
 
         assert mock_interrupt.called
-        interrupt_arg = mock_interrupt.call_args[0][0]
+        interrupt_value = mock_interrupt.call_args[0][0]
+        assert isinstance(interrupt_value, list)
+        interrupt_arg, wait_until_arg = interrupt_value
         assert interrupt_arg.project_name == "TestProject"
         assert interrupt_arg.tag == "v1.0"
         assert interrupt_arg.file_path == "/path/to/document.pdf"
+        assert isinstance(wait_until_arg, WaitUntil)
 
         assert result == {"extracted_data": {"field1": "value1"}}
 
     @pytest.mark.asyncio
     @patch("uipath.platform.UiPath")
-    @patch("uipath_langchain.agent.tools.extraction_tool.interrupt")
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     async def test_extraction_tool_with_different_version_tag(
         self, mock_interrupt, mock_uipath_class
     ):
@@ -327,7 +333,7 @@ class TestExtractionToolFunctionality:
 
     @pytest.mark.asyncio
     @patch("uipath.platform.UiPath")
-    @patch("uipath_langchain.agent.tools.extraction_tool.interrupt")
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     async def test_extraction_tool_handles_alias_keyed_input(
         self, mock_interrupt, mock_uipath_class, extraction_resource
     ):

--- a/tests/agent/tools/test_process_tool.py
+++ b/tests/agent/tools/test_process_tool.py
@@ -9,7 +9,7 @@ from uipath.agent.models.agent import (
     AgentProcessToolResourceConfig,
     AgentToolType,
 )
-from uipath.platform.common import WaitJob
+from uipath.platform.common import WaitJob, WaitUntil
 from uipath.platform.orchestrator import Job
 
 from uipath_langchain.agent.tools.process_tool import create_process_tool
@@ -188,7 +188,8 @@ class TestProcessToolInvocation:
     async def test_invoke_interrupts_with_wait_job(
         self, mock_uipath_class, mock_interrupt, process_resource
     ):
-        """Test that after invoking, the tool interrupts with WaitJobRaw."""
+        """Test that a configured timeout adds WaitUntil beside WaitJobRaw."""
+        process_resource.settings.timeout = 30_000
         mock_job = MagicMock(spec=Job)
         mock_job.key = "job-key-456"
         mock_job.folder_key = "folder-key-456"
@@ -207,10 +208,13 @@ class TestProcessToolInvocation:
         await tool.ainvoke({})
 
         mock_interrupt.assert_called_once()
-        wait_job_arg = mock_interrupt.call_args[0][0]
+        interrupt_value = mock_interrupt.call_args[0][0]
+        assert isinstance(interrupt_value, list)
+        wait_job_arg, wait_until_arg = interrupt_value
         assert isinstance(wait_job_arg, WaitJob)
         assert wait_job_arg.job == mock_job
         assert wait_job_arg.process_folder_key == "folder-key-456"
+        assert isinstance(wait_until_arg, WaitUntil)
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Shared/DataFolder"})

--- a/tests/agent/tools/test_tool_node.py
+++ b/tests/agent/tools/test_tool_node.py
@@ -10,6 +10,7 @@ from langchain_core.messages.tool import ToolCall, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.types import Command
 from pydantic import BaseModel
+from uipath.platform.common import UiPathTimeoutError
 
 from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
@@ -66,6 +67,19 @@ class MockFailingTool(BaseTool):
 
     async def _arun(self, input_text: str = "") -> str:
         raise ValueError(f"Async tool execution failed: {input_text}")
+
+
+class MockTimeoutTool(BaseTool):
+    """Mock tool that always times out."""
+
+    name: str = "mock_timeout_tool"
+    description: str = "A mock tool that times out"
+
+    def _run(self, input_text: str = "") -> str:
+        raise UiPathTimeoutError({"input": input_text})
+
+    async def _arun(self, input_text: str = "") -> str:
+        raise UiPathTimeoutError({"input": input_text})
 
 
 class FilteredState(BaseModel):
@@ -441,6 +455,26 @@ class TestCreateToolNode:
         assert tool_message.status == "error"
         assert isinstance(tool_message.content, str)
         assert "Async tool execution failed: test input" in tool_message.content
+
+    async def test_wrap_tools_with_error_handling_reraises_timeout(self):
+        """A timeout fails the agent instead of becoming an error ToolMessage."""
+        timeout_tool = MockTimeoutTool()
+        tool_call = {
+            "name": "mock_timeout_tool",
+            "args": {"input_text": "test input"},
+            "id": "test_call_id",
+        }
+        state = AgentGraphState(
+            messages=[AIMessage(content="Using tool", tool_calls=[tool_call])]
+        )
+
+        node = UiPathToolNode(timeout_tool)
+        wrapped = wrap_tools_with_error_handling({"mock_timeout_tool": node})[
+            "mock_timeout_tool"
+        ]
+
+        with pytest.raises(UiPathTimeoutError, match="UiPath interrupt timed out"):
+            await wrapped.ainvoke(state)
 
 
 class TestToolNodeConfirmation:

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.14.16"
+version = "0.14.17"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- enforces configured timeouts for process, IXP, DeepRAG, and Batch Transform operations
- fails agent execution when a timed operation expires
- preserves indefinite waiting when no timeout is configured

## Why

configured tool timeouts were stored but not applied by the runtime.
