### PR TITLE
fix: register dynamic schema models in per-conversion modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.16.1"
+version = "0.16.2"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
+++ b/src/uipath_langchain/agent/react/jsonschema_pydantic_converter.py
@@ -1,4 +1,5 @@
 import inspect
+import itertools
 import logging
 import sys
 from types import ModuleType
@@ -18,20 +19,25 @@ logger = logging.getLogger(__name__)
 # via ``title == _UNRESOLVED_TYPE_TITLE``. See create_output_model.
 _UNRESOLVED_TYPE_TITLE = "UiPathUnresolvedType"
 
-# Shared pseudo-module for all dynamically created types
-# This allows get_type_hints() to resolve forward references
-_DYNAMIC_MODULE_NAME = "jsonschema_pydantic_converter._dynamic"
+# Prefix for the per-conversion pseudo-modules that let get_type_hints()
+# resolve each schema's forward references.
+_DYNAMIC_MODULE_PREFIX = "jsonschema_pydantic_converter._dynamic"
+
+_dynamic_module_counter = itertools.count()
 
 
-def _get_or_create_dynamic_module() -> ModuleType:
-    """Get or create the shared pseudo-module for dynamic types."""
-    if _DYNAMIC_MODULE_NAME not in sys.modules:
-        pseudo_module = ModuleType(_DYNAMIC_MODULE_NAME)
-        pseudo_module.__doc__ = (
-            "Shared module for dynamically generated Pydantic models from JSON schemas"
-        )
-        sys.modules[_DYNAMIC_MODULE_NAME] = pseudo_module
-    return sys.modules[_DYNAMIC_MODULE_NAME]
+def _create_dynamic_module() -> ModuleType:
+    """Create a pseudo-module unique to one schema conversion.
+
+    The converter reuses generic class names (``DynamicType_0``, ...) across
+    schemas, so a shared module would let qualified-name lookups (e.g.
+    LangGraph checkpoint deserialization) resolve to a class generated from a
+    different schema.
+    """
+    module_name = f"{_DYNAMIC_MODULE_PREFIX}_{next(_dynamic_module_counter)}"
+    pseudo_module = ModuleType(module_name)
+    sys.modules[module_name] = pseudo_module
+    return pseudo_module
 
 
 def create_model(
@@ -57,17 +63,21 @@ def create_model(
             ),
         ) from e
 
-    pseudo_module = _get_or_create_dynamic_module()
+    pseudo_module = _create_dynamic_module()
 
     for type_name, type_def in namespace.items():
         setattr(pseudo_module, type_name, type_def)
         if inspect.isclass(type_def) and issubclass(type_def, BaseModel):
-            type_def.__module__ = _DYNAMIC_MODULE_NAME
-            # per-class marker; survives the shared module being overwritten.
+            type_def.__module__ = pseudo_module.__name__
+            # the namespace key is a forward-ref alias, not the class's
+            # __name__; register under __name__ too so qualified-name lookups
+            # (e.g. checkpoint deserialization) resolve.
+            setattr(pseudo_module, type_def.__name__, type_def)
+            # per-class marker for lookups by the schema's original type name.
             cast(Any, type_def).__uipath_marker_name__ = type_name
 
     setattr(pseudo_module, model.__name__, model)
-    model.__module__ = _DYNAMIC_MODULE_NAME
+    model.__module__ = pseudo_module.__name__
 
     return model
 

--- a/tests/agent/react/test_jsonschema_pydantic_converter.py
+++ b/tests/agent/react/test_jsonschema_pydantic_converter.py
@@ -1,10 +1,13 @@
 """Tests for jsonschema_pydantic_converter — create_model() and create_output_model()."""
 
 import copy
+import importlib
 import logging
+import sys
 from typing import Any
 
 import pytest
+from pydantic import BaseModel
 
 from uipath_langchain.agent.exceptions import AgentStartupError
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
@@ -502,3 +505,92 @@ class TestCreateOutputModel:
             create_output_model(schema, "my_tool")
         assert "my_tool" in caplog.text
         assert "#/$defs/Nullableofdecimal" in caplog.text
