### PR TITLE
docs(guardrails): drop the stale connection-id line from the BYOG middleware

### DIFF
--- a/src/uipath_langchain/guardrails/middlewares/byo.py
+++ b/src/uipath_langchain/guardrails/middlewares/byo.py
@@ -33,8 +33,10 @@ class UiPathByoGuardrailMiddleware(BuiltInGuardrailMiddlewareMixin):
     content-safety subscription, a vendor validation service, or a custom
     Integration Service connector) into UiPath guardrails. An admin first
     creates the configuration under ``Admin -> AI Trust Layer -> Guardrails
-    Configurations``; this middleware then references it by its validator name
-    and (recommended) Integration Service connection id.
+    Configurations``; this middleware then references it purely by its validator
+    name, which is unique per tenant. The Integration Service connection to use
+    is resolved server-side from the configuration, so an admin rebind is always
+    honored.
 
     Example:
         ```python


### PR DESCRIPTION
## What

One-line docstring fix in `src/uipath_langchain/guardrails/middlewares/byo.py`.

## Why

AL-510 removed `connection_id` from `UiPathByoGuardrailMiddleware` — the signature, the example, and the `Args` entry all went — but the class docstring's opening paragraph still says the middleware references the configuration:

> "by its validator name and (recommended) Integration Service connection id."

`git blame` puts that line on `7f4315f8`, before the removal. It now:
- contradicts its own `Args` block a few lines below ("the Integration Service connection to use is resolved server-side"), and
- documents a constructor parameter that no longer exists — a reader following it writes `connection_id=...` and gets `TypeError`.

## The fix

Reworded to match the phrasing the core `ByoValidator` docstring already uses — name unique per tenant, connection resolved server-side, admin rebind always honored.

```diff
-    Configurations``; this middleware then references it by its validator name
-    and (recommended) Integration Service connection id.
+    Configurations``; this middleware then references it purely by its validator
+    name, which is unique per tenant. The Integration Service connection to use
+    is resolved server-side from the configuration, so an admin rebind is always
+    honored.
```

Docstring only — no signature or behavior change. Swept the rest of `guardrails/` for other connection-id references: none remain (the `byo_connection_id` hits elsewhere in the package are BYO **LLM** chat/embeddings, a separate feature that legitimately uses connection ids).

Counterpart docs fix in core: UiPath/uipath-python#1854.