### PR TITLE
feat(guardrails): resolve BYOG by validator name only [AL-510]

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -70,7 +70,7 @@ from uipath.core.guardrails import GuardrailScope
 | `UiPathIntellectualPropertyMiddleware` | AGENT, LLM only | POST only | `entities` |
 | `UiPathLLMAsJudgeMiddleware` | AGENT, LLM, TOOL | PRE / POST / PRE_AND_POST | `guardrail_text`, `model`, `threshold`, `positive_examples`, `negative_examples`, `tools`, `stage` |
 | `UiPathDeterministicGuardrailMiddleware` | TOOL only | PRE / POST / PRE_AND_POST | `tools`, `rules`, `stage` |
-| `UiPathByoGuardrailMiddleware` | AGENT, LLM, TOOL | PRE / POST / PRE_AND_POST | `validator_name`, `connection_id`, `validator_parameters`, `tools`, `stage` |
+| `UiPathByoGuardrailMiddleware` | AGENT, LLM, TOOL | PRE / POST / PRE_AND_POST | `validator_name`, `validator_parameters`, `tools`, `stage` |
 
 TOOL scope for `UiPathPIIDetectionMiddleware`, `UiPathHarmfulContentMiddleware`, and `UiPathLLMAsJudgeMiddleware` requires passing `tools=[...]` to restrict `wrap_tool_call` hooks to specific tools.
 
