### PR TITLE
test: stabilize integration test dependencies and fixture

### DIFF
--- a/testcases/chat-models/pyproject.toml
+++ b/testcases/chat-models/pyproject.toml
@@ -19,5 +19,15 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }

--- a/testcases/company-research-agent/pyproject.toml
+++ b/testcases/company-research-agent/pyproject.toml
@@ -18,6 +18,16 @@ dev = ["mypy>=1.11.1", "ruff>=0.6.1"]
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }
 

--- a/testcases/debug-breakpoints/pyproject.toml
+++ b/testcases/debug-breakpoints/pyproject.toml
@@ -21,6 +21,16 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }
 

--- a/testcases/dev-console/pyproject.toml
+++ b/testcases/dev-console/pyproject.toml
@@ -21,6 +21,16 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }
 

--- a/testcases/init-flow/pyproject.toml
+++ b/testcases/init-flow/pyproject.toml
@@ -12,5 +12,15 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }

--- a/testcases/model-onboarding/pyproject.toml
+++ b/testcases/model-onboarding/pyproject.toml
@@ -15,5 +15,15 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }

--- a/testcases/multimodal-invoke/pyproject.toml
+++ b/testcases/multimodal-invoke/pyproject.toml
@@ -15,5 +15,15 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }

--- a/testcases/multimodal-invoke/src/main.py
+++ b/testcases/multimodal-invoke/src/main.py
@@ -97,9 +97,13 @@ MODELS_TO_TEST: list[ModelTestConfig] = [
 
 FILES_TO_TEST = [
     FileInfo(
-        url="https://www.w3schools.com/css/img_5terre.jpg",
-        name="img_5terre.jpg",
-        mime_type="image/jpeg",
+        url=(
+            "https://raw.githubusercontent.com/UiPath/uipath-langchain-python/"
+            "241b5addd4c040720c05f28d819dbc4b885b92eb/"
+            "docs/quick_start_images/invoke_output_light.png"
+        ),
+        name="invoke_output_light.png",
+        mime_type="image/png",
     ),
     FileInfo(
         url="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",

--- a/testcases/simple-local-mcp/pyproject.toml
+++ b/testcases/simple-local-mcp/pyproject.toml
@@ -22,5 +22,15 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }

--- a/testcases/template-agent/pyproject.toml
+++ b/testcases/template-agent/pyproject.toml
@@ -11,5 +11,15 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }

--- a/testcases/ticket-classification/pyproject.toml
+++ b/testcases/ticket-classification/pyproject.toml
@@ -20,5 +20,15 @@ requires-python = ">=3.11"
 [tool.uv]
 exclude-newer = "2 days"
 
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+uipath-dev = false
+uipath-langchain-client = false
+uipath-llm-client = false
+jsonschema-pydantic-converter = false
+
 [tool.uv.sources]
 uipath-langchain = { path = "../../", editable = true }


### PR DESCRIPTION
## Summary
- keep the two-day package cutoff for general dependencies
- allow current UiPath packages through the cutoff across integration testcases
- use a repository-owned multimodal image fixture

## Why

the dependency cutoff hid uipath 2.14.1 required by the current package, causing every integration job to fail during resolution. the external image fixture also rejects the CI client with a 403 response.