### PR TITLE
fix: state allowed values in integration tool arg descriptions

### DIFF
--- a/src/uipath_langchain/agent/tools/integration_tool.py
+++ b/src/uipath_langchain/agent/tools/integration_tool.py
@@ -31,7 +31,7 @@ from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
     create_output_model,
 )
 
-from .schema_editing import strip_enum
+from .schema_editing import handle_enum
 from .structured_tool_with_argument_properties import (
     StructuredToolWithArgumentProperties,
 )
@@ -172,7 +172,7 @@ def strip_enums_from_schema(
 
     for param in parameters:
         segments = _param_name_to_segments(param.name)
-        strip_enum(schema, segments)
+        handle_enum(schema, segments)
 
     return schema
 

--- a/src/uipath_langchain/agent/tools/schema_editing.py
+++ b/src/uipath_langchain/agent/tools/schema_editing.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+import re
 from typing import Any
 
 from jsonpath_ng import (  # type: ignore[import-untyped]
@@ -16,6 +17,8 @@ from jsonpath_ng import (  # type: ignore[import-untyped]
 STATIC_ARGUMENT_DESCRIPTION = (
     "This argument is pre-configured and will be overwritten. Leave it empty"
 )
+
+_TEMPLATE_VALUE_PATTERN = re.compile(r"^\{\{.+\}\}$")
 
 
 class SchemaNavigationError(ValueError):
@@ -114,11 +117,15 @@ def _navigate_schema_inlining_refs(
     return current
 
 
-def strip_enum(
+def handle_enum(
     schema: dict[str, Any],
     path_segments: list[str],
 ) -> None:
-    """Navigate to a field in schema and remove its enum constraint.
+    """Navigate to a field in schema and fold its allowed value(s) into the description.
+
+    States the allowed value(s) in plain text in the field's description, in
+    addition to whatever enum/oneOf/const constraint is already there. Removes
+    the redundant `enum` key.
 
     If the path doesn't exist in the schema, this is a no-op.
 
@@ -130,6 +137,22 @@ def strip_enum(
         field_schema = _navigate_schema_inlining_refs(schema, path_segments)
     except SchemaNavigationError:
         return
+
+    values = field_schema.get("enum")
+    if not values and isinstance(field_schema.get("oneOf"), list):
+        values = [
+            branch["const"]
+            for branch in field_schema["oneOf"]
+            if isinstance(branch, dict) and "const" in branch
+        ]
+
+    # Skip templated placeholders ({{arg}}), those aren't real allowed values.
+    if values and not any(
+        isinstance(v, str) and _TEMPLATE_VALUE_PATTERN.match(v) for v in values
+    ):
+        hint = f"Allowed value(s): {', '.join(str(v) for v in values)}."
+        description = field_schema.get("description")
+        field_schema["description"] = f"{description} ({hint})" if description else hint
 
     field_schema.pop("enum", None)
 

--- a/tests/agent/tools/test_integration_tool.py
+++ b/tests/agent/tools/test_integration_tool.py
@@ -566,6 +566,7 @@ class TestStripEnumsFromSchema:
         result = strip_enums_from_schema(schema, parameters)
 
         assert "enum" not in result["properties"]["title"]
+        assert "Custom title" in result["properties"]["title"]["description"]
 
     def test_handles_schema_without_properties(self):
         """A schema with no properties key is returned unchanged."""
@@ -739,6 +740,50 @@ class TestStripEnumsFromSchema:
         result = strip_enums_from_schema(schema, parameters)
 
         assert result == schema
+
+    def test_folds_oneof_const_value_into_description(self):
+        """A field whose fixed value is encoded as both `enum` and `oneOf`/`const`
+        gets its value folded into the description."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "engine": {
+                    "type": "string",
+                    "title": "Search Engine",
+                    "description": "The search engine to use",
+                    "oneOf": [
+                        {"const": "PlaceholderEngine", "title": "PlaceholderEngine"}
+                    ],
+                    "enum": ["PlaceholderEngine"],
+                },
+                "query": {
+                    "type": "string",
+                    "description": "The natural language query to search for",
+                },
+            },
+            "required": ["engine", "query"],
+        }
+        parameters = [
+            AgentIntegrationToolParameter(
+                name="engine",
+                type="string",
+                value="PlaceholderEngine",
+                field_location="body",
+                field_variant="static",
+            ),
+        ]
+
+        result = strip_enums_from_schema(schema, parameters)
+
+        engine_schema = result["properties"]["engine"]
+        assert "enum" not in engine_schema
+        assert engine_schema["oneOf"] == [
+            {"const": "PlaceholderEngine", "title": "PlaceholderEngine"}
+        ]
+        assert engine_schema["type"] == "string"
+        assert engine_schema["title"] == "Search Engine"
+        assert engine_schema["description"].startswith("The search engine to use")
+        assert "PlaceholderEngine" in engine_schema["description"]
 
 
 class TestCreateIntegrationToolWithArgumentProperties:


### PR DESCRIPTION
## Summary
- an integration tool argument pinned to a single legal value could still come back from the model with a different value, failing the call
- the allowed value(s) are now stated in plain text in the argument's description, which the model follows more reliably than a bare schema constraint
- values are read from `enum`, or from the const branches of a `oneOf`, and templated placeholders are skipped since those are not real allowed values
- the constraint itself is left untouched, so validation behavior is unchanged

## Why

A schema-level `enum` is not reliably honored when the model generates a tool call, so it is worth also saying it in the description. Hit in practice on the Web Search tool's `provider` argument, which is fixed to one value but was being sent as `serpapi` or `google`.