### PR TITLE
fix: categorize invalid tool input as user error

### DIFF
--- a/src/uipath_langchain/agent/tools/base_uipath_structured_tool.py
+++ b/src/uipath_langchain/agent/tools/base_uipath_structured_tool.py
@@ -9,7 +9,13 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import StructuredTool
 from langchain_core.tools.base import ArgsSchema, _get_runnable_config_param
 from langchain_core.utils.pydantic import get_fields
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
+from uipath.runtime.errors import UiPathErrorCategory
+
+from uipath_langchain.agent.exceptions import (
+    AgentRuntimeError,
+    AgentRuntimeErrorCode,
+)
 
 
 class BaseUiPathStructuredTool(StructuredTool):
@@ -106,7 +112,10 @@ class BaseUiPathStructuredTool(StructuredTool):
         Fields produced by jsonschema-pydantic-converter for reserved JSON property
         names use exactly such aliases (schema -> schema_ with alias='schema').
         """
-        parsed = super()._parse_input(tool_input, tool_call_id)
+        try:
+            parsed = super()._parse_input(tool_input, tool_call_id)
+        except ValidationError as e:
+            raise self._invalid_input_error(e) from e
         if not isinstance(parsed, dict) or not isinstance(tool_input, dict):
             return parsed
 
@@ -128,6 +137,17 @@ class BaseUiPathStructuredTool(StructuredTool):
             if alias in parsed:
                 parsed[alias] = getattr(result, python_name)
         return parsed
+
+    def _invalid_input_error(self, error: ValidationError) -> AgentRuntimeError:
+        return AgentRuntimeError(
+            code=AgentRuntimeErrorCode.INVALID_INPUT_ARGUMENT,
+            title=f"Invalid input for tool '{self.name}'",
+            detail=(
+                "Revise the agent prompt or tool configuration so the generated "
+                f"arguments match the tool input schema.\n\n{error}"
+            ),
+            category=UiPathErrorCategory.USER,
+        )
 
     @property
     def tool_call_schema(self) -> ArgsSchema:

--- a/tests/agent/tools/test_base_uipath_structured_tool.py
+++ b/tests/agent/tools/test_base_uipath_structured_tool.py
@@ -5,7 +5,12 @@ from types import CodeType
 import pytest
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel
+from uipath.runtime.errors import UiPathErrorCategory
 
+from uipath_langchain.agent.exceptions import (
+    AgentRuntimeError,
+    AgentRuntimeErrorCode,
+)
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import create_model
 from uipath_langchain.agent.tools.base_uipath_structured_tool import (
     BaseUiPathStructuredTool,
@@ -225,3 +230,38 @@ async def test_coroutine_with_self_parameter():
 
     result = await tool.ainvoke({"self": "async_test", "value": 99})
     assert result == "async_test:99"
+
+
+@pytest.mark.asyncio
+async def test_invalid_dynamic_tool_input_is_categorized_as_user_error():
+    input_schema = create_model(
+        {
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "const": "ExpectedProvider",
+                }
+            },
+            "required": ["provider"],
+        }
+    )
+    tool = BaseUiPathStructuredTool(
+        coroutine=_noop_coroutine,
+        name="Web_Search",
+        description="Search the web",
+        args_schema=input_schema,
+    )
+
+    with pytest.raises(AgentRuntimeError) as exc_info:
+        await tool.ainvoke({"provider": "anotherProvider"})
+
+    info = exc_info.value.error_info
+    assert info.code == AgentRuntimeError.full_code(
+        AgentRuntimeErrorCode.INVALID_INPUT_ARGUMENT
+    )
+    assert info.category == UiPathErrorCategory.USER
+    assert info.title == "Invalid input for tool 'Web_Search'"
+    assert "Revise the agent prompt or tool configuration" in info.detail
+    assert "provider" in info.detail
+    assert "ExpectedProvider" in info.detail


### PR DESCRIPTION
## Summary

- categorize dynamic tool argument validation failures as user input errors
- identify the failing tool and preserve schema validation details
- guide users to revise the agent prompt or tool configuration

## Why

Invalid generated tool arguments were reported as unexpected runtime failures instead of actionable user errors.