### PR TITLE
fix: process tool folder fallback when UIPATH_FOLDER_PATH is unset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.16.4"
+version = "0.16.5"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/_utils/__init__.py
+++ b/src/uipath_langchain/_utils/__init__.py
@@ -1,4 +1,4 @@
-from ._environment import get_execution_folder_path
+from ._environment import get_execution_folder_key, get_execution_folder_path
 from ._otel import (
     get_current_span_and_trace_ids,
     set_current_span_error,
@@ -10,6 +10,7 @@ from ._request_mixin import UiPathRequestMixin
 __all__ = [
     "UiPathRequestMixin",
     "get_current_span_and_trace_ids",
+    "get_execution_folder_key",
     "get_execution_folder_path",
     "get_unique_model_field_name",
     "set_current_span_error",

--- a/src/uipath_langchain/_utils/_environment.py
+++ b/src/uipath_langchain/_utils/_environment.py
@@ -6,5 +6,14 @@ def get_execution_folder_path() -> str | None:
     return os.environ.get("UIPATH_FOLDER_PATH")
 
 
+def get_execution_folder_key() -> str | None:
+    """Reads the agent's executing folder key from the runtime environment.
+
+    Some job environments (e.g. eval serverless jobs) only expose the folder
+    key, not the folder path.
+    """
+    return os.environ.get("UIPATH_FOLDER_KEY")
+
+
 def get_default_timeout() -> float:
     return float(os.getenv("UIPATH_TIMEOUT_SECONDS", "895"))

--- a/src/uipath_langchain/agent/tools/process_tool.py
+++ b/src/uipath_langchain/agent/tools/process_tool.py
@@ -12,7 +12,10 @@ from uipath.platform.errors import EnrichedException
 from uipath.platform.orchestrator import JobState
 from uipath.runtime.errors import UiPathErrorCategory
 
-from uipath_langchain._utils import get_execution_folder_path
+from uipath_langchain._utils import (
+    get_execution_folder_key,
+    get_execution_folder_path,
+)
 from uipath_langchain._utils.durable_interrupt import durable_interrupt
 from uipath_langchain.agent.exceptions import raise_for_enriched
 from uipath_langchain.agent.react.job_attachments import get_job_attachments
@@ -52,7 +55,11 @@ def create_process_tool(
 
     tool_name: str = sanitize_tool_name(resource.name)
     process_name = resource.properties.process_name
-    folder_path = get_execution_folder_path()
+    # Eval serverless jobs expose UIPATH_FOLDER_KEY but not UIPATH_FOLDER_PATH;
+    # without a folder header StartJobs returns 404 for a deployed process.
+    # invoke_async accepts only one of folder_path/folder_key, so resolve one.
+    folder_path = get_execution_folder_path() or resource.properties.folder_path
+    folder_key = get_execution_folder_key() if not folder_path else None
 
     input_model: Any = create_model(resource.input_schema)
     output_model: Any = create_output_model(resource.output_schema, resource.name)
@@ -82,6 +89,7 @@ def create_process_tool(
                     job = await client.processes.invoke_async(
                         name=process_name,
                         input_arguments=input_arguments,
+                        folder_key=folder_key,
                         folder_path=folder_path,
                         attachments=attachments,
                         parent_span_id=parent_span_id,
@@ -136,6 +144,7 @@ def create_process_tool(
             "tool_type": resource.type.lower(),
             "display_name": process_name,
             "folder_path": folder_path,
+            "folder_key": folder_key,
             "args_schema": input_model,
             "output_schema": output_model,
             "_span_context": _span_context,

--- a/tests/agent/tools/test_process_tool.py
+++ b/tests/agent/tools/test_process_tool.py
@@ -175,6 +175,7 @@ class TestProcessToolInvocation:
         mock_client.processes.invoke_async.assert_called_once_with(
             name="MyProcess",
             input_arguments={},
+            folder_key=None,
             folder_path="/Shared/MyFolder",
             attachments=[],
             parent_span_id=None,
@@ -487,6 +488,104 @@ class TestProcessToolRunAsMe:
         assert call_kwargs["run_as_me"] is None
 
 
+class TestProcessToolFolderResolution:
+    """Test folder context resolution: env folder path, resource folder path, env folder key."""
+
+    @staticmethod
+    def _mock_client(mock_uipath_class, mock_interrupt):
+        mock_job = MagicMock(spec=Job)
+        mock_job.key = "job-key"
+        mock_job.folder_key = "folder-key"
+
+        mock_resumed_job = MagicMock(spec=Job)
+        mock_resumed_job.state = "successful"
+
+        mock_client = MagicMock()
+        mock_client.processes.invoke_async = AsyncMock(return_value=mock_job)
+        mock_client.jobs.extract_output_async = AsyncMock(return_value=None)
+        mock_uipath_class.return_value = mock_client
+
+        mock_interrupt.return_value = mock_resumed_job
+        return mock_client
+
+    @pytest.fixture
+    def resource_without_folder_path(self):
+        """A process resource with no design-time folder path (solution deployments)."""
+        return AgentProcessToolResourceConfig(
+            type=AgentToolType.PROCESS,
+            name="test_process",
+            description="Test process description",
+            input_schema={"type": "object", "properties": {}},
+            output_schema={"type": "object", "properties": {}},
+            properties=AgentProcessToolProperties(process_name="MyProcess"),
+        )
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_falls_back_to_resource_folder_path_when_env_unset(
+        self, mock_uipath_class, mock_interrupt, process_resource
+    ):
+        """Without UIPATH_FOLDER_PATH, the resource's folderPath is used."""
+        mock_client = self._mock_client(mock_uipath_class, mock_interrupt)
+
+        tool = create_process_tool(process_resource)
+        await tool.ainvoke({})
+
+        call_kwargs = mock_client.processes.invoke_async.call_args[1]
+        assert call_kwargs["folder_path"] == "/Shared/MyFolder"
+        assert call_kwargs["folder_key"] is None
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "env-folder-key"}, clear=True)
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_falls_back_to_env_folder_key_when_no_folder_path(
+        self, mock_uipath_class, mock_interrupt, resource_without_folder_path
+    ):
+        """Eval serverless jobs only expose UIPATH_FOLDER_KEY: it must reach invoke_async."""
+        mock_client = self._mock_client(mock_uipath_class, mock_interrupt)
+
+        tool = create_process_tool(resource_without_folder_path)
+        await tool.ainvoke({})
+
+        call_kwargs = mock_client.processes.invoke_async.call_args[1]
+        assert call_kwargs["folder_path"] is None
+        assert call_kwargs["folder_key"] == "env-folder-key"
+
+    @pytest.mark.asyncio
+    @patch.dict(
+        os.environ,
+        {"UIPATH_FOLDER_PATH": "/Env/Folder", "UIPATH_FOLDER_KEY": "env-folder-key"},
+        clear=True,
+    )
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_env_folder_path_wins_and_folder_key_is_omitted(
+        self, mock_uipath_class, mock_interrupt, process_resource
+    ):
+        """When a folder path is available only one of path/key may be sent."""
+        mock_client = self._mock_client(mock_uipath_class, mock_interrupt)
+
+        tool = create_process_tool(process_resource)
+        await tool.ainvoke({})
+
+        call_kwargs = mock_client.processes.invoke_async.call_args[1]
+        assert call_kwargs["folder_path"] == "/Env/Folder"
+        assert call_kwargs["folder_key"] is None
+
+    @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "env-folder-key"}, clear=True)
+    def test_metadata_has_folder_key_when_resolved_from_env(
+        self, resource_without_folder_path
+    ):
+        """Span metadata exposes the resolved folder key for observability."""
+        tool = create_process_tool(resource_without_folder_path)
+        assert tool.metadata is not None
+        assert tool.metadata["folder_path"] is None
+        assert tool.metadata["folder_key"] == "env-folder-key"
+
+
 class TestProcessToolFlowType:
     """Test that a Flow-type resource flows through create_process_tool correctly."""
 
@@ -530,6 +629,7 @@ class TestProcessToolFlowType:
         mock_client.processes.invoke_async.assert_called_once_with(
             name="MyFlow",
             input_arguments={},
+            folder_key=None,
             folder_path="/Shared/Flows",
             attachments=[],
             parent_span_id=None,
@@ -611,6 +711,7 @@ class TestProcessToolFunctionType:
         mock_client.processes.invoke_async.assert_called_once_with(
             name="MyFunction",
             input_arguments={},
+            folder_key=None,
             folder_path="/Shared/Functions",
             attachments=[],
             parent_span_id=None,

--- a/uv.lock
+++ b/uv.lock
@@ -4546,7 +4546,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.16.4"
+version = "0.16.5"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Problem

Agent evaluations that invoke an RPA/process tool fail with:

```
Failed to execute tool '<tool>'
Could not find process for tool '<tool>'. Please check if the process is deployed in the configured folder.
Code: AGENT_RUNTIME.HTTP_ERROR
```

even though the process **is** deployed. On staging this is ~900 exceptions/3 days across 6 tenants, 100% correlated with eval runs on the serverless LangGraph path; the same tools succeed in normal agent runs.

## Root cause

`create_process_tool` resolves the tool's folder exclusively from the `UIPATH_FOLDER_PATH` env var. Eval serverless job environments expose `UIPATH_FOLDER_KEY` but **not** `UIPATH_FOLDER_PATH` (job log: `ConfigurationManager(... folder_key='ecbc94dd-...', folder_path=None)`), so `processes.invoke_async` was called with `folder_path=None` and no `folder_key`. `header_folder(None, None)` returns `{}`, StartJobs goes out with **no folder header**, and Orchestrator returns 404 (error 1002) — surfaced as the misleading "process not deployed" message.

## Fix

Resolve the folder with a three-step fallback, passing exactly one of path/key to `invoke_async` (`header_folder` rejects both):

1. `UIPATH_FOLDER_PATH` env (current behavior, unchanged)
2. the resource's design-time `folderPath` (previously ignored)
3. `UIPATH_FOLDER_KEY` env — fixes the eval serverless scenario

Also exposes the resolved `folder_key` in tool span metadata so this failure mode is visible in telemetry (the `folder_path: null` spans were the main diagnostic clue).

Covers process, agent, flow, and function tools (all built via `create_process_tool`).

## Telemetry (staging App Insights)

Failure volume by tool (~916 hits / 3 days, 100% eval runs):

```kusto
exceptions
| where timestamp > ago(3d)
| where type == "uipath_langchain.agent.exceptions.exceptions.AgentRuntimeError"
| where outerMessage has "Could not find process for tool"
| extend Tool = extract(@"Could not find process for tool '([^']+)'", 1, outerMessage)
| summarize Failures = count(), Operations = dcount(operation_Id),
    FirstSeen = min(timestamp), LastSeen = max(timestamp) by Tool
| order by Failures desc
```

The smoking gun — failing process-tool spans carry `folder_path: null` and correlate with StartJobs 404s (no folder header sent):

```kusto
dependencies
| where timestamp > ago(3d)
| where name endswith "StartJobs" and resultCode == "404"
| join kind=inner (
    dependencies
    | where timestamp > ago(3d)
    | where tostring(customDimensions.metadata) has '"tool_type": "process"'
        and tostring(customDimensions.metadata) has '"folder_path": null'
    ) on operation_Id
| project timestamp, operation_Id, name, resultCode,
    metadata = customDimensions1.metadata,
    hierarchy = customDimensions1.["uipath.reference_hierarchy"]
```

Failing ops show `uipath.reference_hierarchy = [agent, langgraph]` (serverless eval path); succeeding runs of the same tools show `[agent]` (direct path) with StartJobs 201. Verification after rollout: the first query should trend to zero for eval-sourced operations, and process-tool spans should show a populated `folder_key`.

## Testing

- New `TestProcessToolFolderResolution` suite: resource-path fallback, folder-key fallback, path-over-key precedence, metadata exposure
- Full repo suite green: 2192 passed; ruff check/format clean

## Follow-up (not in this PR)

`context_tool.py`, `escalation_recipient.py`, and `escalation_tool.py` share the same env-path-only resolution and likely need the same fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)