### PR TITLE
revert: process tool folder resolution fallback (#1038)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.16.6"
+version = "0.16.7"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/_utils/__init__.py
+++ b/src/uipath_langchain/_utils/__init__.py
@@ -1,4 +1,4 @@
-from ._environment import get_execution_folder_key, get_execution_folder_path
+from ._environment import get_execution_folder_path
 from ._otel import (
     get_current_span_and_trace_ids,
     set_current_span_error,
@@ -10,7 +10,6 @@ from ._request_mixin import UiPathRequestMixin
 __all__ = [
     "UiPathRequestMixin",
     "get_current_span_and_trace_ids",
-    "get_execution_folder_key",
     "get_execution_folder_path",
     "get_unique_model_field_name",
     "set_current_span_error",

--- a/src/uipath_langchain/_utils/_environment.py
+++ b/src/uipath_langchain/_utils/_environment.py
@@ -6,14 +6,5 @@ def get_execution_folder_path() -> str | None:
     return os.environ.get("UIPATH_FOLDER_PATH")
 
 
-def get_execution_folder_key() -> str | None:
-    """Reads the agent's executing folder key from the runtime environment.
-
-    Some job environments (e.g. eval serverless jobs) only expose the folder
-    key, not the folder path.
-    """
-    return os.environ.get("UIPATH_FOLDER_KEY")
-
-
 def get_default_timeout() -> float:
     return float(os.getenv("UIPATH_TIMEOUT_SECONDS", "895"))

--- a/src/uipath_langchain/agent/tools/process_tool.py
+++ b/src/uipath_langchain/agent/tools/process_tool.py
@@ -12,10 +12,7 @@ from uipath.platform.errors import EnrichedException
 from uipath.platform.orchestrator import JobState
 from uipath.runtime.errors import UiPathErrorCategory
 
-from uipath_langchain._utils import (
-    get_execution_folder_key,
-    get_execution_folder_path,
-)
+from uipath_langchain._utils import get_execution_folder_path
 from uipath_langchain._utils.durable_interrupt import durable_interrupt
 from uipath_langchain.agent.exceptions import raise_for_enriched
 from uipath_langchain.agent.react.job_attachments import get_job_attachments
@@ -55,11 +52,7 @@ def create_process_tool(
 
     tool_name: str = sanitize_tool_name(resource.name)
     process_name = resource.properties.process_name
-    # Eval serverless jobs expose UIPATH_FOLDER_KEY but not UIPATH_FOLDER_PATH;
-    # without a folder header StartJobs returns 404 for a deployed process.
-    # invoke_async accepts only one of folder_path/folder_key, so resolve one.
-    folder_path = get_execution_folder_path() or resource.properties.folder_path
-    folder_key = get_execution_folder_key() if not folder_path else None
+    folder_path = get_execution_folder_path()
 
     input_model: Any = create_model(resource.input_schema)
     output_model: Any = create_output_model(resource.output_schema, resource.name)
@@ -89,7 +82,6 @@ def create_process_tool(
                     job = await client.processes.invoke_async(
                         name=process_name,
                         input_arguments=input_arguments,
-                        folder_key=folder_key,
                         folder_path=folder_path,
                         attachments=attachments,
                         parent_span_id=parent_span_id,
@@ -144,7 +136,6 @@ def create_process_tool(
             "tool_type": resource.type.lower(),
             "display_name": process_name,
             "folder_path": folder_path,
-            "folder_key": folder_key,
             "args_schema": input_model,
             "output_schema": output_model,
             "_span_context": _span_context,

--- a/tests/agent/tools/test_process_tool.py
+++ b/tests/agent/tools/test_process_tool.py
@@ -175,7 +175,6 @@ class TestProcessToolInvocation:
         mock_client.processes.invoke_async.assert_called_once_with(
             name="MyProcess",
             input_arguments={},
-            folder_key=None,
             folder_path="/Shared/MyFolder",
             attachments=[],
             parent_span_id=None,
@@ -488,104 +487,6 @@ class TestProcessToolRunAsMe:
         assert call_kwargs["run_as_me"] is None
 
 
-class TestProcessToolFolderResolution:
-    """Test folder context resolution: env folder path, resource folder path, env folder key."""
-
-    @staticmethod
-    def _mock_client(mock_uipath_class, mock_interrupt):
-        mock_job = MagicMock(spec=Job)
-        mock_job.key = "job-key"
-        mock_job.folder_key = "folder-key"
-
-        mock_resumed_job = MagicMock(spec=Job)
-        mock_resumed_job.state = "successful"
-
-        mock_client = MagicMock()
-        mock_client.processes.invoke_async = AsyncMock(return_value=mock_job)
-        mock_client.jobs.extract_output_async = AsyncMock(return_value=None)
-        mock_uipath_class.return_value = mock_client
-
-        mock_interrupt.return_value = mock_resumed_job
-        return mock_client
-
-    @pytest.fixture
-    def resource_without_folder_path(self):
-        """A process resource with no design-time folder path (solution deployments)."""
-        return AgentProcessToolResourceConfig(
-            type=AgentToolType.PROCESS,
-            name="test_process",
-            description="Test process description",
-            input_schema={"type": "object", "properties": {}},
-            output_schema={"type": "object", "properties": {}},
-            properties=AgentProcessToolProperties(process_name="MyProcess"),
-        )
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {}, clear=True)
-    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
-    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
-    async def test_falls_back_to_resource_folder_path_when_env_unset(
-        self, mock_uipath_class, mock_interrupt, process_resource
-    ):
-        """Without UIPATH_FOLDER_PATH, the resource's folderPath is used."""
-        mock_client = self._mock_client(mock_uipath_class, mock_interrupt)
-
-        tool = create_process_tool(process_resource)
-        await tool.ainvoke({})
-
-        call_kwargs = mock_client.processes.invoke_async.call_args[1]
-        assert call_kwargs["folder_path"] == "/Shared/MyFolder"
-        assert call_kwargs["folder_key"] is None
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "env-folder-key"}, clear=True)
-    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
-    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
-    async def test_falls_back_to_env_folder_key_when_no_folder_path(
-        self, mock_uipath_class, mock_interrupt, resource_without_folder_path
-    ):
-        """Eval serverless jobs only expose UIPATH_FOLDER_KEY: it must reach invoke_async."""
-        mock_client = self._mock_client(mock_uipath_class, mock_interrupt)
-
-        tool = create_process_tool(resource_without_folder_path)
-        await tool.ainvoke({})
-
-        call_kwargs = mock_client.processes.invoke_async.call_args[1]
-        assert call_kwargs["folder_path"] is None
-        assert call_kwargs["folder_key"] == "env-folder-key"
-
-    @pytest.mark.asyncio
-    @patch.dict(
-        os.environ,
-        {"UIPATH_FOLDER_PATH": "/Env/Folder", "UIPATH_FOLDER_KEY": "env-folder-key"},
-        clear=True,
-    )
-    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
-    @patch("uipath_langchain.agent.tools.process_tool.UiPath")
-    async def test_env_folder_path_wins_and_folder_key_is_omitted(
-        self, mock_uipath_class, mock_interrupt, process_resource
-    ):
-        """When a folder path is available only one of path/key may be sent."""
-        mock_client = self._mock_client(mock_uipath_class, mock_interrupt)
-
-        tool = create_process_tool(process_resource)
-        await tool.ainvoke({})
-
-        call_kwargs = mock_client.processes.invoke_async.call_args[1]
-        assert call_kwargs["folder_path"] == "/Env/Folder"
-        assert call_kwargs["folder_key"] is None
-
-    @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "env-folder-key"}, clear=True)
-    def test_metadata_has_folder_key_when_resolved_from_env(
-        self, resource_without_folder_path
-    ):
-        """Span metadata exposes the resolved folder key for observability."""
-        tool = create_process_tool(resource_without_folder_path)
-        assert tool.metadata is not None
-        assert tool.metadata["folder_path"] is None
-        assert tool.metadata["folder_key"] == "env-folder-key"
-
-
 class TestProcessToolFlowType:
     """Test that a Flow-type resource flows through create_process_tool correctly."""
 
@@ -629,7 +530,6 @@ class TestProcessToolFlowType:
         mock_client.processes.invoke_async.assert_called_once_with(
             name="MyFlow",
             input_arguments={},
-            folder_key=None,
             folder_path="/Shared/Flows",
             attachments=[],
             parent_span_id=None,
@@ -711,7 +611,6 @@ class TestProcessToolFunctionType:
         mock_client.processes.invoke_async.assert_called_once_with(
             name="MyFunction",
             input_arguments={},
-            folder_key=None,
             folder_path="/Shared/Functions",
             attachments=[],
             parent_span_id=None,

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-23T13:22:50.1947794Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -172,9 +172,9 @@ name = "aiologic"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-    { name = "wrapt" },
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
 wheels = [
@@ -945,8 +945,8 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic" },
-    { name = "typing-extensions" },
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
 wheels = [
@@ -4546,7 +4546,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.16.6"
+version = "0.16.7"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Reverts the folder resolution change from #1038 (a1bd280). Version bumped 0.16.6 → 0.16.7.

## Why

#1038 broke tool resolution for lowcode agents on serverless. The alpha CI agent (`SimpleAgent` on the `PythonAwsTests` / `PythonK8sTests` tenants) fails on every run with:

```
Failed to execute tool 'SumAgent'
Could not find folder for tool 'SumAgent'. Please check if the folder exists and is accessible by the robot.
```

`Serverless.RuntimeVersions` pins it to the package version, not to anything on the agent side — the agent itself hasn't changed:

| Date (UTC) | uipath-agents | uipath-langchain | SimpleAgent |
|---|---|---|---|
| 08-11 → 08-13 | 200.0.5 → 200.0.12 | 0.16.2 / 0.16.3 | ✅ |
| 08-18 / 08-21 | 200.0.0 / 200.1.0 | 0.15.2 | ✅ |
| 08-15 / 08-20 | 200.0.13 | 0.16.5 | ❌ |
| 08-21 | 201.0.0 | 0.16.5 | ❌ |
| 08-25 | 201.0.4 | 0.16.6 | ❌ |

Fails iff `uipath-langchain >= 0.16.5` — the version #1038 shipped in.

## Root cause

The change introduced this precedence in `create_process_tool`:

```python
folder_path = get_execution_folder_path() or resource.properties.folder_path
folder_key = get_execution_folder_key() if not folder_path else None
```

On a serverless job `UIPATH_FOLDER_PATH` is unset, so it falls through to `resource.properties.folder_path`. For anything exported from Agent Builder / Solutions that value is the literal `"solution_folder"` placeholder baked into `agent.json` at export time. It's truthy, so:

- `folder_key` is forced to `None` and the `UIPATH_FOLDER_KEY` fallback the PR was written for never fires — it's dead code for every packaged agent
- StartJobs goes out with `folderPath="solution_folder"`, Orchestrator rejects it (code 1100), and it surfaces as the "Could not find folder" message above

Before the change, `folder_path=None` was passed and the SDK resolved the process in the job's own execution folder — the correct behaviour for these agents. Lowcode agents never carry a usable `folderPath`; the real value arrives via binding overwrites at runtime.

The eval-serverless failure #1038 was chasing is a missing binding overwrite / `fpsProperties` advertisement on the eval path, not something to compensate for in the runtime.

## Follow-up (agreed in [this thread](https://uipath-product.slack.com/archives/C07FMP2R5EH/p1787661830920719), separate PRs)

- **uipath-langchain**: send `resource.properties.folder_path` literally, so coded agents can pass a folder explicitly
- **uipath-agents**: force the folder in the agent definition to `None`, since lowcode agents always carry the `solution_folder` placeholder and rely on binding overwrites for the real value
- #1044 addresses the same symptom by special-casing the `solution_folder` sentinel — a band-aid on top of this regression; superseded by the above

Reverting now to unblock the pipeline; the proper fix lands on its own timeline.

## Testing

- Full suite green (2684 tests), `ruff check` / `ruff format` clean, httpx client linter clean
- `TestProcessToolFolderResolution` (added by #1038) removed along with the code it covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
