### PR TITLE
fix: require uipath 2.14 and runtime 0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ description = "Python SDK that enables developers to build and deploy LangGraph 
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.13.16, <2.15.0",
+    "uipath>=2.14.1, <2.15.0",
     "uipath-core>=0.5.29, <0.6.0",
     "uipath-platform>=0.2.15, <0.3.0",
-    "uipath-runtime>=0.12.5, <0.14.0",
+    "uipath-runtime>=0.13.0, <0.14.0",
     "uipath-llm-client>=1.17.1, <1.18.0",
     "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.27, <2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4578,7 +4578,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rdflib", specifier = ">=7.0.0,<8.0.0" },
-    { name = "uipath", specifier = ">=2.13.16,<2.15.0" },
+    { name = "uipath", specifier = ">=2.14.1,<2.15.0" },
     { name = "uipath-core", specifier = ">=0.5.29,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.17.1,<1.18.0" },
@@ -4589,7 +4589,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-llm-client", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-platform", specifier = ">=0.2.15,<0.3.0" },
-    { name = "uipath-runtime", specifier = ">=0.12.5,<0.14.0" },
+    { name = "uipath-runtime", specifier = ">=0.13.0,<0.14.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
 


### PR DESCRIPTION
## Summary
- prevent installing uipath-langchain with SDK and runtime versions that lack the required contracts

## Why

uipath-langchain 0.16 consumes functionality available from uipath 2.14.1 and uipath-runtime 0.13, so both declared minimums must match the actual compatibility boundary.