### PR TITLE
fix: categorize analyze files 5xx errors as system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.15.0"
+version = "0.15.1"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/exceptions/licensing.py
+++ b/src/uipath_langchain/agent/exceptions/licensing.py
@@ -23,6 +23,15 @@ _LLM_STATUS_CODE_MAP: dict[int, AgentRuntimeErrorCode] = {
 }
 
 
+def _category_for_status(status_code: int) -> UiPathErrorCategory:
+    """Map LLM provider HTTP statuses to their runtime error category."""
+    if status_code == 403:
+        return UiPathErrorCategory.DEPLOYMENT
+    if status_code >= 500:
+        return UiPathErrorCategory.SYSTEM
+    return UiPathErrorCategory.UNKNOWN
+
+
 def raise_for_provider_http_error(error: UiPathAPIError) -> NoReturn:
     """Convert a normalized ``UiPathAPIError`` into a structured ``AgentRuntimeError``.
 
@@ -31,11 +40,7 @@ def raise_for_provider_http_error(error: UiPathAPIError) -> NoReturn:
     """
     status_code = error.status_code
     code = _LLM_STATUS_CODE_MAP.get(status_code, AgentRuntimeErrorCode.HTTP_ERROR)
-    category = (
-        UiPathErrorCategory.DEPLOYMENT
-        if status_code == 403
-        else UiPathErrorCategory.UNKNOWN
-    )
+    category = _category_for_status(status_code)
     detail = error.body.get("detail") if isinstance(error.body, dict) else None
 
     raise AgentRuntimeError(

--- a/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/analyze_files_tool.py
@@ -21,6 +21,8 @@ from uipath.agent.models.agent import (
 )
 from uipath.core.tracing.span_utils import UiPathSpanUtils
 from uipath.eval.mocks import mockable
+from uipath.llm_client import UiPathAPIError, UiPathError
+from uipath.llm_client.utils.exceptions import as_uipath_error
 from uipath.platform import UiPath
 from uipath.platform.errors import EnrichedException
 from uipath.runtime.errors import UiPathErrorCategory
@@ -34,6 +36,8 @@ from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
     AgentRuntimeErrorCode,
 )
+from uipath_langchain.agent.exceptions.licensing import raise_for_provider_http_error
+from uipath_langchain.agent.exceptions.llm import raise_for_llm_client_error
 from uipath_langchain.agent.multimodal import (
     FileInfo,
     build_file_content_blocks_for,
@@ -335,7 +339,19 @@ def create_analyze_file_tool(
         config = var_child_runnable_config.get(None)
         config = config_without_streaming(config)
         config = _config_with_llm_call_attachments(config, files)
-        result = await non_streaming_llm.ainvoke(messages, config=config)
+        try:
+            result = await non_streaming_llm.ainvoke(messages, config=config)
+        except UiPathAPIError as exc:
+            raise_for_provider_http_error(exc)
+        except UiPathError as exc:
+            raise_for_llm_client_error(exc)
+            raise
+        except Exception as exc:
+            # legacy clients surface raw provider SDK exceptions.
+            uipath_error = as_uipath_error(exc)
+            if isinstance(uipath_error, UiPathAPIError):
+                raise_for_provider_http_error(uipath_error)
+            raise
 
         del messages, human_message_with_files, files
 

--- a/tests/agent/test_licensing.py
+++ b/tests/agent/test_licensing.py
@@ -37,18 +37,24 @@ def test_403_maps_to_license_not_available():
     assert info.detail == _DETAIL
 
 
-def test_other_status_maps_to_http_error():
+def test_5xx_maps_to_system_http_error():
     err = _api_error(500, {"status": 500, "detail": "boom"})
     with pytest.raises(AgentRuntimeError) as exc_info:
         raise_for_provider_http_error(err)
 
     info = exc_info.value.error_info
     assert info.status == 500
-    assert info.category == UiPathErrorCategory.UNKNOWN
+    assert info.category == UiPathErrorCategory.SYSTEM
     assert info.code.endswith(AgentRuntimeErrorCode.HTTP_ERROR.value)
-    # UNKNOWN-category errors are wrapped with a generic prefix by AgentRuntimeError,
-    # but the original gateway detail is preserved within.
     assert "boom" in info.detail
+
+
+def test_unclassified_status_remains_unknown():
+    err = _api_error(400, {"status": 400, "detail": "bad request"})
+    with pytest.raises(AgentRuntimeError) as exc_info:
+        raise_for_provider_http_error(err)
+
+    assert exc_info.value.error_info.category == UiPathErrorCategory.UNKNOWN
 
 
 def test_legacy_raw_provider_error_is_normalized_and_mapped():

--- a/tests/agent/tools/internal_tools/test_analyze_files_tool.py
+++ b/tests/agent/tools/internal_tools/test_analyze_files_tool.py
@@ -5,6 +5,7 @@ import uuid
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
+import openai
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables.config import RunnableConfig
@@ -15,6 +16,7 @@ from uipath.agent.models.agent import (
     AgentInternalToolResourceConfig,
     AgentInternalToolType,
 )
+from uipath.llm_client import UiPathAPIError, UiPathError
 from uipath.platform.errors import EnrichedException
 from uipath.runtime.errors import UiPathErrorCategory
 
@@ -122,6 +124,41 @@ class TestCreateAnalyzeFileTool:
             properties=properties,
         )
 
+    async def _invoke_with_llm_error(self, resource_config, mock_llm, error):
+        with (
+            patch(
+                "uipath_langchain.agent.tools.internal_tools.analyze_files_tool._resolve_job_attachment_arguments"
+            ) as mock_resolve_attachments,
+            patch(
+                "uipath_langchain.agent.tools.internal_tools.analyze_files_tool.add_files_to_message"
+            ) as mock_add_files,
+            patch(
+                "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
+            ),
+        ):
+            mock_resolve_attachments.return_value = [
+                FileInfo(
+                    url="https://example.com/file.pdf",
+                    name="test.pdf",
+                    mime_type="application/pdf",
+                )
+            ]
+            mock_add_files.return_value = HumanMessage(content="Summarize the document")
+            mock_llm.ainvoke.side_effect = error
+
+            tool = create_analyze_file_tool(resource_config, mock_llm)
+            assert tool.coroutine is not None
+            return await tool.coroutine(
+                analysisTask="Summarize the document",
+                attachments=[
+                    MockAttachment(
+                        ID=str(uuid.uuid4()),
+                        FullName="test.pdf",
+                        MimeType="application/pdf",
+                    )
+                ],
+            )
+
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
     )
