### PR TITLE
feat(a2a): upgrade Python SDK to v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.16.3"
+version = "0.16.4"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -25,7 +25,7 @@ dependencies = [
     "langchain-mcp-adapters==0.2.1",
     "pillow>=12.1.1",
     "rdflib>=7.0.0, <8.0.0",
-    "a2a-sdk>=0.2.0,<1.0.0",
+    "a2a-sdk>=1.1.2,<2.0.0",
     "uipath-langchain-client[openai]>=1.17.3,<1.18.0",
 ]
 
@@ -89,6 +89,7 @@ dev = [
     "numpy>=1.24.0",
     "pytest_httpx>=0.35.0",
     "rust-just>=1.39.0",
+    "types-protobuf<7",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
+++ b/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
@@ -12,21 +12,22 @@ import asyncio
 import json
 from contextlib import AsyncExitStack, asynccontextmanager
 from logging import getLogger
-from typing import AsyncGenerator
-from uuid import uuid4
+from typing import Any, AsyncGenerator
+from urllib.parse import urlparse
 
 import httpx
 from a2a.client import Client
+from a2a.helpers import get_artifact_text, get_message_text, new_text_message
 from a2a.types import (
     AgentCard,
+    AgentInterface,
     Message,
-    Part,
     Role,
+    SendMessageRequest,
     Task,
-    TaskArtifactUpdateEvent,
     TaskState,
-    TextPart,
 )
+from google.protobuf.json_format import ParseDict
 from langchain_core.messages import ToolCall, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.types import Command
@@ -52,10 +53,10 @@ logger = getLogger(__name__)
 # The A2A terminal task states
 _TERMINAL_TASK_STATES = frozenset(
     {
-        TaskState.completed.value,
-        TaskState.canceled.value,
-        TaskState.failed.value,
-        TaskState.rejected.value,
+        "completed",
+        "canceled",
+        "failed",
+        "rejected",
     }
 )
 
@@ -78,9 +79,15 @@ class A2aClient:
     pool when done.
     """
 
-    def __init__(self, agent_card: AgentCard, resource_name: str) -> None:
+    def __init__(
+        self,
+        agent_card: AgentCard,
+        resource_name: str,
+        protocol_version: str | None = "1.0",
+    ) -> None:
         self._agent_card = agent_card
         self._resource_name = resource_name
+        self._protocol_version = protocol_version
         self._lock = asyncio.Lock()
         self._client: Client | None = None
         self._http_client: httpx.AsyncClient | None = None
@@ -93,6 +100,12 @@ class A2aClient:
                     from a2a.client import ClientConfig, ClientFactory
                     from uipath.platform import UiPath
 
+                    if self._protocol_version is None:
+                        raise ValueError(
+                            f"Remote A2A agent '{self._resource_name}' has no compatible "
+                            "JSON-RPC endpoint for A2A 1.0 or 0.3"
+                        )
+
                     sdk = UiPath()
                     folder_path = get_execution_folder_path()
                     agent = await sdk.remote_a2a.retrieve_async(
@@ -103,20 +116,31 @@ class A2aClient:
                         raise ValueError(
                             f"Remote A2A agent '{self._resource_name}' has no a2a_url configured"
                         )
-                    self._agent_card.url = agent.a2a_url
+                    runtime_card = AgentCard()
+                    runtime_card.CopyFrom(self._agent_card)
+                    runtime_card.ClearField("supported_interfaces")
+                    runtime_card.supported_interfaces.append(
+                        AgentInterface(
+                            url=agent.a2a_url,
+                            protocol_binding="JSONRPC",
+                            protocol_version=self._protocol_version,
+                        )
+                    )
 
                     client_kwargs = get_httpx_client_kwargs(
                         headers={"Authorization": f"Bearer {sdk._config.secret}"},
                     )
                     client_kwargs["timeout"] = httpx.Timeout(300.0, connect=10.0)
                     self._http_client = httpx.AsyncClient(**client_kwargs)
-                    self._client = await ClientFactory.connect(
-                        self._agent_card,
-                        client_config=ClientConfig(
+                    self._client = ClientFactory(
+                        ClientConfig(
                             httpx_client=self._http_client,
                             streaming=False,
-                        ),
-                    )
+                            accepted_output_modes=list(
+                                runtime_card.default_output_modes
+                            ),
+                        )
+                    ).create(runtime_card)
         return self._client
 
     async def dispose(self) -> None:
@@ -133,31 +157,28 @@ class A2aClient:
 
 def _extract_text(obj: Task | Message) -> str:
     """Extract text content from a Task or Message response."""
-    parts: list[Part] = []
-
     if isinstance(obj, Message):
-        parts = obj.parts or []
-    elif isinstance(obj, Task):
-        if obj.status and obj.status.state == TaskState.input_required:
-            if obj.status.message:
-                parts = obj.status.message.parts or []
-        else:
-            if obj.artifacts:
-                for artifact in obj.artifacts:
-                    parts.extend(artifact.parts or [])
-            if not parts and obj.status and obj.status.message:
-                parts = obj.status.message.parts or []
-            if not parts and obj.history:
-                for msg in reversed(obj.history):
-                    if msg.role == Role.agent:
-                        parts = msg.parts or []
-                        break
+        return get_message_text(obj)
+    if (
+        obj.HasField("status")
+        and obj.status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+        and obj.status.HasField("message")
+    ):
+        return get_message_text(obj.status.message)
+    if obj.artifacts:
+        return "\n".join(filter(None, (get_artifact_text(a) for a in obj.artifacts)))
+    if obj.HasField("status") and obj.status.HasField("message"):
+        return get_message_text(obj.status.message)
+    for message in reversed(obj.history):
+        if message.role == Role.ROLE_AGENT:
+            return get_message_text(message)
+    return ""
 
-    texts = []
-    for part in parts:
-        if isinstance(part.root, TextPart):
-            texts.append(part.root.text)
-    return "\n".join(texts) if texts else ""
+
+def _task_state_name(state: int) -> str:
+    """Return the stable lowercase task-state value used by tool state."""
+    name = TaskState.Name(state).removeprefix("TASK_STATE_").lower()
+    return "unknown" if name == "unspecified" else name
 
 
 def _format_response(text: str, state: str) -> str:
@@ -184,6 +205,75 @@ def _build_description(card: AgentCard) -> str:
     return f"Remote A2A agent: {card.name}" if card.name else "Remote A2A agent"
 
 
+def _build_metadata_card(config: AgentA2aResourceConfig) -> AgentCard:
+    """Build v1 card metadata without retaining cached transport endpoints."""
+    card = AgentCard()
+    if config.cached_agent_card:
+        ParseDict(config.cached_agent_card, card, ignore_unknown_fields=True)
+
+    if not card.name:
+        card.name = config.name
+    if not card.description and config.description:
+        card.description = config.description
+    if not card.default_input_modes:
+        card.default_input_modes.append("text/plain")
+    if not card.default_output_modes:
+        card.default_output_modes.append("text/plain")
+
+    # Cached cards may point directly at third-party agents. Invocation must
+    # always go through the binding-aware AgentHub proxy resolved at runtime.
+    card.ClearField("supported_interfaces")
+    return card
+
+
+def _select_protocol_version(cached_card: dict[str, Any] | None) -> str | None:
+    """Select the best JSON-RPC protocol advertised by a cached agent card."""
+    if not isinstance(cached_card, dict):
+        return None
+
+    interfaces = cached_card.get("supportedInterfaces")
+    if isinstance(interfaces, list):
+        for interface in interfaces:
+            if (
+                isinstance(interface, dict)
+                and _is_http_endpoint(interface.get("url"))
+                and _is_jsonrpc(interface.get("protocolBinding"))
+                and _is_protocol_version(interface.get("protocolVersion"), 1, 0)
+            ):
+                return "1.0"
+
+    if (
+        _is_http_endpoint(cached_card.get("url"))
+        and _is_jsonrpc(cached_card.get("preferredTransport", "JSONRPC"))
+        and _is_protocol_version(cached_card.get("protocolVersion", "0.3.0"), 0, 3)
+    ):
+        return "0.3"
+
+    return None
+
+
+def _is_http_endpoint(value: Any) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme.lower() in {"http", "https"} and bool(parsed.netloc)
+
+
+def _is_jsonrpc(value: Any) -> bool:
+    return isinstance(value, str) and value.strip().upper() == "JSONRPC"
+
+
+def _is_protocol_version(value: Any, major: int, minor: int) -> bool:
+    if not isinstance(value, str):
+        return False
+    parts = value.strip().split(".")
+    if not 2 <= len(parts) <= 4 or not all(
+        part.isascii() and part.isdigit() for part in parts
+    ):
+        return False
+    return int(parts[0]) == major and int(parts[1]) == minor
+
+
 async def _send_a2a_message(
     client: Client,
     agent_label: str,
@@ -204,10 +294,9 @@ async def _send_a2a_message(
     else:
         logger.info("A2A new message to %s", agent_label)
 
-    a2a_message = Message(
-        role=Role.user,
-        parts=[Part(root=TextPart(text=message))],
-        message_id=str(uuid4()),
+    a2a_message = new_text_message(
+        message,
+        role=Role.ROLE_USER,
         task_id=task_id,
         context_id=context_id,
     )
@@ -218,24 +307,22 @@ async def _send_a2a_message(
         new_task_id = task_id
         new_context_id = context_id
 
-        async for event in client.send_message(a2a_message):
-            if isinstance(event, Message):
-                text = _extract_text(event)
-                new_context_id = event.context_id
+        async for response in client.send_message(
+            SendMessageRequest(message=a2a_message)
+        ):
+            if response.HasField("message"):
+                text = _extract_text(response.message)
+                new_context_id = response.message.context_id or new_context_id
                 state = "completed"
                 break
-            else:
-                task, update = event
-                new_task_id = task.id
-                new_context_id = task.context_id
-                state = task.status.state.value if task.status else "unknown"
-                if update is None:
-                    text = _extract_text(task)
-                    break
-                elif isinstance(update, TaskArtifactUpdateEvent):
-                    for part in update.artifact.parts or []:
-                        if isinstance(part.root, TextPart):
-                            text += part.root.text
+            if response.HasField("task"):
+                task = response.task
+                text = _extract_text(task)
+                new_task_id = task.id or new_task_id
+                new_context_id = task.context_id or new_context_id
+                if task.HasField("status"):
+                    state = _task_state_name(task.status.state)
+                break
 
         return (text or "No response received.", state, new_task_id, new_context_id)
 
@@ -391,21 +478,13 @@ def create_a2a_tools_and_clients(
 
         logger.info("Creating A2A tool for resource '%s'", resource.name)
 
-        if resource.cached_agent_card:
-            agent_card = AgentCard(**resource.cached_agent_card)
-        else:
-            agent_card = AgentCard(
-                url="",
-                name=resource.name,
-                description=resource.description or "",
-                version="1.0.0",
-                skills=[],
-                capabilities={},
-                default_input_modes=["text/plain"],
-                default_output_modes=["text/plain"],
-            )
+        agent_card = _build_metadata_card(resource)
 
-        a2a_client = A2aClient(agent_card, resource.name)
+        a2a_client = A2aClient(
+            agent_card,
+            resource.name,
+            protocol_version=_select_protocol_version(resource.cached_agent_card),
+        )
         tool = _create_a2a_tool(resource, a2a_client, agent_card)
         tools.append(tool)
         clients.append(a2a_client)

--- a/tests/agent/tools/test_a2a_sdk_v1_migration.py
+++ b/tests/agent/tools/test_a2a_sdk_v1_migration.py
@@ -1,0 +1,466 @@
+"""Migration contract tests for the A2A Python SDK v1."""
+
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+from typing import Any, cast
+
+import httpx
+import pytest
+from a2a.client import Client
+from a2a.types import (
+    AgentCard,
+    Artifact,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    StreamResponse,
+    Task,
+    TaskState,
+    TaskStatus,
+)
+from uipath.agent.models.agent import AgentA2aResourceConfig
+
+import uipath_langchain.agent.tools.a2a.a2a_tool as a2a_tool
+from uipath_langchain.agent.tools.a2a.a2a_tool import (
+    A2aClient,
+    _send_a2a_message,
+    create_a2a_tools_and_clients,
+)
+
+PROXY_URL = (
+    "https://cloud.uipath.com/org/tenant/agenthub_/a2a/remote/folder/remote-agent"
+)
+
+
+def test_a2a_tool_imports_with_sdk_v1() -> None:
+    """The A2A tool must not import APIs removed by a2a-sdk v1."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import uipath_langchain.agent.tools.a2a.a2a_tool",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+async def test_client_uses_strict_v1_jsonrpc_interface_at_proxy_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached endpoints must not replace the binding-aware AgentHub proxy."""
+    import uipath.platform as uipath_platform
+    from a2a.client import ClientFactory
+
+    sdk = SimpleNamespace(
+        remote_a2a=SimpleNamespace(
+            retrieve_async=lambda **_: _async_value(SimpleNamespace(a2a_url=PROXY_URL))
+        ),
+        _config=SimpleNamespace(secret="token"),
+    )
+    monkeypatch.setattr(uipath_platform, "UiPath", lambda: sdk)
+    monkeypatch.setattr(a2a_tool, "get_execution_folder_path", lambda: "Shared")
+
+    captured: dict[str, Any] = {}
+    connected = SimpleNamespace()
+
+    def _fake_create(self: ClientFactory, card: AgentCard):
+        captured["card"] = card
+        return connected
+
+    monkeypatch.setattr(ClientFactory, "create", _fake_create)
+
+    metadata_card = AgentCard(name="Remote Agent", description="cached")
+    client = A2aClient(metadata_card, resource_name="remote-agent")
+
+    assert await client.get() is connected
+    interfaces = list(captured["card"].supported_interfaces)
+    assert len(interfaces) == 1
+    assert interfaces[0].url == PROXY_URL
+    assert interfaces[0].protocol_binding == "JSONRPC"
+    assert interfaces[0].protocol_version == "1.0"
+    assert client._http_client is not None
+    assert client._http_client.headers["A2A-Version"] == "1.0"
+
+    await client.dispose()
+
+
+async def test_client_uses_v03_compat_for_legacy_only_cached_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A legacy-only binding must use the SDK's v0.3 compatibility client."""
+    import uipath.platform as uipath_platform
+
+    sdk = SimpleNamespace(
+        remote_a2a=SimpleNamespace(
+            retrieve_async=lambda **_: _async_value(SimpleNamespace(a2a_url=PROXY_URL))
+        ),
+        _config=SimpleNamespace(secret="token"),
+    )
+    monkeypatch.setattr(uipath_platform, "UiPath", lambda: sdk)
+    monkeypatch.setattr(a2a_tool, "get_execution_folder_path", lambda: "Shared")
+    captured: dict[str, Any] = {}
+
+    async def _handle_request(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        captured["headers"] = request.headers
+        captured["payload"] = payload
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": payload["id"],
+                "result": {
+                    "kind": "message",
+                    "messageId": "reply-1",
+                    "role": "agent",
+                    "parts": [{"kind": "text", "text": "pong"}],
+                },
+            },
+        )
+
+    monkeypatch.setattr(
+        a2a_tool,
+        "get_httpx_client_kwargs",
+        lambda **kwargs: {
+            "headers": kwargs["headers"],
+            "transport": httpx.MockTransport(_handle_request),
+        },
+    )
+
+    resource = AgentA2aResourceConfig(
+        id="resource-id",
+        name="remote-agent",
+        description="resource description",
+        is_enabled=True,
+        slug="remote-agent",
+        folder_path="Shared",
+        cached_agent_card={
+            "url": "https://legacy.example/a2a",
+            "name": "Legacy Agent",
+            "preferredTransport": "JSONRPC",
+            "protocolVersion": "0.3.0",
+            "capabilities": {},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+        },
+    )
+    _, clients = create_a2a_tools_and_clients([resource])
+
+    connected = await clients[0].get()
+    result = await _send_a2a_message(
+        connected,
+        "remote-agent",
+        message="ping",
+        task_id=None,
+        context_id=None,
+    )
+
+    assert result == ("pong", "completed", None, None)
+    assert captured["url"] == PROXY_URL
+    assert captured["headers"]["A2A-Version"] == "0.3"
+    assert captured["payload"]["method"] == "message/send"
+    assert captured["payload"]["params"]["configuration"]["acceptedOutputModes"] == [
+        "text/plain"
+    ]
+
+    await clients[0].dispose()
+
+
+async def test_client_prefers_v1_when_cached_card_advertises_both_versions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blended card must negotiate v1 without probing the legacy endpoint."""
+    import uipath.platform as uipath_platform
+    from a2a.client import ClientFactory
+
+    sdk = SimpleNamespace(
+        remote_a2a=SimpleNamespace(
+            retrieve_async=lambda **_: _async_value(SimpleNamespace(a2a_url=PROXY_URL))
+        ),
+        _config=SimpleNamespace(secret="token"),
+    )
+    monkeypatch.setattr(uipath_platform, "UiPath", lambda: sdk)
+    monkeypatch.setattr(a2a_tool, "get_execution_folder_path", lambda: "Shared")
+
+    captured: dict[str, Any] = {}
+    connected = SimpleNamespace()
+
+    def _fake_create(self: ClientFactory, card: AgentCard):
+        captured["card"] = card
+        return connected
+
+    monkeypatch.setattr(ClientFactory, "create", _fake_create)
+
+    resource = AgentA2aResourceConfig(
+        id="resource-id",
+        name="remote-agent",
+        description="resource description",
+        is_enabled=True,
+        slug="remote-agent",
+        folder_path="Shared",
+        cached_agent_card={
+            "url": "https://legacy.example/a2a",
+            "name": "Blended Agent",
+            "preferredTransport": "JSONRPC",
+            "protocolVersion": "0.3.0",
+            "supportedInterfaces": [
+                {
+                    "url": "https://v1.example/a2a",
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0",
+                }
+            ],
+            "capabilities": {},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+        },
+    )
+    _, clients = create_a2a_tools_and_clients([resource])
+
+    assert await clients[0].get() is connected
+    assert captured["card"].supported_interfaces[0].protocol_version == "1.0"
+    assert clients[0]._http_client is not None
+    assert clients[0]._http_client.headers["A2A-Version"] == "1.0"
+
+    await clients[0].dispose()
+
+
+async def test_client_rejects_cached_card_without_compatible_jsonrpc_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unsupported card must fail before an A2A request can be dispatched."""
+    import uipath.platform as uipath_platform
+    from a2a.client import ClientFactory
+
+    sdk = SimpleNamespace(
+        remote_a2a=SimpleNamespace(
+            retrieve_async=lambda **_: _async_value(SimpleNamespace(a2a_url=PROXY_URL))
+        ),
+        _config=SimpleNamespace(secret="token"),
+    )
+    monkeypatch.setattr(uipath_platform, "UiPath", lambda: sdk)
+    monkeypatch.setattr(a2a_tool, "get_execution_folder_path", lambda: "Shared")
+    create_calls = 0
+
+    def _fake_create(self: ClientFactory, card: AgentCard):
+        nonlocal create_calls
+        create_calls += 1
+        return SimpleNamespace()
+
+    monkeypatch.setattr(ClientFactory, "create", _fake_create)
+
+    resource = AgentA2aResourceConfig(
+        id="resource-id",
+        name="remote-agent",
+        description="resource description",
+        is_enabled=True,
+        slug="remote-agent",
+        folder_path="Shared",
+        cached_agent_card={
+            "name": "Unsupported Agent",
+            "supportedInterfaces": [
+                {
+                    "url": "https://malformed.example/a2a",
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0.invalid",
+                }
+            ],
+            "capabilities": {},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+        },
+    )
+    _, clients = create_a2a_tools_and_clients([resource])
+
+    with pytest.raises(ValueError, match="no compatible JSON-RPC endpoint"):
+        await clients[0].get()
+    assert create_calls == 0
+
+
+async def _async_value(value: Any) -> Any:
+    return value
+
+
+def test_legacy_cached_card_remains_usable_as_tool_metadata() -> None:
+    """A cached v0.3 card must not prevent creating a v1-backed tool."""
+    resource = AgentA2aResourceConfig(
+        id="resource-id",
+        name="remote-agent",
+        description="resource description",
+        is_enabled=True,
+        slug="remote-agent",
+        folder_path="Shared",
+        cached_agent_card={
+            "url": "https://untrusted.example/ignored",
+            "name": "Remote Agent",
+            "description": "cached description",
+            "version": "2.3.4",
+            "skills": [
+                {
+                    "id": "answer",
+                    "name": "Answer questions",
+                    "description": "Answers a user question",
+                    "tags": ["qa"],
+                }
+            ],
+            "capabilities": {},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+        },
+    )
+
+    tools, clients = create_a2a_tools_and_clients([resource])
+
+    assert tools[0].name == "Remote_Agent"
+    assert "cached description" in tools[0].description
+    assert "Answer questions" in tools[0].description
+    assert clients[0]._agent_card.name == "Remote Agent"
+    assert list(clients[0]._agent_card.supported_interfaces) == []
+
+
+class _FakeClient:
+    def __init__(self, responses: list[StreamResponse]) -> None:
+        self.responses = responses
+        self.sent: list[SendMessageRequest] = []
+
+    async def send_message(self, request: SendMessageRequest):
+        self.sent.append(request)
+        for response in self.responses:
+            yield response
+
+
+async def test_send_message_uses_v1_request_and_reads_message_response() -> None:
+    """A call must use v1 protobuf envelopes while retaining conversation IDs."""
+    response = StreamResponse(
+        message=Message(
+            message_id="reply-1",
+            context_id="context-1",
+            role=Role.ROLE_AGENT,
+            parts=[Part(text="pong")],
+        )
+    )
+    client = _FakeClient([response])
+
+    result = await _send_a2a_message(
+        cast(Client, client),
+        "remote-agent",
+        message="ping",
+        task_id="task-1",
+        context_id="context-1",
+    )
+
+    assert result == ("pong", "completed", "task-1", "context-1")
+    request = client.sent[0]
+    assert request.message.role == Role.ROLE_USER
+    assert request.message.parts[0].text == "ping"
+    assert request.message.task_id == "task-1"
+    assert request.message.context_id == "context-1"
+
+
+async def test_send_message_reads_completed_task_artifacts() -> None:
+    """A v1 task response must return artifacts and its continuation IDs."""
+    response = StreamResponse(
+        task=Task(
+            id="task-2",
+            context_id="context-2",
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+            artifacts=[Artifact(artifact_id="artifact-1", parts=[Part(text="done")])],
+        )
+    )
+    client = _FakeClient([response])
+
+    result = await _send_a2a_message(
+        cast(Client, client),
+        "remote-agent",
+        message="work",
+        task_id=None,
+        context_id=None,
+    )
+
+    assert result == ("done", "completed", "task-2", "context-2")
+
+
+async def test_send_message_reads_input_required_status_message() -> None:
+    """An input-required task must expose the agent's follow-up question."""
+    response = StreamResponse(
+        task=Task(
+            id="task-3",
+            context_id="context-3",
+            artifacts=[
+                Artifact(
+                    artifact_id="partial-1",
+                    parts=[Part(text="stale partial result")],
+                )
+            ],
+            status=TaskStatus(
+                state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                message=Message(
+                    message_id="question-1",
+                    role=Role.ROLE_AGENT,
+                    parts=[Part(text="Which account?")],
+                ),
+            ),
+        )
+    )
+    client = _FakeClient([response])
+
+    result = await _send_a2a_message(
+        cast(Client, client),
+        "remote-agent",
+        message="continue",
+        task_id="task-3",
+        context_id="context-3",
+    )
+
+    assert result == (
+        "Which account?",
+        "input_required",
+        "task-3",
+        "context-3",
+    )
+
+
+async def test_send_message_falls_back_to_latest_agent_history() -> None:
+    """A task without artifacts must surface its latest agent history entry."""
+    response = StreamResponse(
+        task=Task(
+            id="task-4",
+            context_id="context-4",
+            status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+            history=[
+                Message(
+                    message_id="user-1",
+                    role=Role.ROLE_USER,
+                    parts=[Part(text="ignored")],
+                ),
+                Message(
+                    message_id="agent-1",
+                    role=Role.ROLE_AGENT,
+                    parts=[Part(text="Still working")],
+                ),
+            ],
+        )
+    )
+
+    result = await _send_a2a_message(
+        cast(Client, _FakeClient([response])),
+        "remote-agent",
+        message="status",
+        task_id="task-4",
+        context_id="context-4",
+    )
+
+    assert result == (
+        "Still working",
+        "working",
+        "task-4",
+        "context-4",
+    )