@@ -88,7 +88,7 @@ Additional parameters per class:
 - **`UiPathIntellectualPropertyMiddleware`**: `entities` (list of `IntellectualPropertyEntityType` values).
 - **`UiPathLLMAsJudgeMiddleware`**: `guardrail_text` (required — the plain-language rule the judge evaluates against, ≤ 4000 chars), `model` (required — judge model id, e.g. `"gpt-4o-2024-08-06"`; must be a model your governance policy allows for the LLM-as-judge guardrail — LLM Gateway enforces the permitted list), `threshold` (`0` strictest … `6` most lenient, default `2`), `positive_examples` / `negative_examples` (optional calibration payloads — ≤ 2 each, ≤ 1000 chars each), `tools` (required only when `GuardrailScope.TOOL` is used), `stage`. See the [core guardrails documentation](https://uipath.github.io/uipath-python/core/guardrails/#llm-as-judge) for the full parameter reference.
 - **`UiPathDeterministicGuardrailMiddleware`**: `tools` (required — list of tools to guard), `rules` (list of lambda functions), `stage`.
-- **`UiPathByoGuardrailMiddleware`**: `validator_name` (required — the BYOG configuration's validator name), `connection_id` (recommended — the Integration Service connection id backing the configuration), `validator_parameters` (optional connector-defined parameters, passed through as-is), `tools` (required only when `GuardrailScope.TOOL` is used), `stage`. See [Bring Your Own Guardrail](#bring-your-own-guardrail-byog).
+- **`UiPathByoGuardrailMiddleware`**: `validator_name` (required — the BYOG configuration's validator name, unique per tenant), `validator_parameters` (optional connector-defined parameters, passed through as-is), `tools` (required only when `GuardrailScope.TOOL` is used), `stage`. See [Bring Your Own Guardrail](#bring-your-own-guardrail-byog).
 
 ### Full example
 
@@ -236,23 +236,22 @@ byog = UiPathByoGuardrailMiddleware(
     validator_name="my-harmful-content-guardrail",   # the configuration's validator name
     scopes=[GuardrailScope.AGENT],
     action=BlockAction(),
-    connection_id="my-byog-guardrail-connection",     # IS connection id
 )
 
 agent = create_agent(model=llm, tools=[...], middleware=[*byog])
 ```
 
-To find the `validator_name` and `connection_id`, list your tenant's BYOG configurations:
+To find the `validator_name`, list your tenant's BYOG configurations:
 
 ```bash
 uip agent guardrails list --byo --output json
 ```
 
-Each entry carries `ByoValidatorName` (→ `validator_name`) and `ByoConnectionId` (→ `connection_id`), alongside its `AllowedScopes` / `GuardrailStages` and the full `Parameters` schema. No solution binding is needed for the connection: it is resolved server-side from the BYOG configuration.
+Each entry carries `ByoValidatorName` (→ `validator_name`), alongside its `AllowedScopes` / `GuardrailStages` and the full `Parameters` schema. No connection details are needed: the Integration Service connection is resolved server-side from the BYOG configuration.
 
 Notes:
 
-- **Always pass `connection_id`.** Validator names are unique per connection only; without the id the server picks the first configuration matching the name.
+- **The name is the identity.** Validator names are unique per tenant, so the name alone resolves the configuration; the connection comes from the configuration, so an admin rebind is always honored.
 - **You choose the scopes and stages.** BYOG validators are not scope- or stage-restricted: like the built-in validators they are available on AGENT, LLM and TOOL scope for both PRE and POST, and it is up to you which ones to register. The entry's `AllowedScopes` / `GuardrailStages` in the CLI output confirm what a given validator accepts.
 - **Parameters are connector-defined.** Pass `validator_parameters` as raw parameter values when your connector expects them; there is no static schema on the client. See [Tuning a BYOG validator](#tuning-a-byog-validator) below.
 - **Error semantics.** A removed or disabled configuration, BYOG not being enabled for the tenant, or a vendor failure (with fallback off) returns `PROVIDER_ERROR`/`FEATURE_DISABLED` — the middleware treats these like any non-failed result (fail-open) and logs the details. Fallback to the UiPath-managed validator (`FallbackOnUiPath`) applies only when the configuration's validator type maps to an out-of-the-box validator.
@@ -284,7 +283,6 @@ byog = UiPathByoGuardrailMiddleware(
     validator_name="my-harmful-content-guardrail",
     scopes=[GuardrailScope.AGENT],
     action=BlockAction(),
-    connection_id="my-byog-guardrail-connection",
     validator_parameters=byog_parameters,
 )
 ```
@@ -532,7 +530,7 @@ async def my_node(state: Input) -> Output:
 
 `ByoValidator` is the decorator equivalent of [`UiPathByoGuardrailMiddleware`](#bring-your-own-guardrail-byog): it runs a **customer-managed** validator instead of a UiPath-managed one — your own content-safety subscription, a vendor validation service, or a custom Integration Service connector wrapping an internal classifier.
 
-The admin prerequisite and how to look up the validator name, connection id and parameter schema are the same as for the middleware flavor — see [Bring Your Own Guardrail (BYOG)](#bring-your-own-guardrail-byog) under the middleware pattern.
+The admin prerequisite and how to look up the validator name and parameter schema are the same as for the middleware flavor — see [Bring Your Own Guardrail (BYOG)](#bring-your-own-guardrail-byog) under the middleware pattern.
 
 The validator references that configuration by name; scope is inferred from the decorated target as usual:
 
@@ -540,8 +538,7 @@ The validator references that configuration by name; scope is inferred from the 
 from uipath_langchain.guardrails import BlockAction, ByoValidator, guardrail
 
 byog_harmful_content = ByoValidator(
-    "my-harmful-content-guardrail",                          # the configuration's validator name
-    connection_id="my-byog-guardrail-connection",            # IS connection id
+    "my-harmful-content-guardrail",  # the configuration's validator name (unique per tenant)
 )
 
 @guardrail(validator=byog_harmful_content, action=BlockAction())
@@ -549,7 +546,7 @@ def create_joke_agent():
     return create_agent(model=llm, tools=[...])
 ```
 
-Notes specific to the decorator path — the [middleware notes](#bring-your-own-guardrail-byog) on `connection_id`, scopes/stages and connector-defined parameters apply here too:
+Notes specific to the decorator path — the [middleware notes](#bring-your-own-guardrail-byog) on naming, scopes/stages and connector-defined parameters apply here too:
 
 - **`parameters` instead of `validator_parameters`.** Same passthrough of raw parameter values; read the ids and allowed values from the validator's `Parameters` array in `uip agent guardrails list --byo`.
 - **No static stage restriction.** Because BYOG validators are available on every scope and stage, `ByoValidator` declares no `supported_stages` — you pick the `stage`, and the scope comes from the decorated target.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.15.2"
+version = "0.15.3"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/samples/joke-agent-bring-your-own-guardrail/README.md
+++ b/samples/joke-agent-bring-your-own-guardrail/README.md
@@ -3,13 +3,13 @@
 A minimal starter for using a **customer-managed guardrail** in a coded agent — with **both
 guardrail flavors in one agent**. The agent generates a family-friendly joke; agent
 input/output and the tool input are validated by a **BYOG configuration** — your own
-guardrail vendor connected through Integration Service, referenced purely by validator name
-+ connection id. Credentials never appear in this project.
+guardrail vendor connected through Integration Service, referenced purely by its validator
+name. Credentials never appear in this project.
 
 The guardrail can be backed by any vendor your admin configured: a cloud subscription
 (e.g. a content-safety service), a vendor validation platform, or a custom Integration
-Service connector wrapping an internal classifier. The validator name and connection id in
-[graph.py](graph.py) are **placeholders** — substitute your own configuration's values.
+Service connector wrapping an internal classifier. The validator name in
+[graph.py](graph.py) is a **placeholder** — substitute your own configuration's name.
 
 ## How the two flavors are wired
 
@@ -41,11 +41,11 @@ and to reuse one validator across many of them. See
    uip agent guardrails list --byo --output json
    ```
 
-   Copy your configuration's `ByoValidatorName` → `BYOG_VALIDATOR_NAME` and
-   `ByoConnectionId` → `BYOG_CONNECTION_ID` in [graph.py](graph.py) (both ship as
-   placeholders).
+   Copy your configuration's `ByoValidatorName` → `BYOG_VALIDATOR_NAME` in
+   [graph.py](graph.py) (ships as a placeholder).
 
-> Always pass the connection id: validator names are unique **per connection** only.
+> Validator names are unique **per tenant**, so the name alone identifies the
+> configuration; the Integration Service connection is resolved from it server-side.
 
 ## Run it
 
@@ -96,14 +96,14 @@ ignored. Verified end to end against a live configuration:
 ## How it works
 
 - Both flavors build a guardrail with `validator_type="byo"` plus
-  `byoValidatorName`/`byoConnectionId`, evaluated via
+  `byoValidatorName`, evaluated via
   `POST /agentsruntime_/api/execution/guardrails/validate`.
 - The Guardrails Service resolves your configuration and invokes the Integration Service
   connector against your vendor, which returns the verdict.
 - The middleware registers agent hooks for its configured scopes; the decorator infers the
   scope from the decorated target (here: a factory returning a `BaseChatModel` → LLM).
-- No solution binding is needed: the connection is resolved server-side from the BYOG
-  configuration — the agent only references it by validator name + connection id.
+- No connection details are needed: the Integration Service connection is resolved
+  server-side from the BYOG configuration — the agent only sends the validator name.
 
 ## Notes
 

--- a/samples/joke-agent-bring-your-own-guardrail/graph.py
+++ b/samples/joke-agent-bring-your-own-guardrail/graph.py
@@ -12,9 +12,10 @@ One agent, one BYOG configuration, **both guardrail flavors**:
 The validator is *customer-managed* — your own vendor connected through
 Integration Service and configured by an Org Admin under
 ``Admin -> AI Trust Layer -> Guardrails Configurations``. Both flavors
-reference that configuration purely by validator name + connection id; the
-credentials never appear in this project. This sample was validated against a
-harmful-content configuration; substitute your own.
+reference that configuration purely by its validator name (unique per
+tenant); the Integration Service connection is resolved server-side from the
+configuration, and the credentials never appear in this project. This sample
+was validated against a harmful-content configuration; substitute your own.
 """
 
 from langchain.agents import create_agent
@@ -35,13 +36,12 @@ from uipath_langchain.guardrails import (
     guardrail,
 )
 
-# The BYOG configuration both flavors use. Both values come from
-# Admin -> AI Trust Layer -> Guardrails Configurations, or from the CLI:
-# `uip agent guardrails list --byo` (fields `ByoValidatorName` and
-# `ByoConnectionId`).
-# Replace them with your own configuration's values.
+# The BYOG configuration both flavors use, referenced by its validator name
+# (unique per tenant). The name comes from Admin -> AI Trust Layer ->
+# Guardrails Configurations, or from the CLI: `uip agent guardrails list
+# --byo` (field `ByoValidatorName`). Replace it with your own configuration's
+# name.
 BYOG_VALIDATOR_NAME = "my-harmful-content-guardrail"
-BYOG_CONNECTION_ID = "my-byog-guardrail-connection"
 
 # Optional: `validator_parameters` (middleware) / `parameters` (ByoValidator)
 # tune the validator per run.
@@ -88,10 +88,7 @@ BYOG_CONNECTION_ID = "my-byog-guardrail-connection"
 
 # Decorator flavor: a reusable validator object referencing the same BYOG
 # configuration — declare once, stack on any number of targets.
-byog_harmful_content = ByoValidator(
-    BYOG_VALIDATOR_NAME,
-    connection_id=BYOG_CONNECTION_ID,
-)
+byog_harmful_content = ByoValidator(BYOG_VALIDATOR_NAME)
 
 
 class Input(BaseModel):
@@ -160,7 +157,6 @@ agent = create_agent(
             validator_name=BYOG_VALIDATOR_NAME,
             scopes=[GuardrailScope.AGENT],
             action=LogAction(),
-            connection_id=BYOG_CONNECTION_ID,
             # Optionally add validator_parameters=... — see the example above.
             stage=GuardrailExecutionStage.PRE_AND_POST,
             name="BYOG Harmful Content",

--- a/src/uipath_langchain/guardrails/middlewares/byo.py
+++ b/src/uipath_langchain/guardrails/middlewares/byo.py
@@ -56,7 +56,6 @@ class UiPathByoGuardrailMiddleware(BuiltInGuardrailMiddlewareMixin):
             validator_name="my-harmful-content-guardrail",
             scopes=[GuardrailScope.AGENT],
             action=BlockAction(),
-            connection_id="my-byog-guardrail-connection",
         )
 
         # Same configuration applied to a specific tool
@@ -64,7 +63,6 @@ class UiPathByoGuardrailMiddleware(BuiltInGuardrailMiddlewareMixin):
             validator_name="my-harmful-content-guardrail",
             scopes=[GuardrailScope.TOOL],
             action=BlockAction(),
-            connection_id="my-byog-guardrail-connection",
             tools=[analyze_joke_syntax],
         )
 
@@ -78,16 +76,14 @@ class UiPathByoGuardrailMiddleware(BuiltInGuardrailMiddlewareMixin):
     Args:
         validator_name: The BYOG configuration's validator name
             (``byoValidatorName``), as shown in Admin -> AI Trust Layer ->
-            Guardrails Configurations or by ``uip agent guardrails list``.
+            Guardrails Configurations or by ``uip agent guardrails list --byo``.
+            Unique per tenant; the Integration Service connection to use is
+            resolved server-side from the configuration.
         scopes: List of scopes where the guardrail applies (Agent, LLM, Tool).
             BYOG validators are not scope-restricted -- all three scopes are
             available, as with the built-in validators.
         action: Action to take when the validation fails (LogAction,
             BlockAction, EscalateAction, or a custom GuardrailAction).
-        connection_id: Optional Integration Service connection id backing the
-            BYOG configuration. Strongly recommended: validator names are only
-            unique per connection, so omitting it lets the server pick the
-            first configuration matching the name.
         validator_parameters: Optional list of validator parameters. BYO
             parameter schemas are connector-defined, so values are passed
             through as-is; read the ids and allowed values from the
@@ -114,7 +110,6 @@ class UiPathByoGuardrailMiddleware(BuiltInGuardrailMiddlewareMixin):
         scopes: Sequence[GuardrailScope],
         action: GuardrailAction,
         *,
-        connection_id: str | None = None,
         validator_parameters: Sequence[ValidatorParameter] | None = None,
         tools: Sequence[str | BaseTool] | None = None,
         stage: GuardrailExecutionStage = GuardrailExecutionStage.PRE_AND_POST,
@@ -139,7 +134,6 @@ class UiPathByoGuardrailMiddleware(BuiltInGuardrailMiddlewareMixin):
         self.scopes = scopes_list
         self.action = action
         self.validator_name = validator_name
-        self.connection_id = connection_id
         self.validator_parameters = list(validator_parameters or [])
         self._tool_stage = stage
         self._name = name or f"BYO Guardrail ({validator_name})"
@@ -175,5 +169,4 @@ class UiPathByoGuardrailMiddleware(BuiltInGuardrailMiddlewareMixin):
             validator_type=BYO_VALIDATOR_TYPE,
             validator_parameters=self.validator_parameters,
             byo_validator_name=self.validator_name,
-            byo_connection_id=self.connection_id,
         )

--- a/tests/cli/mocks/parity_agent_decorator.py
+++ b/tests/cli/mocks/parity_agent_decorator.py
@@ -244,10 +244,7 @@ llm = create_llm()
 
 
 @guardrail(
-    validator=ByoValidator(
-        "my-harmful-content-guardrail",
-        connection_id="my-byog-guardrail-connection",
-    ),
+    validator=ByoValidator("my-harmful-content-guardrail"),
     action=BlockAction(),
     name="Agent BYOG Detection",
     stage=GuardrailExecutionStage.PRE,

--- a/tests/cli/mocks/parity_agent_middleware.py
+++ b/tests/cli/mocks/parity_agent_middleware.py
@@ -193,11 +193,10 @@ agent = create_agent(
             stage=GuardrailExecutionStage.POST,
         ),
         # AGENT scope BYOG — BlockAction (PRE): customer-managed validator
-        # referenced by name + connection id
+        # referenced by validator name (unique per tenant)
         *UiPathByoGuardrailMiddleware(
             name="Agent BYOG Detection",
             validator_name="my-harmful-content-guardrail",
-            connection_id="my-byog-guardrail-connection",
             scopes=[GuardrailScope.AGENT],
             action=BlockAction(),
             stage=GuardrailExecutionStage.PRE,

--- a/tests/cli/test_guardrails_in_langgraph.py
+++ b/tests/cli/test_guardrails_in_langgraph.py
@@ -618,8 +618,9 @@ class TestGuardrailsParity:
 
         BYOG parity has one extra dimension the built-in scenarios don't: the
         wire contract. Both flavors must deliver the SAME ``byo`` guardrail to
-        the service — ``validator_type="byo"`` carrying ``byoValidatorName`` and
-        ``byoConnectionId`` — and block identically on a failing verdict.
+        the service — ``validator_type="byo"`` carrying ``byoValidatorName``,
+        the sole BYOG identity (unique per tenant) — and block identically on
+        a failing verdict.
         """
         flavor, script, langgraph_json = agent_setup
 
@@ -670,7 +671,9 @@ class TestGuardrailsParity:
         for g in seen_byo_guardrails:
             assert g.validator_type == "byo", f"[{flavor}] wrong validator_type"
             assert g.byo_validator_name == "my-harmful-content-guardrail"
-            assert g.byo_connection_id == "my-byog-guardrail-connection"
+            # BYOG identity is the name alone; no connection id may ride along
+            # (works both before and after uipath-platform drops the field).
+            assert not getattr(g, "byo_connection_id", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/guardrails/middlewares/test_byo.py
+++ b/tests/guardrails/middlewares/test_byo.py
@@ -1,9 +1,9 @@
 """Tests for ``UiPathByoGuardrailMiddleware`` (Bring Your Own Guardrail).
 
-BYOG guardrails reference an admin-created configuration by validator name
-(plus an optional Integration Service connection id). These tests pin:
+BYOG guardrails reference an admin-created configuration purely by validator
+name, which is unique per tenant. These tests pin:
 - the ``BuiltInValidatorGuardrail`` the middleware constructs (``validator_type
-  == "byo"`` sentinel + ``byoValidatorName``/``byoConnectionId`` aliases),
+  == "byo"`` sentinel + the ``byoValidatorName`` alias),
 - constructor validation,
 - hook wiring parity with the other built-in middlewares (scopes x stage),
 - that the evaluation path forwards the BYO guardrail to the service and that
@@ -34,7 +34,6 @@ _LOG = LogAction()
 _BLOCK = BlockAction()
 
 _VALIDATOR_NAME = "my-harmful-content-guardrail"
-_CONNECTION_ID = "my-byog-guardrail-connection"
 
 
 def _hook_names(middleware: Iterable[Any]) -> list[str]:
@@ -59,22 +58,20 @@ class TestByoGuardrailConstruction:
         middleware = _byo()
         assert middleware._guardrail.validator_type == BYO_VALIDATOR_TYPE
 
-    def test_guardrail_carries_validator_name_and_connection_id(self) -> None:
-        middleware = _byo(connection_id=_CONNECTION_ID)
-        assert middleware._guardrail.byo_validator_name == _VALIDATOR_NAME
-        assert middleware._guardrail.byo_connection_id == _CONNECTION_ID
-
-    def test_connection_id_defaults_to_none(self) -> None:
+    def test_guardrail_carries_validator_name(self) -> None:
         middleware = _byo()
-        assert middleware._guardrail.byo_connection_id is None
+        assert middleware._guardrail.byo_validator_name == _VALIDATOR_NAME
 
     def test_aliases_serialize_for_the_wire(self) -> None:
-        middleware = _byo(connection_id=_CONNECTION_ID)
+        middleware = _byo()
         dumped = middleware._guardrail.model_dump(by_alias=True)
         assert dumped["validatorType"] == "byo"
         assert dumped["byoValidatorName"] == _VALIDATOR_NAME
-        assert dumped["byoConnectionId"] == _CONNECTION_ID
         assert dumped["$guardrailType"] == "builtInValidator"
+        # BYOG resolves by validator name alone (unique per tenant). On
+        # uipath-platform releases that still carry the legacy field it dumps
+        # as None; once removed it is absent - never a real value.
+        assert dumped.get("byoConnectionId") is None
 
     def test_validator_parameters_pass_through(self) -> None:
         parameter = NumberParameterValue(
@@ -214,7 +211,7 @@ class TestByoGuardrailEvaluationPath:
         )
 
     def test_evaluate_forwards_byo_guardrail_to_service(self) -> None:
-        middleware = _byo(connection_id=_CONNECTION_ID)
+        middleware = _byo()
         mock_uipath = MagicMock()
         mock_uipath.guardrails.evaluate_guardrail.return_value = self._passed()
         middleware._uipath = mock_uipath
@@ -227,7 +224,6 @@ class TestByoGuardrailEvaluationPath:
         assert input_data == "some input"
         assert guardrail.validator_type == BYO_VALIDATOR_TYPE
         assert guardrail.byo_validator_name == _VALIDATOR_NAME
-        assert guardrail.byo_connection_id == _CONNECTION_ID
 
     def test_block_action_raises_on_validation_failed(self) -> None:
         middleware = _byo(action=_BLOCK)

--- a/tests/guardrails/test_byo_validator.py
+++ b/tests/guardrails/test_byo_validator.py
@@ -8,9 +8,9 @@ Two groups:
    deleted/disabled config, BYOG not enabled) is visible instead of silent.
 
 2. **``ByoValidator`` through ``@guardrail``** — the validator reaches the
-   guardrails service as a ``byo`` guardrail carrying ``byoValidatorName`` /
-   ``byoConnectionId``, for a tool, a plain function, and a validator reused
-   across targets.
+   guardrails service as a ``byo`` guardrail carrying ``byoValidatorName``
+   (the sole BYOG identity, unique per tenant), for a tool, a plain function,
+   and a validator reused across targets.
 """
 
 import logging
@@ -111,10 +111,7 @@ class TestByoValidatorThroughDecorator:
 
     def test_tool_scope_forwards_byo_guardrail(self) -> None:
         @guardrail(
-            validator=ByoValidator(
-                "my-harmful-content-guardrail",
-                connection_id="my-byog-guardrail-connection",
-            ),
+            validator=ByoValidator("my-harmful-content-guardrail"),
             action=LogAction(),
             name="BYOG tool guardrail",
         )
@@ -132,7 +129,6 @@ class TestByoValidatorThroughDecorator:
         _, g = mock_uipath.guardrails.evaluate_guardrail.call_args[0]
         assert g.validator_type == "byo"
         assert g.byo_validator_name == "my-harmful-content-guardrail"
-        assert g.byo_connection_id == "my-byog-guardrail-connection"
         assert g.name == "BYOG tool guardrail"
 
     def test_plain_function_forwards_byo_guardrail(self) -> None:
@@ -151,10 +147,9 @@ class TestByoValidatorThroughDecorator:
         _, g = mock_uipath.guardrails.evaluate_guardrail.call_args[0]
         assert g.validator_type == "byo"
         assert g.byo_validator_name == "byog-pii"
-        assert g.byo_connection_id is None
 
     def test_validator_is_reusable_across_targets(self) -> None:
-        shared = ByoValidator("byog-shared", connection_id="conn-1")
+        shared = ByoValidator("byog-shared")
 
         @guardrail(validator=shared, action=LogAction())
         def first(text: str) -> str:
@@ -174,4 +169,3 @@ class TestByoValidatorThroughDecorator:
         for call in calls:
             _, g = call[0]
             assert g.byo_validator_name == "byog-shared"
-            assert g.byo_connection_id == "conn-1"

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.15.2"
+version = "0.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## What changed?

The Agents backend now enforces BYOG validator-name uniqueness **per tenant** and no longer accepts a connection id at validation nor persists one in the agent (UiPath/Agents#5959, AL-510): the name alone resolves the configuration, and the Integration Service connection is taken from it server-side — an admin rebind is always honored. This PR removes the now-dead connection id from the langchain BYOG surface. Counterpart of UiPath/uipath-python#1840 (platform side); the two are independent — no release-ordering coupling.

- **`UiPathByoGuardrailMiddleware`** — the `connection_id` kwarg is removed and the middleware no longer sets `byo_connection_id` on the guardrail. The docstring's "validator names are only unique per connection" advice — now factually wrong — is replaced with the per-tenant rule.
- **Sample `joke-agent-bring-your-own-guardrail`** — references the configuration by `BYOG_VALIDATOR_NAME` alone; `BYOG_CONNECTION_ID` is gone.
- **`docs/guardrails.md`, both BYOG sections** — examples and the middleware parameter table lose `connection_id`; the "> Always pass the connection id" callout becomes "the name is the identity"; discovery copies `ByoValidatorName` only.
- **Tests** — middleware, decorator-adapter and parity suites assert the name-only wire contract. The parity scenario additionally pins that **no connection id rides along**, written tolerantly (`getattr`/`.get`) so it passes with `uipath-platform` releases both before and after the field removal — the floor stays `>=0.2.14`.
- **Version** — 0.15.3 (0.15.2 is published on PyPI).

**Version-skew safety:** published `uipath-langchain` 0.14.18–0.15.2 still send `byoConnectionId`; the server ignores unknown fields, and the platform model keeps `extra="allow"`, so every old/new combination keeps working. This PR only stops producing the field.

## How has this been tested?

- `tests/guardrails/middlewares/test_byo.py` — name-only construction; wire dump asserts `byoConnectionId` is `None`/absent.
- `tests/guardrails/test_byo_validator.py` — `ByoValidator` name-only through `@guardrail` (tool / plain function / reuse).
- Parity scenario 12 (`test_byog_agent_block`, both flavors) — identical block contract + name-only wire contract.
- Full suite green; `ruff check`, `ruff format --check`, `mypy` clean; `uv lock --check` clean; BYOG doc fences compile.
- **Live E2E on alpha** (`AdminStudioTest`) with the validator **name alone** against the real BYOG harmful-content configuration: benign topic → both flavors evaluate, joke returned; harmful topic → agent-scope guardrail logs, LLM-scope guardrail blocks with the vendor verdict *"Harmful content detected: Violence (severity 4)"* — proving the server resolves the configuration and its IS connection from the name only.

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] API removals
- [ ] None
- [ ] DB migrations

`UiPathByoGuardrailMiddleware(connection_id=...)` from 0.14.18–0.15.2 now raises `TypeError`. The parameter shipped days ago (July 30) and the server already ignores the field it fed — deliberate hard removal in agreement with the backend change rather than a deprecation shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
