### PR TITLE
chore: change to centralized managed GitHub pool

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
 
     needs:
       - lint
@@ -26,15 +26,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: ".python-version"
 
@@ -45,14 +45,14 @@ jobs:
         run: uv build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: release-dists
           path: dist/
 
   pypi-publish:
     name: Upload release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: pypi
 
     needs:
@@ -63,10 +63,10 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: release-dists
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -6,15 +6,15 @@ on:
 jobs:
   commitlint:
     name: Commit Lint
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Validate PR commits with commitlint
-        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed  # v6

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,12 +13,12 @@ permissions:
 
 jobs:
   discover-testcases:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       testcases: ${{ steps.discover.outputs.testcases }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
     - name: Discover testcases
       # Skip common directory - it's shared utilities, not a testcase
@@ -41,7 +41,7 @@ jobs:
 
   integration-tests:
     needs: [discover-testcases]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     timeout-minutes: 10
     container:
       image: ghcr.io/astral-sh/uv:python3.12-bookworm
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
     - name: Install Dependencies
       run: uv sync

--- a/.github/workflows/lint-custom-version.yml
+++ b/.github/workflows/lint-custom-version.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   lint-with-custom-version:
     name: Lint with Custom UiPath Version
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')
     permissions:
       contents: read
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Extract version from PR
         id: extract-version
@@ -34,12 +34,12 @@ jobs:
           "version=$version" | Add-Content -Path $env:GITHUB_OUTPUT
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: ".python-version"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   # Job that runs when custom version testing is enabled - just completes successfully
   skip-lint:
     name: Skip Lint (Custom Version Testing)
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')
     permissions:
       contents: read
@@ -19,22 +19,22 @@ jobs:
   # Job that runs normal lint process when custom version testing is NOT enabled
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')"
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: ".python-version"
 

--- a/.github/workflows/model_onboarding.yml
+++ b/.github/workflows/model_onboarding.yml
@@ -42,7 +42,7 @@ jobs:
   # Turn the comma-separated `environments` input into a JSON array the matrix
   # can consume, so a single dispatch can fan out across chosen environments.
   resolve-environments:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       environments: ${{ steps.split.outputs.environments }}
     steps:
@@ -59,7 +59,7 @@ jobs:
 
   model-onboarding:
     needs: [resolve-environments]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     timeout-minutes: 10
     container:
       image: ghcr.io/astral-sh/uv:python3.12-bookworm
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
     - name: Install Dependencies
       run: uv sync

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-dev:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
@@ -16,15 +16,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: ".python-version"
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   publish-docs:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: ${{ github.repository == 'UiPath/uipath-langchain-python' }}
     steps:
       - name: Trigger Publish Docs

--- a/.github/workflows/publish-prior-stable-version.yml
+++ b/.github/workflows/publish-prior-stable-version.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish-prior-stable-version:
     name: Publish Fixed Version
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: pypi
 
     permissions:
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: ".python-version"
 

--- a/.github/workflows/test-custom-version.yml
+++ b/.github/workflows/test-custom-version.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest]
+        os: [uipath-ubuntu-latest, uipath-windows-latest]
 
     permissions:
       contents: read
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Extract version from PR
         id: extract-version
@@ -46,12 +46,12 @@ jobs:
           "version=$version" | Add-Content -Path $env:GITHUB_OUTPUT
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest]
+        os: [uipath-ubuntu-latest, uipath-windows-latest]
 
     permissions:
       contents: read
@@ -33,15 +33,15 @@ jobs:
 
       - name: Checkout
         if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
         if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')"
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
         if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version')"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload coverage HTML report
         if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-html-report
           path: htmlcov/
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload coverage XML report
         if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-xml-report
           path: coverage.xml
@@ -86,23 +86,23 @@ jobs:
   sonarcloud:
     name: SonarCloud
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: always() && needs.test.result != 'failure'
     permissions:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Download coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         continue-on-error: true
         with:
           name: coverage-xml-report
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
+        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703  # v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         run: uv sync --all-extras --python ${{ matrix.python-version }}
 
       - name: Run tests
-        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13')"
+        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && !(matrix.os == 'uipath-ubuntu-latest' && matrix.python-version == '3.13')"
         run: uv run --python ${{ matrix.python-version }} pytest
         env:
           UIPATH_URL: ${{ secrets.UIPATH_URL }}
@@ -58,7 +58,7 @@ jobs:
           UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
 
       - name: Run tests with coverage
-        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'"
+        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'uipath-ubuntu-latest' && matrix.python-version == '3.13'"
         run: uv run --python ${{ matrix.python-version }} pytest --cov-report=xml --cov-report=html --tb=short
         env:
           UIPATH_URL: ${{ secrets.UIPATH_URL }}
@@ -66,7 +66,7 @@ jobs:
           UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
 
       - name: Upload coverage HTML report
-        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()"
+        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'uipath-ubuntu-latest' && matrix.python-version == '3.13' && always()"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-html-report
@@ -74,7 +74,7 @@ jobs:
           retention-days: 30
 
       - name: Upload coverage XML report
-        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()"
+        if: "!contains(github.event.pull_request.labels.*.name, 'test-core-dev-version') && matrix.os == 'uipath-ubuntu-latest' && matrix.python-version == '3.13' && always()"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-xml-report


### PR DESCRIPTION
## Summary

Moves this repository's workflows to the centralized managed GitHub pool.

- Runner images are prefixed with `uipath-` in all workflow files
- e.g. `ubuntu-latest` → `uipath-ubuntu-latest`

## Changes

All workflow `.yml` files (including non-standard locations like `workflows-src/`) with static `runs-on` values are updated.
Dynamic expressions (`${{ ... }}`) and already-prefixed images are skipped.

## Action Version Pinning

All `uses:` references are pinned to the SHA of the latest release published ≥ **48h** ago.
This prevents supply-chain attacks via recently-published compromised versions.