### PR TITLE
docs(guardrails): note BYOG and LLM-as-judge are not enabled on every tenant yet

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -219,9 +219,13 @@ agent = create_agent(
 
 ### Bring Your Own Guardrail (BYOG)
 
+<!-- REMOVE WHEN: BYOG feature flag is enabled on all rings -->
+!!! info "Platform Availability"
+    `UiPathByoGuardrailMiddleware` ships in the `uipath-langchain` package on PyPI and works on any tenant where Bring Your Own Guardrail is enabled. The admin step it depends on — configuring a guardrail connection from a guardrail connection template under **Admin → AI Trust Layer → Guardrails Configurations** — is still rolling out and isn't enabled on every tenant yet. If that page isn't in your Admin panel, BYOG isn't enabled on yours — watch the UiPath product release notes for when it lands.
+
 `UiPathByoGuardrailMiddleware` runs a **customer-managed** validator instead of a UiPath-managed one — for example a cloud content-safety subscription, a vendor validation service, or a custom Integration Service connector wrapping an internal classifier.
 
-**Admin prerequisite.** An Org Admin first creates the BYOG configuration under **Admin → AI Trust Layer → Guardrails Configurations**: pick a guardrail connector (a UiPath-shipped one or a custom one wrapping your own vendor), create an Integration Service connection with your credentials, and save the configuration with a validator name. If the Guardrails Configurations page is not available, Bring Your Own Guardrail is not enabled on your tenant yet.
+**Admin prerequisite.** An Org Admin first creates the BYOG configuration under **Admin → AI Trust Layer → Guardrails Configurations**: pick a guardrail connector (a UiPath-shipped one or a custom one wrapping your own vendor), create an Integration Service connection with your credentials, and save the configuration with a validator name.
 
 The middleware references that configuration by name:
 
@@ -483,6 +487,10 @@ agent = create_my_agent()
 
 ### LLM-as-judge
 
+<!-- REMOVE WHEN: LLM-as-judge feature flag is enabled on all rings -->
+!!! info "Platform Availability"
+    `UiPathLLMAsJudgeMiddleware` and `LLMAsJudgeValidator` ship in the `uipath-langchain` package on PyPI, but the LLM-as-judge guardrail they call is still rolling out on the platform side and isn't enabled on every tenant yet — regardless of which judge models your governance policy permits. Watch the UiPath product release notes for when it lands.
+
 Use `LLMAsJudgeValidator` to check content against a plain-language rule via a judge LLM. Scope is inferred from the decorated target (here, the agent factory → AGENT scope). See the [core guardrails documentation](https://uipath.github.io/uipath-python/core/guardrails/#llm-as-judge) for the full parameter reference (`threshold`, `positive_examples`, `negative_examples`, and their limits).
 
 ```python
@@ -527,6 +535,10 @@ async def my_node(state: Input) -> Output:
 ```
 
 ### Bring Your Own Guardrail (BYOG)
+
+<!-- REMOVE WHEN: BYOG feature flag is enabled on all rings -->
+!!! info "Platform Availability"
+    Same rollout as the middleware flavor — the guardrail connection template configuration isn't enabled on every tenant yet. See [Bring Your Own Guardrail (BYOG)](#bring-your-own-guardrail-byog) under the middleware pattern.
 
 `ByoValidator` is the decorator equivalent of [`UiPathByoGuardrailMiddleware`](#bring-your-own-guardrail-byog): it runs a **customer-managed** validator instead of a UiPath-managed one — your own content-safety subscription, a vendor validation service, or a custom Integration Service connector wrapping an internal classifier.
 


### PR DESCRIPTION
Pairs with UiPath/uipath-python#1868. This repo's `docs/` is symlinked into the SDK site as `docs/langchain` by that repo's `publish-docs.yml`, so the guardrails guidance here is published alongside the core page and needs the same notes.

The BYOG and LLM-as-judge sections read as if both features are live. Their SDK halves are — `UiPathByoGuardrailMiddleware`, `UiPathLLMAsJudgeMiddleware`, `ByoValidator` and `LLMAsJudgeValidator` all ship on PyPI — but the platform side of each is still behind a feature flag and isn't enabled on every tenant.

**No release number, on review feedback.** A date published here is a date we then have to hit, and this repo is public. The notes say the feature isn't enabled everywhere yet and point at the product release notes instead.

**Three notes, not four.** BYOG has a section under both the middleware and decorator patterns, and both get one: the decorator section has its own anchor (`#bring-your-own-guardrail-byog_1`) that people deep-link to, so a bare cross-reference wasn't enough. LLM-as-judge has only one `### LLM-as-judge` heading (decorator pattern) — `UiPathLLMAsJudgeMiddleware` appears only in the middleware table, whose bullet already deep-links to the core page's `#llm-as-judge` anchor, which now carries the same note. That note names both classes so either reader is covered.

**The BYOG and LLM-as-judge notes are worded differently on purpose.** BYOG's gate is one admin step (configuring a guardrail connection from a guardrail connection template) with the rest of the feature live. For LLM-as-judge the whole guardrail is gated.

Also drops the vaguer "if the Guardrails Configurations page is not available, Bring Your Own Guardrail is not enabled on your tenant yet" from the Admin prerequisite paragraph — the note now says that two paragraphs above.

**Blast radius:** additive, docs only. No code change.

**Merge order:** merging this fires a `repository_dispatch` at uipath-python that rebuilds and republishes the whole site, so land UiPath/uipath-python#1868 first or alongside.

**Cleanup:** `grep -rn "REMOVE WHEN" docs/` finds all three notes. BYOG and LLM-as-judge are flagged separately and may not clear at the same time; each comment names its own flag.

**Verified:** built the full site locally from uipath-python with this repo's `docs/` symlinked in, exactly as `publish-docs.yml` does. Confirmed in the rendered HTML that all three notes come out as styled `admonition info` blocks titled `Platform Availability`, that no literal `!!!` leaks, that the `#llm-as-judge`, `#bring-your-own-guardrail-byog` and `#bring-your-own-guardrail-byog_1` anchors all resolve, and that no release number appears anywhere in the built page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)