### PR TITLE
feat: support runtime system prompt interpolation in advanced agents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.15.1"
+version = "0.15.2"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/_utils/__init__.py
+++ b/src/uipath_langchain/_utils/__init__.py
@@ -4,12 +4,14 @@ from ._otel import (
     set_current_span_error,
     set_span_attribute,
 )
+from ._pydantic import get_unique_model_field_name
 from ._request_mixin import UiPathRequestMixin
 
 __all__ = [
     "UiPathRequestMixin",
     "get_current_span_and_trace_ids",
     "get_execution_folder_path",
+    "get_unique_model_field_name",
     "set_current_span_error",
     "set_span_attribute",
 ]

--- a/src/uipath_langchain/_utils/_pydantic.py
+++ b/src/uipath_langchain/_utils/_pydantic.py
@@ -1,0 +1,42 @@
+"""Shared Pydantic model utilities."""
+
+from pydantic import AliasChoices, AliasPath, BaseModel
+
+
+def get_unique_model_field_name(
+    preferred_name: str,
+    *models: type[BaseModel] | BaseModel | None,
+) -> str:
+    """Return a deterministic field name unused by the supplied Pydantic models."""
+    occupied_names: set[str] = set()
+
+    for model in models:
+        if model is None:
+            continue
+        model_type = model if isinstance(model, type) else type(model)
+        occupied_names.update(model_type.model_fields)
+
+        for field in model_type.model_fields.values():
+            aliases: list[str | AliasPath] = []
+            if field.alias is not None:
+                aliases.append(field.alias)
+            if isinstance(field.validation_alias, AliasChoices):
+                aliases.extend(field.validation_alias.choices)
+            elif field.validation_alias is not None:
+                aliases.append(field.validation_alias)
+
+            for alias in aliases:
+                if isinstance(alias, str):
+                    occupied_names.add(alias)
+                elif alias.path and isinstance(alias.path[0], str):
+                    occupied_names.add(alias.path[0])
+
+    if preferred_name not in occupied_names:
+        return preferred_name
+
+    for suffix in range(1, len(occupied_names) + 1):
+        candidate = f"{preferred_name}_{suffix}"
+        if candidate not in occupied_names:
+            return candidate
+
+    raise AssertionError("A unique model field name must exist")