+
+
+# --- Dynamic module registration (checkpoint-deserialization safety) ---
+
+
+class TestDynamicModuleRegistration:
+    """Generated classes must resolve to themselves by (module, class name).
+
+    LangGraph checkpoint deserialization reconstructs pydantic values via
+    ``getattr(import_module(cls.__module__), cls.__name__)``; a same-named
+    class from another schema conversion must never shadow them.
+    """
+
+    @staticmethod
+    def _generated_classes(model: type) -> list[type]:
+        module = sys.modules[model.__module__]
+        return [
+            attr
+            for attr in vars(module).values()
+            if isinstance(attr, type) and issubclass(attr, BaseModel)
+        ]
+
+    def test_classes_from_different_schemas_resolve_by_qualified_name(self) -> None:
+        first = create_model(
+            {
+                "type": "object",
+                "properties": {"details": {"$ref": "#/$defs/Details"}},
+                "$defs": {
+                    "Details": {
+                        "type": "object",
+                        "properties": {"site": {"type": "string"}},
+                    }
+                },
+            }
+        )
+        second = create_model(
+            {
+                "type": "object",
+                "properties": {"topic": {"$ref": "#/$defs/Topic"}},
+                "$defs": {
+                    "Topic": {
+                        "type": "object",
+                        "properties": {"kind": {"type": "number"}},
+                    }
+                },
+            }
+        )
+
+        assert first.__module__ != second.__module__
+
+        for cls in [
+            *self._generated_classes(first),
+            *self._generated_classes(second),
+        ]:
+            resolved = getattr(importlib.import_module(cls.__module__), cls.__name__)
+            assert resolved is cls, (
+                f"{cls.__module__}.{cls.__name__} resolved to a different class"
+            )
+
+    def test_generated_models_validate_their_own_schema(self) -> None:
+        model = create_model(
+            {
+                "type": "object",
+                "properties": {"details": {"$ref": "#/$defs/Details"}},
+                "$defs": {
+                    "Details": {
+                        "type": "object",
+                        "properties": {"site": {"type": "string"}},
+                    }
+                },
+            }
+        )
+        # a later conversion with the same generic type names must not affect it
+        create_model(
+            {
+                "type": "object",
+                "properties": {"other": {"$ref": "#/$defs/Other"}},
+                "$defs": {
+                    "Other": {
+                        "type": "object",
+                        "properties": {"kind": {"type": "number"}},
+                        "required": ["kind"],
+                    }
+                },
+            }
+        )
+
+        instance = model.model_validate({"details": {"site": "syd"}})
+        assert model.model_validate(instance) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -13,9 +13,9 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
-uipath-runtime = false
 uipath = false
 uipath-platform = false
+uipath-runtime = false
 uipath-llm-client = false
 jsonschema-pydantic-converter = false
 uipath-langchain-client = false
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.16.1"
+version = "0.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Problem

An agent with an LLM-scope guardrail (e.g. prompt injection) consistently ends its run right after calling a process tool: the job is reported **Successful**, the tool shows no output, and the agent never resumes when the started Orchestrator job completes. Without the guardrail the same agent suspends and resumes correctly.

Root cause chain:

1. Every JSON schema the agent converts (agent input/output and each tool's input/output) goes through `jsonschema_pydantic_converter.create_model()`, which registered all generated Pydantic classes in **one shared pseudo-module** (`jsonschema_pydantic_converter._dynamic`) while the underlying converter reuses generic class names (`DynamicType_0`, `DynamicType_1`, ...). Each conversion silently overwrote the previous schema's same-named classes. Nested classes were additionally only registered under their forward-ref alias (e.g. `__Details`), never under their actual `__name__`.
2. With a guardrail, the LLM node becomes a compiled subgraph whose Pydantic state writes generated input-model **instances** back into the root graph's checkpoint (a plain LLM node only writes messages, which is why the bug needs a guardrail to surface).
3. When a process tool suspends via `interrupt()`, the runtime calls `graph.aget_state()` to classify the run. LangGraph checkpoint deserialization resolves those instances by `(cls.__module__, cls.__name__)` — which, due to the shadowing, returned a **different schema's class**. Re-validation inside `aget_state()` then raised `ValidationError: Input should be a valid dictionary or instance of DynamicType_0 ... input_type=DynamicType_0`.
4. The runtime swallows `aget_state()` failures and classified the interrupted run as `SUCCESSFUL`, so no resume trigger was ever created and the raw `Interrupt` object leaked into the job output (`Object of type Interrupt is not JSON serializable` in the logs).

## Fix

`create_model()` now registers each conversion in its **own** pseudo-module (`_dynamic_0`, `_dynamic_1`, ...), and every generated class is also registered under its real `__name__`. Qualified-name lookups therefore always resolve to the exact class that was serialized, `aget_state()` succeeds after a tool interrupt, and the run is correctly reported `SUSPENDED`. If a lookup ever misses (e.g. conversion order changes between suspend and resume), deserialization now degrades to a plain dict that Pydantic re-coerces — instead of resolving to a wrong same-named class.

## Testing

- New `TestDynamicModuleRegistration` tests pin the `(module, __name__)` round-trip across multiple conversions; the main test fails on the previous implementation.
- Reproduced the full production scenario (guardrail + `durable_interrupt` process tool + sqlite checkpointer, on the deployed pins uipath-langchain 0.14.12 / langgraph 1.1.10 / langgraph-checkpoint 4.0.2): `SUCCESSFUL` with a raw interrupt before the fix, `SUSPENDED` with a healthy `aget_state()` after.
- Full suite: 2628 passed; ruff, httpx linter, and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)