@@ -202,6 +239,100 @@ class TestCreateAnalyzeFileTool:
         assert len(messages_arg) == 2
         assert messages_arg[0].content == ANALYZE_FILES_SYSTEM_MESSAGE
         assert messages_arg[1] == mock_message_with_files
+
+    @patch(
+        "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
+    )
+    @patch(
+        "uipath_langchain.agent.tools.internal_tools.analyze_files_tool.add_files_to_message"
+    )
+    @patch(
+        "uipath_langchain.agent.tools.internal_tools.analyze_files_tool._resolve_job_attachment_arguments"
+    )
+    async def test_provider_5xx_is_categorized_as_system(
+        self,
+        mock_resolve_attachments,
+        mock_add_files,
+        mock_get_wrapper,
+        resource_config,
+        mock_llm,
+    ):
+        mock_resolve_attachments.return_value = [
+            FileInfo(
+                url="https://example.com/file.pdf",
+                name="test.pdf",
+                mime_type="application/pdf",
+            )
+        ]
+        mock_add_files.return_value = HumanMessage(content="Summarize the document")
+        mock_get_wrapper.return_value = Mock()
+
+        request = httpx.Request("POST", "http://llm-gateway/completions")
+        response = httpx.Response(
+            500,
+            request=request,
+            json={
+                "error": {
+                    "message": (
+                        "Exception of type 'System.OutOfMemoryException' was thrown."
+                    )
+                }
+            },
+        )
+        mock_llm.ainvoke.side_effect = openai.InternalServerError(
+            "Internal server error",
+            response=response,
+            body=response.json(),
+        )
+
+        tool = create_analyze_file_tool(resource_config, mock_llm)
+        assert tool.coroutine is not None
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            await tool.coroutine(
+                analysisTask="Summarize the document",
+                attachments=[
+                    MockAttachment(
+                        ID=str(uuid.uuid4()),
+                        FullName="test.pdf",
+                        MimeType="application/pdf",
+                    )
+                ],
+            )
+
+        info = exc_info.value.error_info
+        assert info.status == 500
+        assert info.category == UiPathErrorCategory.SYSTEM
+        assert info.code.endswith(AgentRuntimeErrorCode.HTTP_ERROR.value)
+        assert info.title == "LLM provider returned HTTP 500"
+
+    async def test_normalized_provider_5xx_is_categorized_as_system(
+        self, resource_config, mock_llm
+    ):
+        request = httpx.Request("POST", "http://llm-gateway/completions")
+        response = httpx.Response(
+            500,
+            request=request,
+            json={"status": 500, "detail": "LLM gateway failed"},
+        )
+        error = UiPathAPIError.from_response(response)
+
+        with pytest.raises(AgentRuntimeError) as exc_info:
+            await self._invoke_with_llm_error(resource_config, mock_llm, error)
+
+        info = exc_info.value.error_info
+        assert info.status == 500
+        assert info.category == UiPathErrorCategory.SYSTEM
+
+    async def test_unmapped_llm_client_error_propagates_unchanged(
+        self, resource_config, mock_llm
+    ):
+        error = UiPathError(error_code="SOME_OTHER_CODE", detail="unrelated")
+
+        with pytest.raises(UiPathError) as exc_info:
+            await self._invoke_with_llm_error(resource_config, mock_llm, error)
+
+        assert exc_info.value is error
 
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- surface `Analyze Files` provider `5xx` failures as `System HTTP` errors
- preserve the provider status and error detail instead of reporting a generic `Unknown` failure

## Why

`Analyze Files` invokes the LLM outside the main agent node, so provider 500 responses bypassed existing normalization and appeared as Unexpected Error with an Unknown category. This applies the same taxonomy used by the main LLM path.