--- a/src/uipath_langchain/_utils/_pydantic.py
+++ b/src/uipath_langchain/_utils/_pydantic.py
@@ -15,6 +15,7 @@ def get_unique_model_field_name(
             continue
         model_type = model if isinstance(model, type) else type(model)
         occupied_names.update(model_type.model_fields)
+        occupied_names.update(model_type.model_computed_fields)
 
         for field in model_type.model_fields.values():
             aliases: list[str | AliasPath] = []
@@ -30,6 +31,12 @@ def get_unique_model_field_name(
                     occupied_names.add(alias)
                 elif alias.path and isinstance(alias.path[0], str):
                     occupied_names.add(alias.path[0])
+
+        occupied_names.update(
+            field.alias
+            for field in model_type.model_computed_fields.values()
+            if field.alias is not None
+        )
 
     if preferred_name not in occupied_names:
         return preferred_name

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -135,7 +135,7 @@ def create_advanced_agent_graph(
         static_system_prompt = system_prompt
     runtime_system_prompt_key = (
         get_unique_model_field_name(
-            "uipath_system_prompt", AdvancedAgentGraphState, input_schema
+            "uipath__system_prompt", AdvancedAgentGraphState, input_schema
         )
         if build_system_prompt is not None
         else None

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -53,11 +53,13 @@ class _RuntimeSystemPromptMiddleware(AgentMiddleware[AgentState[Any], Any]):
         if request.system_message is None:
             system_message = SystemMessage(content=runtime_prompt)
         else:
-            system_message = SystemMessage(
-                content_blocks=[
-                    {"type": "text", "text": f"{runtime_prompt}\n\n"},
-                    *request.system_message.content_blocks,
-                ]
+            system_message = request.system_message.model_copy(
+                update={
+                    "content": [
+                        {"type": "text", "text": f"{runtime_prompt}\n\n"},
+                        *request.system_message.content_blocks,
+                    ]
+                }
             )
         return request.override(system_message=system_message)
 

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -20,9 +20,10 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool
 from langgraph.graph import END, START
 from langgraph.graph.state import CompiledStateGraph, StateGraph
-from pydantic import AliasChoices, AliasPath, BaseModel, create_model
+from pydantic import BaseModel, create_model
 from uipath.core.chat import UiPathConversationMessageData
 
+from uipath_langchain._utils import get_unique_model_field_name
 from uipath_langchain.agent.react.job_attachments import get_job_attachment_paths
 
 from .types import AdvancedAgentGraphState, ConversationalAdvancedAgentGraphState
@@ -73,40 +74,6 @@ class _RuntimeSystemPromptMiddleware(AgentMiddleware[AgentState[Any], Any]):
         handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
     ) -> ModelResponse[Any]:
         return await handler(self._prepare_request(request))
-
-
-def _allocate_runtime_system_prompt_key(
-    input_schema: type[BaseModel] | None,
-) -> str:
-    """Allocate a graph-state key that cannot overlap the graph's input contract."""
-    occupied_fields = set(AdvancedAgentGraphState.model_fields)
-    if input_schema is not None:
-        occupied_fields.update(input_schema.model_fields)
-        for field in input_schema.model_fields.values():
-            aliases: list[str | AliasPath] = []
-            if field.alias is not None:
-                aliases.append(field.alias)
-            if isinstance(field.validation_alias, AliasChoices):
-                aliases.extend(field.validation_alias.choices)
-            elif field.validation_alias is not None:
-                aliases.append(field.validation_alias)
-
-            for alias in aliases:
-                if isinstance(alias, str):
-                    occupied_fields.add(alias)
-                elif alias.path and isinstance(alias.path[0], str):
-                    occupied_fields.add(alias.path[0])
-
-    default_key = "uipath_system_prompt"
-    if default_key not in occupied_fields:
-        return default_key
-
-    for suffix in range(1, len(occupied_fields) + 1):
-        state_key = f"{default_key}_{suffix}"
-        if state_key not in occupied_fields:
-            return state_key
-
-    raise AssertionError("A free system-prompt state key must exist")
 
 
 def create_advanced_agent(
@@ -165,7 +132,9 @@ def create_advanced_agent_graph(
         build_system_prompt = None
         static_system_prompt = system_prompt
     runtime_system_prompt_key = (
-        _allocate_runtime_system_prompt_key(input_schema)
+        get_unique_model_field_name(
+            "uipath_system_prompt", AdvancedAgentGraphState, input_schema
+        )
         if build_system_prompt is not None
         else None
     )

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -1,20 +1,26 @@
 """Advanced agent builder."""
 
-from collections.abc import Callable, Sequence
-from typing import Any
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, NotRequired, cast
 
 from deepagents import CompiledSubAgent, SubAgent
 from deepagents import create_deep_agent as _create_deep_agent
 from deepagents.backends import BackendProtocol
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import BackendFactory
+from langchain.agents.middleware import (
+    AgentMiddleware,
+    AgentState,
+    ModelRequest,
+    ModelResponse,
+)
 from langchain.agents.structured_output import ResponseFormat
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool
 from langgraph.graph import END, START
 from langgraph.graph.state import CompiledStateGraph, StateGraph
-from pydantic import BaseModel
+from pydantic import AliasChoices, AliasPath, BaseModel, create_model
 from uipath.core.chat import UiPathConversationMessageData
 
 from uipath_langchain.agent.react.job_attachments import get_job_attachment_paths
@@ -27,14 +33,91 @@ from .utils import (
 )
 
 
+class _RuntimeSystemPromptMiddleware(AgentMiddleware[AgentState[Any], Any]):
+    """Attach a once-resolved invocation prompt to every model request."""
+
+    def __init__(self, state_key: str) -> None:
+        self.state_key = state_key
+        self.state_schema = type(
+            "RuntimeSystemPromptState",
+            (AgentState,),
+            {"__annotations__": {state_key: NotRequired[str | None]}},
+        )
+
+    def _prepare_request(self, request: ModelRequest[Any]) -> ModelRequest[Any]:
+        runtime_prompt = cast("str | None", request.state.get(self.state_key))
+        if runtime_prompt is None:
+            return request
+
+        if request.system_message is None:
+            system_message = SystemMessage(content=runtime_prompt)
+        else:
+            system_message = SystemMessage(
+                content_blocks=[
+                    {"type": "text", "text": f"{runtime_prompt}\n\n"},
+                    *request.system_message.content_blocks,
+                ]
+            )
+        return request.override(system_message=system_message)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        return handler(self._prepare_request(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
+    ) -> ModelResponse[Any]:
+        return await handler(self._prepare_request(request))
+
+
+def _allocate_runtime_system_prompt_key(
+    input_schema: type[BaseModel] | None,
+) -> str:
+    """Allocate a graph-state key that cannot overlap the graph's input contract."""
+    occupied_fields = set(AdvancedAgentGraphState.model_fields)
+    if input_schema is not None:
+        occupied_fields.update(input_schema.model_fields)
+        for field in input_schema.model_fields.values():
+            aliases: list[str | AliasPath] = []
+            if field.alias is not None:
+                aliases.append(field.alias)
+            if isinstance(field.validation_alias, AliasChoices):
+                aliases.extend(field.validation_alias.choices)
+            elif field.validation_alias is not None:
+                aliases.append(field.validation_alias)
+
+            for alias in aliases:
+                if isinstance(alias, str):
+                    occupied_fields.add(alias)
+                elif alias.path and isinstance(alias.path[0], str):
+                    occupied_fields.add(alias.path[0])
+
+    default_key = "uipath_system_prompt"
+    if default_key not in occupied_fields:
+        return default_key
+
+    for suffix in range(1, len(occupied_fields) + 1):
+        state_key = f"{default_key}_{suffix}"
+        if state_key not in occupied_fields:
+            return state_key
+
+    raise AssertionError("A free system-prompt state key must exist")
+
+
 def create_advanced_agent(
     model: BaseChatModel,
-    system_prompt: str = "",
+    system_prompt: str | SystemMessage | None = "",
     tools: Sequence[BaseTool] = (),
     subagents: Sequence[SubAgent | CompiledSubAgent] = (),
     backend: BackendProtocol | BackendFactory | None = None,
     response_format: ResponseFormat[Any] | None = None,
     memory: Sequence[str] = (),
+    middleware: Sequence[AgentMiddleware[Any, Any]] = (),
 ) -> CompiledStateGraph[Any, Any, Any, Any]:
     """Create a deepagents agent with planning, filesystem, and sub-agent tools.
 
@@ -50,13 +133,14 @@ def create_advanced_agent(
         backend=backend,
         response_format=response_format,
         memory=list(memory) or None,
+        middleware=list(middleware),
     )
 
 
 def create_advanced_agent_graph(
     model: BaseChatModel,
     tools: Sequence[BaseTool],
-    system_prompt: str,
+    system_prompt: str | Callable[[dict[str, Any]], str],
     backend: BackendProtocol | BackendFactory | None,
     response_format: ResponseFormat[Any] | None,
     input_schema: type[BaseModel] | None,
@@ -74,18 +158,45 @@ def create_advanced_agent_graph(
     memory_sources = (
         [MEMORY_INDEX_VIRTUAL_PATH] if isinstance(backend, FilesystemBackend) else []
     )
+    if callable(system_prompt):
+        build_system_prompt = system_prompt
+        static_system_prompt = None
+    else:
+        build_system_prompt = None
+        static_system_prompt = system_prompt
+    runtime_system_prompt_key = (
+        _allocate_runtime_system_prompt_key(input_schema)
+        if build_system_prompt is not None
+        else None
+    )
 
     inner_graph = create_advanced_agent(
         model=model,
         tools=tools,
-        system_prompt=system_prompt,
+        system_prompt=static_system_prompt,
         backend=backend,
         response_format=response_format,
         memory=memory_sources,
+        middleware=(
+            [_RuntimeSystemPromptMiddleware(runtime_system_prompt_key)]
+            if runtime_system_prompt_key is not None
+            else []
+        ),
     )
 
     wrapper_state = create_state_with_input(input_schema)
+    if runtime_system_prompt_key is not None:
+        runtime_state_field: dict[str, Any] = {
+            runtime_system_prompt_key: (str | None, None)
+        }
+        wrapper_state = create_model(
+            "RuntimeAdvancedAgentGraphState",
+            __base__=wrapper_state,
+            **runtime_state_field,
+        )
     internal_fields = set(AdvancedAgentGraphState.model_fields.keys())
+    if runtime_system_prompt_key is not None:
+        internal_fields.add(runtime_system_prompt_key)
     attachment_paths = (
         get_job_attachment_paths(input_schema) if input_schema is not None else []
     )
@@ -103,7 +214,12 @@ def create_advanced_agent_graph(
                 backend, attachment_paths, input_args
             )
         user_text = build_user_message(input_args)
-        return {"messages": [HumanMessage(content=user_text, id="user-input")]}
+        update: dict[str, Any] = {
+            "messages": [HumanMessage(content=user_text, id="user-input")]
+        }
+        if build_system_prompt is not None and runtime_system_prompt_key is not None:
+            update[runtime_system_prompt_key] = build_system_prompt(input_args)
+        return update
 
     def transform_output(state: BaseModel) -> dict[str, Any]:
         structured = getattr(state, "structured_response", {})

--- a/tests/agent/advanced/test_create_advanced_agent_graph.py
+++ b/tests/agent/advanced/test_create_advanced_agent_graph.py
@@ -296,7 +296,13 @@ def test_runtime_system_prompt_middleware_preserves_prepared_prompt() -> None:
     request = ModelRequest(
         model=_mock_model(),
         messages=[],
-        system_message=SystemMessage(content_blocks=cast(Any, prepared_blocks)),
+        system_message=SystemMessage(
+            content_blocks=cast(Any, prepared_blocks),
+            id="prepared-system-message",
+            name="prepared-system",
+            additional_kwargs={"provider": "value"},
+            response_metadata={"response": "value"},
+        ),
         state=cast(
             Any,
             {
@@ -316,6 +322,10 @@ def test_runtime_system_prompt_middleware_preserves_prepared_prompt() -> None:
     assert captured[0].system_message is not None
     assert captured[0].system_message.text == ("runtime prompt\n\ndeepagents prompt")
     assert captured[0].system_message.content_blocks[1:] == prepared_blocks
+    assert captured[0].system_message.id == "prepared-system-message"
+    assert captured[0].system_message.name == "prepared-system"
+    assert captured[0].system_message.additional_kwargs == {"provider": "value"}
+    assert captured[0].system_message.response_metadata == {"response": "value"}
 
 
 @pytest.mark.asyncio

--- a/tests/agent/advanced/test_create_advanced_agent_graph.py
+++ b/tests/agent/advanced/test_create_advanced_agent_graph.py
@@ -8,10 +8,9 @@ from langchain.agents.middleware import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableLambda
-from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from uipath_langchain.agent.advanced.agent import (
-    _allocate_runtime_system_prompt_key,
     _RuntimeSystemPromptMiddleware,
     create_advanced_agent_graph,
 )
@@ -80,26 +79,6 @@ def test_callable_system_prompt_enables_runtime_middleware() -> None:
     assert len(call_kwargs["middleware"]) == 1
     assert isinstance(call_kwargs["middleware"][0], _RuntimeSystemPromptMiddleware)
     assert call_kwargs["middleware"][0].state_key == "uipath_system_prompt"
-
-
-@pytest.mark.parametrize(
-    "validation_alias",
-    [
-        "uipath_system_prompt",
-        AliasChoices("uipath_system_prompt", "prompt"),
-        AliasPath("uipath_system_prompt", "value"),
-    ],
-)
-def test_runtime_prompt_key_avoids_input_aliases(
-    validation_alias: str | AliasChoices | AliasPath,
-) -> None:
-    class AliasedPromptInput(BaseModel):
-        prompt: str = Field(validation_alias=validation_alias)
-
-    assert (
-        _allocate_runtime_system_prompt_key(AliasedPromptInput)
-        == "uipath_system_prompt_1"
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/agent/advanced/test_create_advanced_agent_graph.py
+++ b/tests/agent/advanced/test_create_advanced_agent_graph.py
@@ -35,8 +35,8 @@ class _AliasedInput(BaseModel):
 
 
 class _PromptNamedInput(BaseModel):
-    uipath_system_prompt: str
-    uipath_system_prompt_1: str
+    uipath__system_prompt: str
+    uipath__system_prompt_1: str
 
 
 def _mock_model() -> MagicMock:
@@ -78,7 +78,7 @@ def test_callable_system_prompt_enables_runtime_middleware() -> None:
     assert call_kwargs["system_prompt"] is None
     assert len(call_kwargs["middleware"]) == 1
     assert isinstance(call_kwargs["middleware"][0], _RuntimeSystemPromptMiddleware)
-    assert call_kwargs["middleware"][0].state_key == "uipath_system_prompt"
+    assert call_kwargs["middleware"][0].state_key == "uipath__system_prompt"
 
 
 @pytest.mark.asyncio
@@ -92,7 +92,7 @@ async def test_transform_input_without_schema_builds_single_user_message() -> No
     assert isinstance(message, HumanMessage)
     assert message.content == "hi there"
     assert message.id == "user-input"
-    assert "uipath_system_prompt" not in out
+    assert "uipath__system_prompt" not in out
 
 
 @pytest.mark.asyncio
@@ -114,15 +114,15 @@ async def test_transform_input_builds_runtime_system_prompt_once() -> None:
     out = await graph.nodes["transform_input"].runnable.ainvoke(state)
 
     assert calls == [{"book": {}, "question": "runtime value"}]
-    assert out["uipath_system_prompt"] == "system:runtime value"
+    assert out["uipath__system_prompt"] == "system:runtime value"
 
 
 @pytest.mark.asyncio
 async def test_internal_prompt_state_does_not_shadow_user_input() -> None:
     """A generated collision is rejected in favor of a fresh internal state key."""
     captured_args: list[dict[str, Any]] = []
-    colliding_key = "uipath_system_prompt"
-    fresh_key = "uipath_system_prompt_2"
+    colliding_key = "uipath__system_prompt"
+    fresh_key = "uipath__system_prompt_2"
 
     def build_user_message(args: dict[str, Any]) -> str:
         captured_args.append(args)
@@ -135,8 +135,8 @@ async def test_internal_prompt_state_does_not_shadow_user_input() -> None:
     )
     state_cls = create_state_with_input(_PromptNamedInput)
     state = state_cls(
-        uipath_system_prompt="user value",
-        uipath_system_prompt_1="another user value",
+        uipath__system_prompt="user value",
+        uipath__system_prompt_1="another user value",
     )
 
     out = await graph.nodes["transform_input"].runnable.ainvoke(state)
@@ -144,7 +144,7 @@ async def test_internal_prompt_state_does_not_shadow_user_input() -> None:
     assert captured_args == [
         {
             colliding_key: "user value",
-            "uipath_system_prompt_1": "another user value",
+            "uipath__system_prompt_1": "another user value",
         }
     ]
     assert out[fresh_key] == "system:user value"

--- a/tests/agent/advanced/test_create_advanced_agent_graph.py
+++ b/tests/agent/advanced/test_create_advanced_agent_graph.py
@@ -1,14 +1,20 @@
 """Tests for the create_advanced_agent_graph wrapper builder."""
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain.agents.middleware import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import HumanMessage
-from pydantic import BaseModel, ConfigDict, Field
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.runnables import RunnableLambda
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field
 
-from uipath_langchain.agent.advanced.agent import create_advanced_agent_graph
+from uipath_langchain.agent.advanced.agent import (
+    _allocate_runtime_system_prompt_key,
+    _RuntimeSystemPromptMiddleware,
+    create_advanced_agent_graph,
+)
 from uipath_langchain.agent.advanced.types import AdvancedAgentGraphState
 from uipath_langchain.agent.advanced.utils import create_state_with_input
 
@@ -27,6 +33,11 @@ class _AliasedInput(BaseModel):
 
     schema_: str = Field(alias="schema")
     question: str = ""
+
+
+class _PromptNamedInput(BaseModel):
+    uipath_system_prompt: str
+    uipath_system_prompt_1: str
 
 
 def _mock_model() -> MagicMock:
@@ -56,6 +67,41 @@ def test_wrapper_graph_has_io_nodes() -> None:
     assert {"transform_input", "advanced_agent", "transform_output"} <= set(graph.nodes)
 
 
+def test_callable_system_prompt_enables_runtime_middleware() -> None:
+    """The inner deep agent keeps its base prompt and receives runtime middleware."""
+    with patch(
+        "uipath_langchain.agent.advanced.agent._create_deep_agent",
+        return_value=MagicMock(),
+    ) as mock_create:
+        _build(system_prompt=lambda args: f"system:{args}")
+
+    call_kwargs = mock_create.call_args.kwargs
+    assert call_kwargs["system_prompt"] is None
+    assert len(call_kwargs["middleware"]) == 1
+    assert isinstance(call_kwargs["middleware"][0], _RuntimeSystemPromptMiddleware)
+    assert call_kwargs["middleware"][0].state_key == "uipath_system_prompt"
+
+
+@pytest.mark.parametrize(
+    "validation_alias",
+    [
+        "uipath_system_prompt",
+        AliasChoices("uipath_system_prompt", "prompt"),
+        AliasPath("uipath_system_prompt", "value"),
+    ],
+)
+def test_runtime_prompt_key_avoids_input_aliases(
+    validation_alias: str | AliasChoices | AliasPath,
+) -> None:
+    class AliasedPromptInput(BaseModel):
+        prompt: str = Field(validation_alias=validation_alias)
+
+    assert (
+        _allocate_runtime_system_prompt_key(AliasedPromptInput)
+        == "uipath_system_prompt_1"
+    )
+
+
 @pytest.mark.asyncio
 async def test_transform_input_without_schema_builds_single_user_message() -> None:
     """With no input schema, the built message comes straight from build_user_message."""
@@ -67,6 +113,137 @@ async def test_transform_input_without_schema_builds_single_user_message() -> No
     assert isinstance(message, HumanMessage)
     assert message.content == "hi there"
     assert message.id == "user-input"
+    assert "uipath_system_prompt" not in out
+
+
+@pytest.mark.asyncio
+async def test_transform_input_builds_runtime_system_prompt_once() -> None:
+    """A callable system prompt is resolved from invocation input by the pre-node."""
+    calls: list[dict[str, Any]] = []
+
+    def build_system_prompt(args: dict[str, Any]) -> str:
+        calls.append(args)
+        return f"system:{args['question']}"
+
+    graph = _build(
+        input_schema=_Input,
+        system_prompt=build_system_prompt,
+    )
+    state_cls = create_state_with_input(_Input)
+    state = state_cls(question="runtime value")
+
+    out = await graph.nodes["transform_input"].runnable.ainvoke(state)
+
+    assert calls == [{"book": {}, "question": "runtime value"}]
+    assert out["uipath_system_prompt"] == "system:runtime value"
+
+
+@pytest.mark.asyncio
+async def test_internal_prompt_state_does_not_shadow_user_input() -> None:
+    """A generated collision is rejected in favor of a fresh internal state key."""
+    captured_args: list[dict[str, Any]] = []
+    colliding_key = "uipath_system_prompt"
+    fresh_key = "uipath_system_prompt_2"
+
+    def build_user_message(args: dict[str, Any]) -> str:
+        captured_args.append(args)
+        return "user"
+
+    graph = _build(
+        input_schema=_PromptNamedInput,
+        system_prompt=lambda args: f"system:{args[colliding_key]}",
+        build_user_message=build_user_message,
+    )
+    state_cls = create_state_with_input(_PromptNamedInput)
+    state = state_cls(
+        uipath_system_prompt="user value",
+        uipath_system_prompt_1="another user value",
+    )
+
+    out = await graph.nodes["transform_input"].runnable.ainvoke(state)
+
+    assert captured_args == [
+        {
+            colliding_key: "user value",
+            "uipath_system_prompt_1": "another user value",
+        }
+    ]
+    assert out[fresh_key] == "system:user value"
+
+
+@pytest.mark.asyncio
+async def test_runtime_system_prompt_crosses_into_deep_agent_once() -> None:
+    """The wrapper carries one resolved prompt into the deep-agent state schema."""
+    resolver_calls: list[dict[str, Any]] = []
+    captured_requests: list[ModelRequest[Any]] = []
+    prepared_blocks = [
+        {
+            "type": "text",
+            "text": "deepagents prompt",
+            "cache_control": {"type": "ephemeral"},
+        },
+        {"type": "non_standard", "value": {"custom": "value"}},
+    ]
+
+    def build_system_prompt(args: dict[str, Any]) -> str:
+        resolver_calls.append(args)
+        return f"runtime:{args['question']}"
+
+    def create_inner_graph(**kwargs: Any) -> Any:
+        middleware = kwargs["middleware"][0]
+        runtime_key = middleware.state_key
+
+        def capture_model_request(state: BaseModel) -> dict[str, Any]:
+            state_data = state.model_dump()
+            assert runtime_key in state_data
+            state_data["messages"] = cast(Any, state).messages
+            request = ModelRequest(
+                model=_mock_model(),
+                messages=state_data["messages"],
+                system_message=SystemMessage(content_blocks=cast(Any, prepared_blocks)),
+                state=cast(Any, state_data),
+            )
+
+            def handler(prepared: ModelRequest[Any]) -> ModelResponse[Any]:
+                captured_requests.append(prepared)
+                return ModelResponse(result=[])
+
+            middleware.wrap_model_call(request, handler)
+            return {"structured_response": {"result": "done"}}
+
+        return RunnableLambda(capture_model_request)
+
+    with patch(
+        "uipath_langchain.agent.advanced.agent._create_deep_agent",
+        side_effect=create_inner_graph,
+    ):
+        wrapper = create_advanced_agent_graph(
+            model=_mock_model(),
+            tools=[],
+            system_prompt=build_system_prompt,
+            backend=None,
+            response_format=None,
+            input_schema=_Input,
+            output_schema=_Output,
+            build_user_message=lambda args: f"user:{args['question']}",
+        )
+        initial_state = wrapper.state_schema(question="value")
+        transform_node = cast(Any, wrapper.nodes["transform_input"].runnable)
+        transform_update = await transform_node.ainvoke(initial_state)
+        inner_input = wrapper.state_schema(question="value", **transform_update)
+        inner_node = cast(Any, wrapper.nodes["advanced_agent"].runnable)
+
+        result = inner_node.invoke(inner_input)
+
+    assert result == {"structured_response": {"result": "done"}}
+    assert resolver_calls == [{"book": {}, "question": "value"}]
+    assert len(captured_requests) == 1
+    request = captured_requests[0]
+    assert request.system_message is not None
+    assert request.system_message.text == "runtime:value\n\ndeepagents prompt"
+    assert request.system_message.content_blocks[1:] == prepared_blocks
+    assert isinstance(request.messages[0], HumanMessage)
+    assert request.messages[0].content == "user:value"
 
 
 @pytest.mark.asyncio
@@ -124,3 +301,66 @@ def test_transform_output_validates_structured_response() -> None:
         AdvancedAgentGraphState(structured_response={"result": "done"})
     )
     assert out == {"result": "done"}
+
+
+def test_runtime_system_prompt_middleware_preserves_prepared_prompt() -> None:
+    """The runtime prompt is prepended without discarding deepagents' prompt."""
+    middleware = _RuntimeSystemPromptMiddleware("runtime_prompt")
+    prepared_blocks = [
+        {
+            "type": "text",
+            "text": "deepagents prompt",
+            "cache_control": {"type": "ephemeral"},
+        },
+        {"type": "non_standard", "value": {"custom": "value"}},
+    ]
+    request = ModelRequest(
+        model=_mock_model(),
+        messages=[],
+        system_message=SystemMessage(content_blocks=cast(Any, prepared_blocks)),
+        state=cast(
+            Any,
+            {
+                "messages": [],
+                middleware.state_key: "runtime prompt",
+            },
+        ),
+    )
+    captured: list[ModelRequest[Any]] = []
+
+    def handler(prepared: ModelRequest[Any]) -> ModelResponse[Any]:
+        captured.append(prepared)
+        return ModelResponse(result=[])
+
+    middleware.wrap_model_call(request, handler)
+
+    assert captured[0].system_message is not None
+    assert captured[0].system_message.text == ("runtime prompt\n\ndeepagents prompt")
+    assert captured[0].system_message.content_blocks[1:] == prepared_blocks
+
+
+@pytest.mark.asyncio
+async def test_runtime_system_prompt_middleware_supports_async_model_calls() -> None:
+    middleware = _RuntimeSystemPromptMiddleware("runtime_prompt")
+    request = ModelRequest(
+        model=_mock_model(),
+        messages=[],
+        system_message=SystemMessage(content="deepagents prompt"),
+        state=cast(
+            Any,
+            {
+                "messages": [],
+                middleware.state_key: "runtime prompt",
+            },
+        ),
+    )
+    captured: list[ModelRequest[Any]] = []
+
+    async def handler(prepared: ModelRequest[Any]) -> ModelResponse[Any]:
+        captured.append(prepared)
+        return ModelResponse(result=[])
+
+    await middleware.awrap_model_call(request, handler)
+
+    assert captured[0].system_message is not None
+    assert captured[0].system_message.text == ("runtime prompt\n\ndeepagents prompt")

--- a/tests/agent/advanced/test_utils.py
+++ b/tests/agent/advanced/test_utils.py
@@ -33,6 +33,17 @@ def test_create_state_merges_schema_with_state() -> None:
     assert "question" in merged.model_fields
 
 
+def test_create_state_does_not_retain_extra_fields() -> None:
+    """The combined deep-agent state must not silently allow undeclared keys."""
+    state_type = create_state_with_input(_InputSchema)
+    state = state_type.model_validate(
+        {"question": "value", "undeclared": "extra"}
+    )
+
+    assert state_type.model_config.get("extra") != "allow"
+    assert "undeclared" not in state.model_dump()
+
+
 @pytest.mark.asyncio
 async def test_resolve_input_attachments_downloads_and_adds_filepath(
     tmp_path: Path,

--- a/tests/agent/advanced/test_utils.py
+++ b/tests/agent/advanced/test_utils.py
@@ -36,9 +36,7 @@ def test_create_state_merges_schema_with_state() -> None:
 def test_create_state_does_not_retain_extra_fields() -> None:
     """The combined deep-agent state must not silently allow undeclared keys."""
     state_type = create_state_with_input(_InputSchema)
-    state = state_type.model_validate(
-        {"question": "value", "undeclared": "extra"}
-    )
+    state = state_type.model_validate({"question": "value", "undeclared": "extra"})
 
     assert state_type.model_config.get("extra") != "allow"
     assert "undeclared" not in state.model_dump()

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -1,7 +1,7 @@
 """Tests for shared Pydantic model utilities."""
 
 import pytest
-from pydantic import AliasChoices, AliasPath, BaseModel, Field
+from pydantic import AliasChoices, AliasPath, BaseModel, Field, computed_field
 
 from uipath_langchain._utils import get_unique_model_field_name
 
@@ -20,6 +20,15 @@ def test_unique_model_field_name_accepts_classes_and_instances() -> None:
 
     assert get_unique_model_field_name("state_key", instance) == "state_key_2"
     assert get_unique_model_field_name("state_key", _OccupiedNames) == "state_key_2"
+
+
+def test_unique_model_field_name_avoids_computed_fields_and_aliases() -> None:
+    class ComputedNames(BaseModel):
+        @computed_field(alias="state_key_1")
+        def state_key(self) -> str:
+            return "value"
+
+    assert get_unique_model_field_name("state_key", ComputedNames) == "state_key_2"
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -1,0 +1,39 @@
+"""Tests for shared Pydantic model utilities."""
+
+import pytest
+from pydantic import AliasChoices, AliasPath, BaseModel, Field
+
+from uipath_langchain._utils import get_unique_model_field_name
+
+
+class _OccupiedNames(BaseModel):
+    state_key: str
+    state_key_1: str
+
+
+def test_unique_model_field_name_uses_preferred_name_when_available() -> None:
+    assert get_unique_model_field_name("state_key", None) == "state_key"
+
+
+def test_unique_model_field_name_accepts_classes_and_instances() -> None:
+    instance = _OccupiedNames(state_key="value", state_key_1="value")
+
+    assert get_unique_model_field_name("state_key", instance) == "state_key_2"
+    assert get_unique_model_field_name("state_key", _OccupiedNames) == "state_key_2"
+
+
+@pytest.mark.parametrize(
+    "validation_alias",
+    [
+        "state_key",
+        AliasChoices("state_key", "value"),
+        AliasPath("state_key", "value"),
+    ],
+)
+def test_unique_model_field_name_avoids_validation_aliases(
+    validation_alias: str | AliasChoices | AliasPath,
+) -> None:
+    class AliasedInput(BaseModel):
+        value: str = Field(validation_alias=validation_alias)
+
+    assert get_unique_model_field_name("state_key", AliasedInput) == "state_key_1"

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- accept callable system prompts in `create_advanced_agent_graph` and resolve them once from invocation inputs
- carry the resolved prompt through dynamically declared graph state and prepend it to each Deep Agents model request
- preserve the prepared Deep Agents prompt content blocks, prompt ordering, and cache metadata
- avoid input-schema collisions by using `uipath__system_prompt` by default and selecting the first available deterministic suffix
- bump `uipath-langchain` to 0.14.20

## Verification

- `uv lock --check`
- Ruff format and lint
- mypy on changed implementation and tests
- targeted advanced-agent and workspace-memory tests (16 passed)
- manual local validation