### PR TITLE
fix: never send the solution_folder sentinel as a folder path

### DIFF
--- a/src/uipath_langchain/agent/tools/process_tool.py
+++ b/src/uipath_langchain/agent/tools/process_tool.py
@@ -29,6 +29,9 @@ from uipath_langchain.agent.tools.structured_tool_with_argument_properties impor
 
 from .utils import sanitize_tool_name
 
+# Mirrors SOLUTION_FOLDER_SENTINEL in the agents packager (bindings/handlers/common.ts).
+_SOLUTION_FOLDER_SENTINEL = "solution_folder"
+
 _START_JOBS_ERRORS: dict[tuple[int, str | None], tuple[str, UiPathErrorCategory]] = {
     (404, "1002"): (
         "Could not find process for tool '{tool}'. Please check if the process is deployed in the configured folder.",
@@ -58,7 +61,12 @@ def create_process_tool(
     # Eval serverless jobs expose UIPATH_FOLDER_KEY but not UIPATH_FOLDER_PATH;
     # without a folder header StartJobs returns 404 for a deployed process.
     # invoke_async accepts only one of folder_path/folder_key, so resolve one.
-    folder_path = get_execution_folder_path() or resource.properties.folder_path
+    # "solution_folder" is the packager sentinel for solution-local resources
+    # ("no folder", same as null/empty) — never send it as a real folder path.
+    configured_folder_path = resource.properties.folder_path
+    if configured_folder_path == _SOLUTION_FOLDER_SENTINEL:
+        configured_folder_path = None
+    folder_path = get_execution_folder_path() or configured_folder_path
     folder_key = get_execution_folder_key() if not folder_path else None
 
     input_model: Any = create_model(resource.input_schema)

--- a/tests/agent/tools/test_process_tool.py
+++ b/tests/agent/tools/test_process_tool.py
@@ -585,6 +585,55 @@ class TestProcessToolFolderResolution:
         assert tool.metadata["folder_path"] is None
         assert tool.metadata["folder_key"] == "env-folder-key"
 
+    @pytest.fixture
+    def resource_with_solution_folder_sentinel(self):
+        """A solution-local resource: folderPath carries the packager sentinel."""
+        return AgentProcessToolResourceConfig(
+            type=AgentToolType.PROCESS,
+            name="test_process",
+            description="Test process description",
+            input_schema={"type": "object", "properties": {}},
+            output_schema={"type": "object", "properties": {}},
+            properties=AgentProcessToolProperties(
+                process_name="MyProcess", folder_path="solution_folder"
+            ),
+        )
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "env-folder-key"}, clear=True)
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_solution_folder_sentinel_is_not_a_folder_path(
+        self, mock_uipath_class, mock_interrupt, resource_with_solution_folder_sentinel
+    ):
+        """The packager's "solution_folder" sentinel means "no folder": it must not
+        be sent as a folder path, and must not shadow the env folder key."""
+        mock_client = self._mock_client(mock_uipath_class, mock_interrupt)
+
+        tool = create_process_tool(resource_with_solution_folder_sentinel)
+        await tool.ainvoke({})
+
+        call_kwargs = mock_client.processes.invoke_async.call_args[1]
+        assert call_kwargs["folder_path"] is None
+        assert call_kwargs["folder_key"] == "env-folder-key"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Env/Folder"}, clear=True)
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
+    async def test_env_folder_path_still_wins_over_sentinel(
+        self, mock_uipath_class, mock_interrupt, resource_with_solution_folder_sentinel
+    ):
+        """UIPATH_FOLDER_PATH keeps precedence when the resource carries the sentinel."""
+        mock_client = self._mock_client(mock_uipath_class, mock_interrupt)
+
+        tool = create_process_tool(resource_with_solution_folder_sentinel)
+        await tool.ainvoke({})
+
+        call_kwargs = mock_client.processes.invoke_async.call_args[1]
+        assert call_kwargs["folder_path"] == "/Env/Folder"
+        assert call_kwargs["folder_key"] is None
+
 
 class TestProcessToolFlowType:
     """Test that a Flow-type resource flows through create_process_tool correctly."""


### PR DESCRIPTION
## Problem

`create_process_tool` treats `resource.properties.folder_path` as a real folder path. For **solution-local** resources that value is the literal string `solution_folder` — a packager sentinel meaning *"no folder"* (`SOLUTION_FOLDER_SENTINEL` in the agents repo, `packages/agents-packager/src/bindings/handlers/common.ts`, documented there as *"treat as 'no folder', same as null/empty"*). The packager omits `folderPath` from generated bindings when it sees that value, but never strips it from `agent.json`, so it reaches the runtime.

The fallback chain added in #1038 is:

```python
folder_path = get_execution_folder_path() or resource.properties.folder_path
folder_key  = get_execution_folder_key() if not folder_path else None
```

With `UIPATH_FOLDER_PATH` unset and a solution-local resource, `folder_path` becomes the truthy string `"solution_folder"`, so:

1. `StartJobs` goes out with `X-UIPATH-FolderPath: solution_folder`, a folder that does not exist for the solution; and
2. because it is truthy, `folder_key` is forced to `None`, so `UIPATH_FOLDER_KEY` is never consulted — and the platform client's env-level `FolderContext` header (`_folder_context.py`), which applied before #1038 when `header_folder(None, None)` returned `{}`, is bypassed too.

Net effect: for solution-local tools #1038 **narrowed** the reachable folder set rather than widening it.

Verified in the agents repo that this is a real hazard rather than theoretical: tenants accumulate folders literally named `solution_folder`, `solution_folder 1`, … so a path-based lookup on the sentinel can bind to an unrelated solution's folder.

## Fix

Map the sentinel to `None` before resolving, mirroring the packager's own rule. Precedence is otherwise unchanged: `UIPATH_FOLDER_PATH` → resource `folderPath` → `UIPATH_FOLDER_KEY`.

## Testing

- `test_solution_folder_sentinel_is_not_a_folder_path` — sentinel must not be sent as `folder_path` and must not shadow `UIPATH_FOLDER_KEY`.
- `test_env_folder_path_still_wins_over_sentinel` — `UIPATH_FOLDER_PATH` keeps precedence.
- `tests/agent/tools/test_process_tool.py`: **31 passed**; `ruff check` / `ruff format --check` clean.

## Scope

This is a correctness/hardening fix. It is **not** by itself the fix for the agent-evaluation failures on solution-local workflow tools — in the eval path the shipped snapshot arrives with `folder_path=None`, so this code path is inert there; that root cause (eval jobs not carrying the debug context that lets solution-local workflows resolve) is tracked separately. Filing this on its own because the sentinel-as-folder-path behavior is wrong regardless.

Follow-up noted in #1038 still stands: `context_tool.py`, `escalation_recipient.py`, and `escalation_tool.py` do their own env-path-only resolution and should get the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZRJcED9mUhXSTkmPSzgbx