--- a/tests/agent/tools/test_a2a_tool.py
+++ b/tests/agent/tools/test_a2a_tool.py
@@ -17,10 +17,11 @@ from a2a.types import (
     Message,
     Part,
     Role,
+    SendMessageRequest,
+    StreamResponse,
     Task,
     TaskState,
     TaskStatus,
-    TextPart,
 )
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -139,11 +140,14 @@ def _patch_runtime(monkeypatch: pytest.MonkeyPatch, sdk: Any) -> dict[str, Any]:
 
     connected = SimpleNamespace(value="connected")
 
-    async def _fake_connect(agent_card, *, client_config):
+    captured: dict[str, AgentCard] = {}
+
+    def _fake_create(self: ClientFactory, agent_card: AgentCard):
+        captured["card"] = agent_card
         return connected
 
-    monkeypatch.setattr(ClientFactory, "connect", staticmethod(_fake_connect))
-    return {"connected": connected}
+    monkeypatch.setattr(ClientFactory, "create", _fake_create)
+    return {"connected": connected, "captured": captured}
 
 
 async def test_client_resolves_proxy_url_via_retrieve(
@@ -153,7 +157,6 @@ async def test_client_resolves_proxy_url_via_retrieve(
     handles = _patch_runtime(monkeypatch, sdk)
 
     card = AgentCard(
-        url=CACHED_URL,
         name="Remote Agent",
         description="cached",
         version="1.0.0",
@@ -168,7 +171,10 @@ async def test_client_resolves_proxy_url_via_retrieve(
 
     assert result is handles["connected"]
     # URL resolved from the retrieved agent's a2a_url, not the cached card URL.
-    assert card.url == PROXY_URL
+    runtime_card = handles["captured"]["card"]
+    assert runtime_card.supported_interfaces[0].url == PROXY_URL
+    assert runtime_card.supported_interfaces[0].protocol_binding == "JSONRPC"
+    assert runtime_card.supported_interfaces[0].protocol_version == "1.0"
     assert sdk.remote_a2a.calls == [("Remote Agent", "Shared")]
 
     await client.dispose()
@@ -181,7 +187,6 @@ async def test_client_raises_when_agent_has_no_proxy_url(
     _patch_runtime(monkeypatch, sdk)
 
     card = AgentCard(
-        url="",
         name="Remote Agent",
         description="",
         version="1.0.0",
@@ -196,37 +201,38 @@ async def test_client_raises_when_agent_has_no_proxy_url(
         await client.get()
 
 
-def _agent_message(text: str, context_id: str | None = None) -> Message:
-    return Message(
-        role=Role.agent,
-        parts=[Part(root=TextPart(text=text))],
-        message_id="msg-1",
-        context_id=context_id,
+def _agent_message(text: str, context_id: str | None = None) -> StreamResponse:
+    return StreamResponse(
+        message=Message(
+            role=Role.ROLE_AGENT,
+            parts=[Part(text=text)],
+            message_id="msg-1",
+            context_id=context_id or "",
+        )
     )
 
 
 class _FakeA2aClient:
     """Minimal stand-in for the a2a Client whose send_message yields events."""
 
-    def __init__(self, events: list[object]) -> None:
+    def __init__(self, events: list[StreamResponse]) -> None:
         self._events = events
-        self.sent: list[Message] = []
+        self.sent: list[SendMessageRequest] = []
 
-    async def send_message(self, message: Message):
-        self.sent.append(message)
+    async def send_message(self, request: SendMessageRequest):
+        self.sent.append(request)
         for event in self._events:
             yield event
 
 
 class _RaisingA2aClient:
-    async def send_message(self, message: Message):
+    async def send_message(self, request: SendMessageRequest):
         raise RuntimeError("boom")
         yield  # pragma: no cover - marks this as an async generator
 
 
 def test_build_description_falls_back_to_name() -> None:
     card = AgentCard(
-        url="",
         name="Finance Agent",
         description="",
         version="1.0.0",
@@ -240,7 +246,6 @@ def test_build_description_falls_back_to_name() -> None:
 
 def test_build_description_generic_when_no_name() -> None:
     card = AgentCard(
-        url="",
         name="",
         description="",
         version="1.0.0",
@@ -278,7 +283,7 @@ async def test_send_a2a_message_continues_existing_task() -> None:
     assert text == "again"
     assert context_id == "ctx-2"
     # The continued message carries the prior task/context ids.
-    assert client.sent[0].task_id == "task-1"
+    assert client.sent[0].message.task_id == "task-1"
 
 
 async def test_send_a2a_message_handles_error() -> None:
@@ -334,34 +339,38 @@ async def test_tool_wrapper_persists_conversation(
 
 def _completed_task(
     *, task_id: str = "task-1", context_id: str = "ctx-1", text: str = "done"
-) -> Task:
-    return Task(
-        id=task_id,
-        context_id=context_id,
-        status=TaskStatus(state=TaskState.completed),
-        artifacts=[
-            Artifact(
-                artifact_id="artifact-1",
-                parts=[Part(root=TextPart(text=text))],
-            )
-        ],
+) -> StreamResponse:
+    return StreamResponse(
+        task=Task(
+            id=task_id,
+            context_id=context_id,
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+            artifacts=[
+                Artifact(
+                    artifact_id="artifact-1",
+                    parts=[Part(text=text)],
+                )
+            ],
+        )
     )
 
 
 def _input_required_task(
     *, task_id: str = "task-1", context_id: str = "ctx-1", text: str = "need more"
-) -> Task:
-    return Task(
-        id=task_id,
-        context_id=context_id,
-        status=TaskStatus(
-            state=TaskState.input_required,
-            message=Message(
-                role=Role.agent,
-                parts=[Part(root=TextPart(text=text))],
-                message_id="status-msg",
+) -> StreamResponse:
+    return StreamResponse(
+        task=Task(
+            id=task_id,
+            context_id=context_id,
+            status=TaskStatus(
+                state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                message=Message(
+                    role=Role.ROLE_AGENT,
+                    parts=[Part(text=text)],
+                    message_id="status-msg",
+                ),
             ),
-        ),
+        )
     )
 
 
@@ -373,9 +382,7 @@ async def test_tool_wrapper_drops_task_id_after_terminal_state(
     resource = _make_resource(cached_agent_card=_cached_card())
     tools, clients = create_a2a_tools_and_clients([resource])
     tool = cast(A2aStructuredToolWithWrapper, tools[0])
-    fake = _FakeA2aClient(
-        [(_completed_task(task_id="task-1", context_id="ctx-1"), None)]
-    )
+    fake = _FakeA2aClient([_completed_task(task_id="task-1", context_id="ctx-1")])
 
     async def _get():
         return fake
@@ -400,9 +407,7 @@ async def test_tool_wrapper_keeps_task_id_when_not_terminal(
     resource = _make_resource(cached_agent_card=_cached_card())
     tools, clients = create_a2a_tools_and_clients([resource])
     tool = cast(A2aStructuredToolWithWrapper, tools[0])
-    fake = _FakeA2aClient(
-        [(_input_required_task(task_id="task-1", context_id="ctx-1"), None)]
-    )
+    fake = _FakeA2aClient([_input_required_task(task_id="task-1", context_id="ctx-1")])
 
     async def _get():
         return fake

--- a/uv.lock
+++ b/uv.lock
@@ -23,18 +23,21 @@ uipath-core = false
 
 [[package]]
 name = "a2a-sdk"
-version = "0.3.26"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "culsans", marker = "python_full_version < '3.13'" },
     { name = "google-api-core" },
+    { name = "googleapis-common-protos" },
     { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "json-rpc" },
+    { name = "packaging" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/97/a6840e01795b182ce751ca165430d46459927cde9bfab838087cbb24aef7/a2a_sdk-0.3.26.tar.gz", hash = "sha256:44068e2d037afbb07ab899267439e9bc7eaa7ac2af94f1e8b239933c993ad52d", size = 274598, upload-time = "2026-04-09T15:21:13.902Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/cc/59b35c518d8289bd59d20d9d216ca29ccb41c4697eb85971efe41d1adaf3/a2a_sdk-1.1.2.tar.gz", hash = "sha256:f928d8bf9a0dc0a473ee8258bd5226c1b8520a85c70e7f233c3b9b0e30a1bd10", size = 379627, upload-time = "2026-07-22T13:40:51.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/d5/51f4ee1bf3b736add42a542d3c8a3fd3fa85f3d36c17972127defc46c26f/a2a_sdk-0.3.26-py3-none-any.whl", hash = "sha256:754e0573f6d33b225c1d8d51f640efa69cbbed7bdfb06ce9c3540ea9f58d4a91", size = 151016, upload-time = "2026-04-09T15:21:12.35Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/33/d414a03d5ef5a7d6d09a20dc9f8094e7fb9edb488662ff99c535a2a62cf1/a2a_sdk-1.1.2-py3-none-any.whl", hash = "sha256:eb9a698f526dc45a9ea967d7804e7aa363ff273d2c44fbed699bc68c9399f9c9", size = 245981, upload-time = "2026-07-22T13:40:49.484Z" },
 ]
 
 [[package]]
@@ -162,6 +165,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
     { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
     { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
+]
+
+[[package]]
+name = "aiologic"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/d3/2d310b1b839014034dba0cba685e492df8a5c7ad32c19cab7e979eed6554/aiologic-0.17.1-py3-none-any.whl", hash = "sha256:c66b319830fedb7ca3d2b2125fa6f5b653f89418c2a27ea76f259ec5f00943c0", size = 161331, upload-time = "2026-06-27T20:41:31.877Z" },
 ]
 
 [[package]]
@@ -921,6 +938,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
     { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
     { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+]
+
+[[package]]
+name = "culsans"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811, upload-time = "2025-12-31T23:15:37.189Z" },
 ]
 
 [[package]]
@@ -1754,6 +1784,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "json-rpc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854, upload-time = "2023-06-11T09:45:49.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450, upload-time = "2023-06-11T09:45:47.136Z" },
 ]
 
 [[package]]
@@ -4422,6 +4461,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-protobuf"
+version = "6.32.1.20260221"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/e2/9aa4a3b2469508bd7b4e2ae11cbedaf419222a09a1b94daffcd5efca4023/types_protobuf-6.32.1.20260221.tar.gz", hash = "sha256:6d5fb060a616bfb076cbb61b4b3c3969f5fc8bec5810f9a2f7e648ee5cbcbf6e", size = 64408, upload-time = "2026-02-21T03:55:13.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e8/1fd38926f9cf031188fbc5a96694203ea6f24b0e34bd64a225ec6f6291ba/types_protobuf-6.32.1.20260221-py3-none-any.whl", hash = "sha256:da7cdd947975964a93c30bfbcc2c6841ee646b318d3816b033adc2c4eb6448e4", size = 77956, upload-time = "2026-02-21T03:55:12.894Z" },
+]
+
+[[package]]
 name = "types-s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4498,7 +4546,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4556,12 +4604,13 @@ dev = [
     { name = "pytest-mock" },
     { name = "ruff" },
     { name = "rust-just" },
+    { name = "types-protobuf" },
     { name = "virtualenv" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.2.0,<1.0.0" },
+    { name = "a2a-sdk", specifier = ">=1.1.2,<2.0.0" },
     { name = "boto3-stubs", marker = "extra == 'bedrock'", specifier = ">=1.41.4" },
     { name = "deepagents", specifier = ">=0.5.9,<0.6.0" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -4606,6 +4655,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.11.1" },
     { name = "ruff", specifier = ">=0.9.4" },
     { name = "rust-just", specifier = ">=1.39.0" },
+    { name = "types-protobuf", specifier = "<7" },
     { name = "virtualenv", specifier = ">=20.36.1" },
 ]
 


### PR DESCRIPTION
## Description

- Bump the uipath-langchain package version from 0.16.3 to 0.16.4.
- Upgrade a2a-sdk from 0.3.x to 1.1.2 and migrate the A2A tool to the v1 protobuf request and response types.
- Negotiate the runtime JSON-RPC protocol from the cached agent card: prefer an advertised v1 interface, otherwise use the SDK's v0.3 compatibility transport for a valid legacy endpoint.
- Populate the SDK client's accepted output modes from the selected card, including the required `acceptedOutputModes` field on v0.3 requests.
- Fail before dispatch when the card advertises neither compatible endpoint; do not retry or downgrade after sending a request.
- Always replace cached third-party URLs with the binding-aware AgentHub proxy URL. The selected SDK transport supplies the matching A2A-Version header and wire format.
- Preserve bearer authentication, task and context continuation, terminal-task cleanup, response extraction, client disposal, and the existing single A2A trace span.
- Prioritize input-required status prompts over stale or partial artifacts.
- AgentHub version-aware proxy routing is already merged in UiPath/AgentHubService#1619.

## Validation

- Full test suite: 2,684 passed (86.20% coverage).
- Focused A2A suite: 27 passed.
- Real Alpha external 0.3-only agent through the AgentHub Remote proxy: verified card negotiation, two `message/send` requests, `A2A-Version: 0.3`, card-derived `acceptedOutputModes`, and non-empty responses.
- Exact published dev wheel against a real Alpha stateful conversational agent: verified both v1 and v0.3 initial requests and continuations with task/context preservation.
- Mypy: passed across 357 source files.
- Ruff lint and format checks: passed across 357 files.
- Custom httpx client lint: passed.
- Wheel and source archive build: passed with package version 0.16.4.
- Vulnerability audit of the changed dependency set: no known vulnerabilities found.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-langchain==0.16.4.dev1010365581",

  # Any version from PR
  "uipath-langchain>=0.16.4.dev1010360000,<0.16.4.dev1010370000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-langchain = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath-langchain>=0.16.4.dev1010360000,<0.16.4.dev1010370000",
]
```
<!-- DEV_PACKAGE_END -->
