### PR TITLE
feat(deeprag): default to single-shot from-attachments (kill switch: DisableDeepRagFromAttachments)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "uipath>=2.14.6, <2.15.0",
     "uipath-core>=0.5.29, <0.6.0",
-    "uipath-platform>=0.2.20, <0.3.0",
+    "uipath-platform>=0.2.22, <0.3.0",
     "uipath-runtime>=0.13.0, <0.14.0",
     "uipath-llm-client>=1.18.0, <1.19.0",
     "langgraph>=1.1.8, <2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.16.12"
+version = "0.16.13"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -9,26 +9,12 @@ from uipath.agent.models.agent import (
     AgentInternalDeepRagToolProperties,
     AgentInternalToolResourceConfig,
 )
-from uipath.core.feature_flags import (
-    DEEP_RAG_FROM_ATTACHMENTS_FEATURE_FLAG,
-    FeatureFlags,
-)
 from uipath.eval.mocks import mockable
-from uipath.platform import UiPath
-from uipath.platform.common import CreateDeepRag, UiPathConfig, WaitEphemeralIndex
-from uipath.platform.context_grounding import (
-    CitationMode,
-    EphemeralIndexUsage,
-)
-from uipath.platform.context_grounding.context_grounding_index import (
-    ContextGroundingIndex,
-)
+from uipath.platform.common import CreateDeepRag, UiPathConfig
+from uipath.platform.context_grounding import CitationMode
 from uipath.runtime.errors import UiPathErrorCategory
 
-from uipath_langchain._utils.durable_interrupt import (
-    SkipInterruptValue,
-    durable_interrupt,
-)
+from uipath_langchain._utils.durable_interrupt import durable_interrupt
 from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErrorCode
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
     create_model,
@@ -41,17 +27,6 @@ from uipath_langchain.agent.tools.structured_tool_with_argument_properties impor
     StructuredToolWithArgumentProperties,
 )
 from uipath_langchain.agent.tools.utils import sanitize_tool_name
-
-
-class ReadyEphemeralIndex(SkipInterruptValue):
-    """An ephemeral index that is already ready (no wait needed)."""
-
-    def __init__(self, index: ContextGroundingIndex):
-        self.index = index
-
-    @property
-    def resume_value(self) -> Any:
-        return self.index.model_dump()
 
 
 def create_deeprag_tool(
@@ -118,56 +93,17 @@ def create_deeprag_tool(
             example_calls=[],  # Examples cannot be provided for internal tools
         )
         async def invoke_deeprag(**_tool_kwargs: Any):
-            if FeatureFlags.is_flag_enabled(
-                DEEP_RAG_FROM_ATTACHMENTS_FEATURE_FLAG, default=False
-            ):
-
-                @durable_interrupt
-                async def create_deeprag_from_attachments():
-                    return CreateDeepRag(
-                        name=f"task-{uuid.uuid4()}",
-                        prompt=query,
-                        attachments=[attachment_id],
-                        citation_mode=citation_mode,
-                        index_folder_key=UiPathConfig.folder_key,
-                    )
-
-                return await create_deeprag_from_attachments()
-
-            @durable_interrupt
-            async def create_ephemeral_index():
-                uipath = UiPath()
-                ephemeral_index = (
-                    await uipath.context_grounding.create_ephemeral_index_async(
-                        usage=EphemeralIndexUsage.DEEP_RAG,
-                        attachments=[attachment_id],
-                        folder_key=UiPathConfig.folder_key,
-                    )
-                )
-                if ephemeral_index.in_progress_ingestion():
-                    return WaitEphemeralIndex(index=ephemeral_index)
-                return ReadyEphemeralIndex(index=ephemeral_index)
-
-            index_result = await create_ephemeral_index()
-            if isinstance(index_result, dict):
-                ephemeral_index = ContextGroundingIndex(**index_result)
-            else:
-                ephemeral_index = index_result
-
             @durable_interrupt
             async def create_deeprag():
                 return CreateDeepRag(
                     name=f"task-{uuid.uuid4()}",
-                    index_name=ephemeral_index.name,
-                    index_id=ephemeral_index.id,
                     prompt=query,
+                    attachments=[attachment_id],
                     citation_mode=citation_mode,
-                    is_ephemeral_index=True,
+                    index_folder_key=UiPathConfig.folder_key,
                 )
 
-            result = await create_deeprag()
-
-            return result
+            return await create_deeprag()
 
         return await invoke_deeprag(**kwargs)
 

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -9,12 +9,23 @@ from uipath.agent.models.agent import (
     AgentInternalDeepRagToolProperties,
     AgentInternalToolResourceConfig,
 )
+from uipath.core.feature_flags import FeatureFlags
 from uipath.eval.mocks import mockable
-from uipath.platform.common import CreateDeepRag, UiPathConfig
-from uipath.platform.context_grounding import CitationMode
+from uipath.platform import UiPath
+from uipath.platform.common import CreateDeepRag, UiPathConfig, WaitEphemeralIndex
+from uipath.platform.context_grounding import (
+    CitationMode,
+    EphemeralIndexUsage,
+)
+from uipath.platform.context_grounding.context_grounding_index import (
+    ContextGroundingIndex,
+)
 from uipath.runtime.errors import UiPathErrorCategory
 
-from uipath_langchain._utils.durable_interrupt import durable_interrupt
+from uipath_langchain._utils.durable_interrupt import (
+    SkipInterruptValue,
+    durable_interrupt,
+)
 from uipath_langchain.agent.exceptions import AgentStartupError, AgentStartupErrorCode
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
     create_model,
@@ -27,6 +38,19 @@ from uipath_langchain.agent.tools.structured_tool_with_argument_properties impor
     StructuredToolWithArgumentProperties,
 )
 from uipath_langchain.agent.tools.utils import sanitize_tool_name
+
+DEEP_RAG_FROM_ATTACHMENTS_FEATURE_FLAG = "DeepRagFromAttachments"
+
+
+class ReadyEphemeralIndex(SkipInterruptValue):
+    """An ephemeral index that is already ready (no wait needed)."""
+
+    def __init__(self, index: ContextGroundingIndex):
+        self.index = index
+
+    @property
+    def resume_value(self) -> Any:
+        return self.index.model_dump()
 
 
 def create_deeprag_tool(
@@ -93,17 +117,56 @@ def create_deeprag_tool(
             example_calls=[],  # Examples cannot be provided for internal tools
         )
         async def invoke_deeprag(**_tool_kwargs: Any):
+            if FeatureFlags.is_flag_enabled(
+                DEEP_RAG_FROM_ATTACHMENTS_FEATURE_FLAG, default=False
+            ):
+
+                @durable_interrupt
+                async def create_deeprag_from_attachments():
+                    return CreateDeepRag(
+                        name=f"task-{uuid.uuid4()}",
+                        prompt=query,
+                        attachments=[attachment_id],
+                        citation_mode=citation_mode,
+                        index_folder_key=UiPathConfig.folder_key,
+                    )
+
+                return await create_deeprag_from_attachments()
+
+            @durable_interrupt
+            async def create_ephemeral_index():
+                uipath = UiPath()
+                ephemeral_index = (
+                    await uipath.context_grounding.create_ephemeral_index_async(
+                        usage=EphemeralIndexUsage.DEEP_RAG,
+                        attachments=[attachment_id],
+                        folder_key=UiPathConfig.folder_key,
+                    )
+                )
+                if ephemeral_index.in_progress_ingestion():
+                    return WaitEphemeralIndex(index=ephemeral_index)
+                return ReadyEphemeralIndex(index=ephemeral_index)
+
+            index_result = await create_ephemeral_index()
+            if isinstance(index_result, dict):
+                ephemeral_index = ContextGroundingIndex(**index_result)
+            else:
+                ephemeral_index = index_result
+
             @durable_interrupt
             async def create_deeprag():
                 return CreateDeepRag(
                     name=f"task-{uuid.uuid4()}",
+                    index_name=ephemeral_index.name,
+                    index_id=ephemeral_index.id,
                     prompt=query,
-                    attachments=[attachment_id],
                     citation_mode=citation_mode,
-                    index_folder_key=UiPathConfig.folder_key,
+                    is_ephemeral_index=True,
                 )
 
-            return await create_deeprag()
+            result = await create_deeprag()
+
+            return result
 
         return await invoke_deeprag(**kwargs)
 

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -9,6 +9,10 @@ from uipath.agent.models.agent import (
     AgentInternalDeepRagToolProperties,
     AgentInternalToolResourceConfig,
 )
+from uipath.core.feature_flags import (
+    DEEP_RAG_FROM_ATTACHMENTS_FEATURE_FLAG,
+    FeatureFlags,
+)
 from uipath.eval.mocks import mockable
 from uipath.platform import UiPath
 from uipath.platform.common import CreateDeepRag, UiPathConfig, WaitEphemeralIndex
@@ -114,6 +118,22 @@ def create_deeprag_tool(
             example_calls=[],  # Examples cannot be provided for internal tools
         )
         async def invoke_deeprag(**_tool_kwargs: Any):
+            if FeatureFlags.is_flag_enabled(
+                DEEP_RAG_FROM_ATTACHMENTS_FEATURE_FLAG, default=False
+            ):
+
+                @durable_interrupt
+                async def create_deeprag_from_attachments():
+                    return CreateDeepRag(
+                        name=f"task-{uuid.uuid4()}",
+                        prompt=query,
+                        attachments=[attachment_id],
+                        citation_mode=citation_mode,
+                        index_folder_key=UiPathConfig.folder_key,
+                    )
+
+                return await create_deeprag_from_attachments()
+
             @durable_interrupt
             async def create_ephemeral_index():
                 uipath = UiPath()

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -22,6 +22,8 @@ from uipath.platform.context_grounding.context_grounding_index import (
 )
 from uipath.runtime.errors import UiPathErrorCategory
 
+from langgraph.types import interrupt
+
 from uipath_langchain._utils.durable_interrupt import (
     SkipInterruptValue,
     durable_interrupt,
@@ -120,18 +122,15 @@ def create_deeprag_tool(
             if not FeatureFlags.is_flag_enabled(
                 DEEP_RAG_FROM_ATTACHMENTS_KILL_SWITCH, default=False
             ):
-
-                @durable_interrupt
-                async def create_deeprag_from_attachments():
-                    return CreateDeepRag(
+                return interrupt(
+                    CreateDeepRag(
                         name=f"task-{uuid.uuid4()}",
                         prompt=query,
                         attachments=[attachment_id],
                         citation_mode=citation_mode,
                         index_folder_key=UiPathConfig.folder_key,
                     )
-
-                return await create_deeprag_from_attachments()
+                )
 
             @durable_interrupt
             async def create_ephemeral_index():

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -39,7 +39,7 @@ from uipath_langchain.agent.tools.structured_tool_with_argument_properties impor
 )
 from uipath_langchain.agent.tools.utils import sanitize_tool_name
 
-DEEP_RAG_FROM_ATTACHMENTS_FEATURE_FLAG = "DeepRagFromAttachments"
+DEEP_RAG_FROM_ATTACHMENTS_KILL_SWITCH = "DisableDeepRagFromAttachments"
 
 
 class ReadyEphemeralIndex(SkipInterruptValue):
@@ -117,8 +117,8 @@ def create_deeprag_tool(
             example_calls=[],  # Examples cannot be provided for internal tools
         )
         async def invoke_deeprag(**_tool_kwargs: Any):
-            if FeatureFlags.is_flag_enabled(
-                DEEP_RAG_FROM_ATTACHMENTS_FEATURE_FLAG, default=False
+            if not FeatureFlags.is_flag_enabled(
+                DEEP_RAG_FROM_ATTACHMENTS_KILL_SWITCH, default=False
             ):
 
                 @durable_interrupt

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.tools import StructuredTool
+from langgraph.types import interrupt
 from uipath.agent.models.agent import (
     AgentInternalDeepRagToolProperties,
     AgentInternalToolResourceConfig,
@@ -21,8 +22,6 @@ from uipath.platform.context_grounding.context_grounding_index import (
     ContextGroundingIndex,
 )
 from uipath.runtime.errors import UiPathErrorCategory
-
-from langgraph.types import interrupt
 
 from uipath_langchain._utils.durable_interrupt import (
     SkipInterruptValue,

--- a/tests/agent/tools/internal_tools/test_deeprag_tool.py
+++ b/tests/agent/tools/internal_tools/test_deeprag_tool.py
@@ -431,7 +431,7 @@ class TestCreateDeepRagTool:
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
     )
-    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.interrupt")
     @patch(
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,

--- a/tests/agent/tools/internal_tools/test_deeprag_tool.py
+++ b/tests/agent/tools/internal_tools/test_deeprag_tool.py
@@ -18,6 +18,9 @@ from uipath.agent.models.agent import (
     DeepRagFileExtensionSetting,
 )
 from uipath.platform.common import CreateDeepRag
+from uipath.platform.context_grounding.context_grounding_index import (
+    ContextGroundingIndex,
+)
 
 from uipath_langchain.agent.tools.internal_tools.deeprag_tool import (
     create_deeprag_tool,
@@ -120,47 +123,142 @@ class TestCreateDeepRagTool:
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
     )
+    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.UiPath")
     @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     @patch(
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
-    async def test_create_deeprag_tool_static_query(
+    async def test_create_deeprag_tool_static_query_index_ready(
         self,
         mock_interrupt,
+        mock_uipath_class,
         mock_get_wrapper,
         resource_config_static,
         mock_llm,
     ):
-        """Static-query path emits a single CreateDeepRag interrupt with the configured prompt."""
-        mock_interrupt.side_effect = [{"text": "Deep RAG analysis result"}]
-        mock_get_wrapper.return_value = Mock()
+        """Test DeepRAG tool with static query when index is immediately ready."""
+        # Setup mocks
+        mock_uipath = AsyncMock()
+        mock_uipath_class.return_value = mock_uipath
 
+        mock_index = ContextGroundingIndex(
+            id=str(uuid.uuid4()),
+            name="ephemeral-index-123",
+            last_ingestion_status="Successful",
+        )
+
+        mock_uipath.context_grounding.create_ephemeral_index_async = AsyncMock(
+            return_value=mock_index
+        )
+
+        # Index is ready → ReadyEphemeralIndex skips interrupt() (no scratchpad in tests).
+        # Only create_deeprag calls interrupt().
+        mock_interrupt.side_effect = [
+            {"text": "Deep RAG analysis result"},
+        ]
+
+        mock_wrapper = Mock()
+        mock_get_wrapper.return_value = mock_wrapper
+
+        # Create tool
         tool = create_deeprag_tool(resource_config_static, mock_llm)
 
+        # Verify tool creation
         assert tool.name == "deeprag_static"
         assert tool.description == "Analyze document with DeepRAG (static query)"
 
-        attachment_id = str(uuid.uuid4())
+        # Test tool execution
         mock_attachment = MockAttachment(
-            ID=attachment_id, FullName="test.pdf", MimeType="application/pdf"
+            ID=str(uuid.uuid4()), FullName="test.pdf", MimeType="application/pdf"
         )
 
         assert tool.coroutine is not None
         result = await tool.coroutine(attachment=mock_attachment)
 
+        # Verify result
         assert result == {"text": "Deep RAG analysis result"}
 
+        # Verify ephemeral index was created
+        mock_uipath.context_grounding.create_ephemeral_index_async.assert_called_once()
+        call_kwargs = (
+            mock_uipath.context_grounding.create_ephemeral_index_async.call_args.kwargs
+        )
+        assert call_kwargs["usage"] == "DeepRAG"
+        assert mock_attachment.ID in call_kwargs["attachments"]
+
+        # Only create_deeprag calls interrupt(); index was instant-resumed
         assert mock_interrupt.call_count == 1
-        create_payload = mock_interrupt.call_args.args[0]
-        assert isinstance(create_payload, CreateDeepRag)
-        assert create_payload.attachments == [attachment_id]
-        assert create_payload.prompt == "What are the main points?"
-        assert create_payload.citation_mode == CitationMode.INLINE
 
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
     )
+    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.UiPath")
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch(
+        "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
+        lambda **kwargs: lambda f: f,
+    )
+    async def test_create_deeprag_tool_static_query_wait_for_ingestion(
+        self,
+        mock_interrupt,
+        mock_uipath_class,
+        mock_get_wrapper,
+        resource_config_static,
+        mock_llm,
+    ):
+        """Test DeepRAG tool with static query when index needs to wait for ingestion."""
+        # Setup mocks
+        mock_uipath = AsyncMock()
+        mock_uipath_class.return_value = mock_uipath
+
+        pending_id = str(uuid.uuid4())
+        mock_index_pending = ContextGroundingIndex(
+            id=pending_id,
+            name="ephemeral-index-456",
+            last_ingestion_status="InProgress",
+        )
+
+        mock_index_complete = {
+            "id": mock_index_pending.id,
+            "name": mock_index_pending.name,
+            "last_ingestion_status": "Successful",
+        }
+
+        mock_uipath.context_grounding.create_ephemeral_index_async = AsyncMock(
+            return_value=mock_index_pending
+        )
+
+        # First interrupt returns completed index, second returns DeepRAG result
+        mock_interrupt.side_effect = [
+            mock_index_complete,
+            {"text": "Deep RAG analysis after waiting"},
+        ]
+
+        mock_wrapper = Mock()
+        mock_get_wrapper.return_value = mock_wrapper
+
+        # Create tool
+        tool = create_deeprag_tool(resource_config_static, mock_llm)
+
+        # Test tool execution
+        mock_attachment = MockAttachment(
+            ID=str(uuid.uuid4()), FullName="test.pdf", MimeType="application/pdf"
+        )
+
+        assert tool.coroutine is not None
+        result = await tool.coroutine(attachment=mock_attachment)
+
+        # Verify result
+        assert result == {"text": "Deep RAG analysis after waiting"}
+
+        # Verify interrupt was called twice (WaitEphemeralIndex + CreateDeepRag)
+        assert mock_interrupt.call_count == 2
+
+    @patch(
+        "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
+    )
+    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.UiPath")
     @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     @patch(
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
@@ -169,19 +267,40 @@ class TestCreateDeepRagTool:
     async def test_create_deeprag_tool_dynamic_query(
         self,
         mock_interrupt,
+        mock_uipath_class,
         mock_get_wrapper,
         resource_config_dynamic,
         mock_llm,
     ):
-        """Dynamic-query path threads the caller's query into the CreateDeepRag prompt."""
-        mock_interrupt.side_effect = [{"content": "Dynamic query result"}]
-        mock_get_wrapper.return_value = Mock()
+        """Test DeepRAG tool with dynamic query."""
+        # Setup mocks
+        mock_uipath = AsyncMock()
+        mock_uipath_class.return_value = mock_uipath
 
+        mock_index = ContextGroundingIndex(
+            id=str(uuid.uuid4()),
+            name="ephemeral-index-789",
+            last_ingestion_status="Successful",
+        )
+
+        mock_uipath.context_grounding.create_ephemeral_index_async = AsyncMock(
+            return_value=mock_index
+        )
+
+        # Index is ready → ReadyEphemeralIndex skips interrupt(). Only create_deeprag fires.
+        mock_interrupt.side_effect = [
+            {"content": "Dynamic query result"},
+        ]
+
+        mock_wrapper = Mock()
+        mock_get_wrapper.return_value = mock_wrapper
+
+        # Create tool
         tool = create_deeprag_tool(resource_config_dynamic, mock_llm)
 
-        attachment_id = str(uuid.uuid4())
+        # Test tool execution with dynamic query
         mock_attachment = MockAttachment(
-            ID=attachment_id, FullName="test.txt", MimeType="text/plain"
+            ID=str(uuid.uuid4()), FullName="test.txt", MimeType="text/plain"
         )
 
         assert tool.coroutine is not None
@@ -189,14 +308,8 @@ class TestCreateDeepRagTool:
             attachment=mock_attachment, query="What is the summary?"
         )
 
+        # Verify result
         assert result == {"content": "Dynamic query result"}
-
-        assert mock_interrupt.call_count == 1
-        create_payload = mock_interrupt.call_args.args[0]
-        assert isinstance(create_payload, CreateDeepRag)
-        assert create_payload.attachments == [attachment_id]
-        assert create_payload.prompt == "What is the summary?"
-        assert create_payload.citation_mode == CitationMode.SKIP
 
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
@@ -261,22 +374,37 @@ class TestCreateDeepRagTool:
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
     )
+    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.UiPath")
     @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     @patch(
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
     @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "test-folder-key"})
-    async def test_create_deeprag_passes_folder_key(
+    async def test_create_ephemeral_index_passes_folder_key(
         self,
         mock_interrupt,
+        mock_uipath_class,
         mock_get_wrapper,
         resource_config_static,
         mock_llm,
     ):
-        """CreateDeepRag.index_folder_key resolves from UIPATH_FOLDER_KEY at invoke time."""
+        """Test that create_ephemeral_index_async receives folder_key from the execution environment."""
+        mock_uipath = AsyncMock()
+        mock_uipath_class.return_value = mock_uipath
+
+        mock_index = ContextGroundingIndex(
+            id=str(uuid.uuid4()),
+            name="ephemeral-index-folder",
+            last_ingestion_status="Successful",
+        )
+        mock_uipath.context_grounding.create_ephemeral_index_async = AsyncMock(
+            return_value=mock_index
+        )
         mock_interrupt.side_effect = [{"text": "result"}]
-        mock_get_wrapper.return_value = Mock()
+
+        mock_wrapper = Mock()
+        mock_get_wrapper.return_value = mock_wrapper
 
         tool = create_deeprag_tool(resource_config_static, mock_llm)
         mock_attachment = MockAttachment(
@@ -286,6 +414,45 @@ class TestCreateDeepRagTool:
         assert tool.coroutine is not None
         await tool.coroutine(attachment=mock_attachment)
 
+        call_kwargs = (
+            mock_uipath.context_grounding.create_ephemeral_index_async.call_args.kwargs
+        )
+        assert call_kwargs["folder_key"] == "test-folder-key"
+
+    @patch(
+        "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
+    )
+    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
+    @patch(
+        "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
+        lambda **kwargs: lambda f: f,
+    )
+    @patch.dict(os.environ, {"UIPATH_FEATURE_DeepRagFromAttachments": "1"})
+    async def test_create_deeprag_tool_from_attachments_flag_on(
+        self,
+        mock_interrupt,
+        mock_get_wrapper,
+        resource_config_static,
+        mock_llm,
+    ):
+        """When the DeepRagFromAttachments flag is on, emit a single CreateDeepRag interrupt."""
+        mock_interrupt.side_effect = [{"text": "Deep RAG analysis result"}]
+        mock_get_wrapper.return_value = Mock()
+
+        tool = create_deeprag_tool(resource_config_static, mock_llm)
+
+        attachment_id = str(uuid.uuid4())
+        mock_attachment = MockAttachment(
+            ID=attachment_id, FullName="test.pdf", MimeType="application/pdf"
+        )
+
+        assert tool.coroutine is not None
+        result = await tool.coroutine(attachment=mock_attachment)
+
+        assert result == {"text": "Deep RAG analysis result"}
+
+        assert mock_interrupt.call_count == 1
         create_payload = mock_interrupt.call_args.args[0]
         assert isinstance(create_payload, CreateDeepRag)
-        assert create_payload.index_folder_key == "test-folder-key"
+        assert create_payload.attachments == [attachment_id]
+        assert create_payload.prompt == "What are the main points?"

--- a/tests/agent/tools/internal_tools/test_deeprag_tool.py
+++ b/tests/agent/tools/internal_tools/test_deeprag_tool.py
@@ -129,6 +129,7 @@ class TestCreateDeepRagTool:
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
+    @patch.dict(os.environ, {"UIPATH_FEATURE_DisableDeepRagFromAttachments": "1"})
     async def test_create_deeprag_tool_static_query_index_ready(
         self,
         mock_interrupt,
@@ -199,6 +200,7 @@ class TestCreateDeepRagTool:
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
+    @patch.dict(os.environ, {"UIPATH_FEATURE_DisableDeepRagFromAttachments": "1"})
     async def test_create_deeprag_tool_static_query_wait_for_ingestion(
         self,
         mock_interrupt,
@@ -264,6 +266,7 @@ class TestCreateDeepRagTool:
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
+    @patch.dict(os.environ, {"UIPATH_FEATURE_DisableDeepRagFromAttachments": "1"})
     async def test_create_deeprag_tool_dynamic_query(
         self,
         mock_interrupt,
@@ -380,7 +383,13 @@ class TestCreateDeepRagTool:
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
-    @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "test-folder-key"})
+    @patch.dict(
+        os.environ,
+        {
+            "UIPATH_FOLDER_KEY": "test-folder-key",
+            "UIPATH_FEATURE_DisableDeepRagFromAttachments": "1",
+        },
+    )
     async def test_create_ephemeral_index_passes_folder_key(
         self,
         mock_interrupt,
@@ -427,15 +436,14 @@ class TestCreateDeepRagTool:
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
-    @patch.dict(os.environ, {"UIPATH_FEATURE_DeepRagFromAttachments": "1"})
-    async def test_create_deeprag_tool_from_attachments_flag_on(
+    async def test_create_deeprag_tool_from_attachments_default(
         self,
         mock_interrupt,
         mock_get_wrapper,
         resource_config_static,
         mock_llm,
     ):
-        """When the DeepRagFromAttachments flag is on, emit a single CreateDeepRag interrupt."""
+        """Default (kill switch off) emits a single CreateDeepRag from-attachments interrupt."""
         mock_interrupt.side_effect = [{"text": "Deep RAG analysis result"}]
         mock_get_wrapper.return_value = Mock()
 

--- a/tests/agent/tools/internal_tools/test_deeprag_tool.py
+++ b/tests/agent/tools/internal_tools/test_deeprag_tool.py
@@ -17,9 +17,7 @@ from uipath.agent.models.agent import (
     DeepRagFileExtension,
     DeepRagFileExtensionSetting,
 )
-from uipath.platform.context_grounding.context_grounding_index import (
-    ContextGroundingIndex,
-)
+from uipath.platform.common import CreateDeepRag
 
 from uipath_langchain.agent.tools.internal_tools.deeprag_tool import (
     create_deeprag_tool,
@@ -122,142 +120,47 @@ class TestCreateDeepRagTool:
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
     )
-    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.UiPath")
     @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     @patch(
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
-    async def test_create_deeprag_tool_static_query_index_ready(
+    async def test_create_deeprag_tool_static_query(
         self,
         mock_interrupt,
-        mock_uipath_class,
         mock_get_wrapper,
         resource_config_static,
         mock_llm,
     ):
-        """Test DeepRAG tool with static query when index is immediately ready."""
-        # Setup mocks
-        mock_uipath = AsyncMock()
-        mock_uipath_class.return_value = mock_uipath
+        """Static-query path emits a single CreateDeepRag interrupt with the configured prompt."""
+        mock_interrupt.side_effect = [{"text": "Deep RAG analysis result"}]
+        mock_get_wrapper.return_value = Mock()
 
-        mock_index = ContextGroundingIndex(
-            id=str(uuid.uuid4()),
-            name="ephemeral-index-123",
-            last_ingestion_status="Successful",
-        )
-
-        mock_uipath.context_grounding.create_ephemeral_index_async = AsyncMock(
-            return_value=mock_index
-        )
-
-        # Index is ready → ReadyEphemeralIndex skips interrupt() (no scratchpad in tests).
-        # Only create_deeprag calls interrupt().
-        mock_interrupt.side_effect = [
-            {"text": "Deep RAG analysis result"},
-        ]
-
-        mock_wrapper = Mock()
-        mock_get_wrapper.return_value = mock_wrapper
-
-        # Create tool
         tool = create_deeprag_tool(resource_config_static, mock_llm)
 
-        # Verify tool creation
         assert tool.name == "deeprag_static"
         assert tool.description == "Analyze document with DeepRAG (static query)"
 
-        # Test tool execution
+        attachment_id = str(uuid.uuid4())
         mock_attachment = MockAttachment(
-            ID=str(uuid.uuid4()), FullName="test.pdf", MimeType="application/pdf"
+            ID=attachment_id, FullName="test.pdf", MimeType="application/pdf"
         )
 
         assert tool.coroutine is not None
         result = await tool.coroutine(attachment=mock_attachment)
 
-        # Verify result
         assert result == {"text": "Deep RAG analysis result"}
 
-        # Verify ephemeral index was created
-        mock_uipath.context_grounding.create_ephemeral_index_async.assert_called_once()
-        call_kwargs = (
-            mock_uipath.context_grounding.create_ephemeral_index_async.call_args.kwargs
-        )
-        assert call_kwargs["usage"] == "DeepRAG"
-        assert mock_attachment.ID in call_kwargs["attachments"]
-
-        # Only create_deeprag calls interrupt(); index was instant-resumed
         assert mock_interrupt.call_count == 1
+        create_payload = mock_interrupt.call_args.args[0]
+        assert isinstance(create_payload, CreateDeepRag)
+        assert create_payload.attachments == [attachment_id]
+        assert create_payload.prompt == "What are the main points?"
+        assert create_payload.citation_mode == CitationMode.INLINE
 
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
     )
-    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.UiPath")
-    @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
-    @patch(
-        "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
-        lambda **kwargs: lambda f: f,
-    )
-    async def test_create_deeprag_tool_static_query_wait_for_ingestion(
-        self,
-        mock_interrupt,
-        mock_uipath_class,
-        mock_get_wrapper,
-        resource_config_static,
-        mock_llm,
-    ):
-        """Test DeepRAG tool with static query when index needs to wait for ingestion."""
-        # Setup mocks
-        mock_uipath = AsyncMock()
-        mock_uipath_class.return_value = mock_uipath
-
-        pending_id = str(uuid.uuid4())
-        mock_index_pending = ContextGroundingIndex(
-            id=pending_id,
-            name="ephemeral-index-456",
-            last_ingestion_status="InProgress",
-        )
-
-        mock_index_complete = {
-            "id": mock_index_pending.id,
-            "name": mock_index_pending.name,
-            "last_ingestion_status": "Successful",
-        }
-
-        mock_uipath.context_grounding.create_ephemeral_index_async = AsyncMock(
-            return_value=mock_index_pending
-        )
-
-        # First interrupt returns completed index, second returns DeepRAG result
-        mock_interrupt.side_effect = [
-            mock_index_complete,
-            {"text": "Deep RAG analysis after waiting"},
-        ]
-
-        mock_wrapper = Mock()
-        mock_get_wrapper.return_value = mock_wrapper
-
-        # Create tool
-        tool = create_deeprag_tool(resource_config_static, mock_llm)
-
-        # Test tool execution
-        mock_attachment = MockAttachment(
-            ID=str(uuid.uuid4()), FullName="test.pdf", MimeType="application/pdf"
-        )
-
-        assert tool.coroutine is not None
-        result = await tool.coroutine(attachment=mock_attachment)
-
-        # Verify result
-        assert result == {"text": "Deep RAG analysis after waiting"}
-
-        # Verify interrupt was called twice (WaitEphemeralIndex + CreateDeepRag)
-        assert mock_interrupt.call_count == 2
-
-    @patch(
-        "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
-    )
-    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.UiPath")
     @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     @patch(
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
@@ -266,40 +169,19 @@ class TestCreateDeepRagTool:
     async def test_create_deeprag_tool_dynamic_query(
         self,
         mock_interrupt,
-        mock_uipath_class,
         mock_get_wrapper,
         resource_config_dynamic,
         mock_llm,
     ):
-        """Test DeepRAG tool with dynamic query."""
-        # Setup mocks
-        mock_uipath = AsyncMock()
-        mock_uipath_class.return_value = mock_uipath
+        """Dynamic-query path threads the caller's query into the CreateDeepRag prompt."""
+        mock_interrupt.side_effect = [{"content": "Dynamic query result"}]
+        mock_get_wrapper.return_value = Mock()
 
-        mock_index = ContextGroundingIndex(
-            id=str(uuid.uuid4()),
-            name="ephemeral-index-789",
-            last_ingestion_status="Successful",
-        )
-
-        mock_uipath.context_grounding.create_ephemeral_index_async = AsyncMock(
-            return_value=mock_index
-        )
-
-        # Index is ready → ReadyEphemeralIndex skips interrupt(). Only create_deeprag fires.
-        mock_interrupt.side_effect = [
-            {"content": "Dynamic query result"},
-        ]
-
-        mock_wrapper = Mock()
-        mock_get_wrapper.return_value = mock_wrapper
-
-        # Create tool
         tool = create_deeprag_tool(resource_config_dynamic, mock_llm)
 
-        # Test tool execution with dynamic query
+        attachment_id = str(uuid.uuid4())
         mock_attachment = MockAttachment(
-            ID=str(uuid.uuid4()), FullName="test.txt", MimeType="text/plain"
+            ID=attachment_id, FullName="test.txt", MimeType="text/plain"
         )
 
         assert tool.coroutine is not None
@@ -307,8 +189,14 @@ class TestCreateDeepRagTool:
             attachment=mock_attachment, query="What is the summary?"
         )
 
-        # Verify result
         assert result == {"content": "Dynamic query result"}
+
+        assert mock_interrupt.call_count == 1
+        create_payload = mock_interrupt.call_args.args[0]
+        assert isinstance(create_payload, CreateDeepRag)
+        assert create_payload.attachments == [attachment_id]
+        assert create_payload.prompt == "What is the summary?"
+        assert create_payload.citation_mode == CitationMode.SKIP
 
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
@@ -373,37 +261,22 @@ class TestCreateDeepRagTool:
     @patch(
         "uipath_langchain.agent.wrappers.job_attachment_wrapper.get_job_attachment_wrapper"
     )
-    @patch("uipath_langchain.agent.tools.internal_tools.deeprag_tool.UiPath")
     @patch("uipath_langchain._utils.durable_interrupt.decorator.interrupt")
     @patch(
         "uipath_langchain.agent.tools.internal_tools.deeprag_tool.mockable",
         lambda **kwargs: lambda f: f,
     )
     @patch.dict(os.environ, {"UIPATH_FOLDER_KEY": "test-folder-key"})
-    async def test_create_ephemeral_index_passes_folder_key(
+    async def test_create_deeprag_passes_folder_key(
         self,
         mock_interrupt,
-        mock_uipath_class,
         mock_get_wrapper,
         resource_config_static,
         mock_llm,
     ):
-        """Test that create_ephemeral_index_async receives folder_key from the execution environment."""
-        mock_uipath = AsyncMock()
-        mock_uipath_class.return_value = mock_uipath
-
-        mock_index = ContextGroundingIndex(
-            id=str(uuid.uuid4()),
-            name="ephemeral-index-folder",
-            last_ingestion_status="Successful",
-        )
-        mock_uipath.context_grounding.create_ephemeral_index_async = AsyncMock(
-            return_value=mock_index
-        )
+        """CreateDeepRag.index_folder_key resolves from UIPATH_FOLDER_KEY at invoke time."""
         mock_interrupt.side_effect = [{"text": "result"}]
-
-        mock_wrapper = Mock()
-        mock_get_wrapper.return_value = mock_wrapper
+        mock_get_wrapper.return_value = Mock()
 
         tool = create_deeprag_tool(resource_config_static, mock_llm)
         mock_attachment = MockAttachment(
@@ -413,7 +286,6 @@ class TestCreateDeepRagTool:
         assert tool.coroutine is not None
         await tool.coroutine(attachment=mock_attachment)
 
-        call_kwargs = (
-            mock_uipath.context_grounding.create_ephemeral_index_async.call_args.kwargs
-        )
-        assert call_kwargs["folder_key"] == "test-folder-key"
+        create_payload = mock_interrupt.call_args.args[0]
+        assert isinstance(create_payload, CreateDeepRag)
+        assert create_payload.index_folder_key == "test-folder-key"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-26T20:05:23.6501197Z"
+exclude-newer = "2026-08-26T20:22:33.9044027Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -4546,7 +4546,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.16.12"
+version = "0.16.13"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-26T20:05:23.6501197Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -172,9 +172,9 @@ name = "aiologic"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-    { name = "wrapt" },
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
 wheels = [
@@ -945,8 +945,8 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic" },
-    { name = "typing-extensions" },
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
 wheels = [
@@ -4637,7 +4637,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["openai"], specifier = ">=1.18.0,<1.19.0" },
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.18.0,<1.19.0" },
     { name = "uipath-llm-client", specifier = ">=1.18.0,<1.19.0" },
-    { name = "uipath-platform", specifier = ">=0.2.20,<0.3.0" },
+    { name = "uipath-platform", specifier = ">=0.2.22,<0.3.0" },
     { name = "uipath-runtime", specifier = ">=0.13.0,<0.14.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
@@ -4722,7 +4722,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.20"
+version = "0.2.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4733,9 +4733,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/27/58792e0856dd988d99d144e9a9e1f7d21ed6b7fb875ed172fc9a14f35230/uipath_platform-0.2.20.tar.gz", hash = "sha256:ef28d601b8a80a5562355ebf97df79e30f73c06989caaedb5d99fffaa15ff106", size = 438000, upload-time = "2026-08-19T13:11:36.511Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/8d/a25ffcdf4def8ccaf88f8484ce0fe32899b5bdda0cb2010b0afd4ea39254/uipath_platform-0.2.22.tar.gz", hash = "sha256:081d32e57d5b709db90713f1acd6e0084a1de3aa2e29352cd94f8dcf5f2e43a3", size = 439219, upload-time = "2026-08-28T19:53:39.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/d3/aa2b04c08fd5dcccbe702866240148d3ee201067a4a6e3132359592b0142/uipath_platform-0.2.20-py3-none-any.whl", hash = "sha256:83e758d23850559ca809deb27b9a9bfb85b7b7d006a311c02e88e21569a1f067", size = 286704, upload-time = "2026-08-19T13:11:35.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6d/08c4bde3deee1f7c6eab42ce936d9b155fe17432eb8f1782cfe8dea9bd39/uipath_platform-0.2.22-py3-none-any.whl", hash = "sha256:00749f4b13df3b70354b01e7ed1d9cd6df80f3c514c9feb872ec02e433b2148a", size = 287206, upload-time = "2026-08-28T19:53:38.523Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Makes DeepRag's internal tool default to the single-call `start_deep_rag_from_attachments` primitive — one durable interrupt returning `CreateDeepRag(attachments=[attachment_id], ...)`; the server creates the ephemeral index and starts the Deep RAG task in one operation. The previous two-step ephemeral-index flow is retained behind a kill switch so we can flip back in production if something goes wrong.

## Changes

- `deeprag_tool.py`:
  - Default path: single `@durable_interrupt` emitting `CreateDeepRag(attachments=[...], index_folder_key=UiPathConfig.folder_key)`.
  - Fallback path (kill switch on): the previous `create_ephemeral_index` + `WaitEphemeralIndex` / `ReadyEphemeralIndex` + `create_deeprag(index_id, index_name, is_ephemeral_index=True)` two-step flow, unchanged.
  - Kill switch: `DisableDeepRagFromAttachments` — declared locally as `DEEP_RAG_FROM_ATTACHMENTS_KILL_SWITCH` because the constant that lived in an earlier draft of the SDK PR never made it into the merged SDK. `FeatureFlags.is_flag_enabled(..., default=False)` resolves it against `UIPATH_FEATURE_DisableDeepRagFromAttachments`.
- `test_deeprag_tool.py`:
  - Default-suite tests cover the new single-shot path — one interrupt, `CreateDeepRag.attachments`, `.prompt`, `.citation_mode`, `.index_folder_key` from `UIPATH_FOLDER_KEY`.
  - Fallback tests set `UIPATH_FEATURE_DisableDeepRagFromAttachments=1` and exercise the two-step path (instant-ready index, wait-for-ingestion, folder-key passthrough).
- `pyproject.toml` / `uv.lock`: bump `uipath-platform>=0.2.20` → `>=0.2.22` for the new primitive; bump package `0.16.12` → `0.16.13`.

## Depends on

- [UiPath/uipath-python#1872](https://github.com/UiPath/uipath-python/pull/1872) — merged. Ships the `start_deep_rag_from_attachments` primitive, `CreateDeepRag.attachments` field, and dispatcher branch this PR relies on.

## Why

Old path: two durable interrupts, one with a `WaitEphemeralIndex` suspend in between while the server ingested the attachments. New path: one interrupt — the server does index creation + ingestion + task start in one call. The trailing wait for the DeepRag task itself is unchanged.

Making the new path the default (rather than opt-in) commits us to the simpler flow; the kill switch is the safety net for a fast rollback without a code change if the server-side path regresses in production.

## Rollback

Set `UIPATH_FEATURE_DisableDeepRagFromAttachments=1` on the runtime. The tool reverts to the previous two-step behaviour immediately — no redeploy needed.