### PR TITLE
fix: restore tool wrapper state resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.16.9"
+version = "0.16.10"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/internal_tools/http_request_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/http_request_tool.py
@@ -42,7 +42,6 @@ from uipath_langchain.agent.tools.structured_tool_with_argument_properties impor
     StructuredToolWithArgumentProperties,
 )
 from uipath_langchain.agent.tools.utils import sanitize_tool_name
-from uipath_langchain.agent.wrappers import get_job_attachment_wrapper
 
 HTTP_REQUEST_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
 
@@ -420,6 +419,8 @@ def create_http_request_tool(
             "headers": dict(response.headers),
             "body": response.text,
         }
+
+    from uipath_langchain.agent.wrappers import get_job_attachment_wrapper
 
     job_attachment_wrapper = get_job_attachment_wrapper(output_type=output_model)
 

--- a/src/uipath_langchain/agent/wrappers/job_attachment_wrapper.py
+++ b/src/uipath_langchain/agent/wrappers/job_attachment_wrapper.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from langchain_core.messages.tool import ToolCall
 from langchain_core.tools import BaseTool
@@ -14,10 +12,8 @@ from uipath_langchain.agent.attachments.job_attachments import (
     replace_job_attachment_ids,
 )
 from uipath_langchain.agent.attachments.pydantic_json import coerce_json_strings
-
-if TYPE_CHECKING:
-    from uipath_langchain.agent.react.types import AgentGraphState
-    from uipath_langchain.agent.tools.tool_node import AsyncToolWrapperWithState
+from uipath_langchain.agent.react.types import AgentGraphState
+from uipath_langchain.agent.tools.tool_node import AsyncToolWrapperWithState
 
 
 def _parse(content: str) -> Any:

--- a/tests/agent/tools/test_tool_node.py
+++ b/tests/agent/tools/test_tool_node.py
@@ -304,6 +304,26 @@ class TestUiPathToolNode:
             AgentRuntimeErrorCode.TOOL_INVALID_WRAPPER_STATE
         )
 
+    def test_shipped_wrapper_state_annotation_resolves_to_a_class(self, mock_tool):
+        """The job attachment wrapper's state annotation must resolve to a model.
+
+        A wrapper module that defers its imports (``TYPE_CHECKING`` plus PEP 563
+        annotations) leaves the state parameter as a bare name, which used to
+        reach ``issubclass`` and raise ``TypeError`` on the first tool call.
+        """
+        from uipath_langchain.agent.react.types import AgentGraphState
+        from uipath_langchain.agent.wrappers.job_attachment_wrapper import (
+            resolve_job_attachment_args,
+        )
+
+        node = UiPathToolNode(mock_tool, wrapper=resolve_job_attachment_args)
+
+        filtered_state = node._filter_state(
+            AgentGraphState(messages=[]), resolve_job_attachment_args
+        )
+
+        assert isinstance(filtered_state, AgentGraphState)
+
     def test_tool_error_propagates(self, mock_state):
         """Test that tool errors propagate from UiPathToolNode."""
         failing_tool = MockFailingTool()

--- a/uv.lock
+++ b/uv.lock
@@ -4546,7 +4546,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.16.9"
+version = "0.16.10"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- every tool that goes through the job attachment wrapper fails on its first call in 0.16.9, with `issubclass() arg 1 must be a class`
- the wrapper's state parameter is a real class again, so the tool node can validate state against it

## Why

0.16.9 added `from __future__ import annotations` plus deferred imports to the job attachment wrapper, to keep it out of an import cycle. That turned its `state` parameter into the string `AgentGraphState`, and the tool node passes that parameter straight to `issubclass`, so the first tool call raised `TypeError`. Unit tests never exercised that path, so it shipped.

The wrapper imports the state model at runtime again. The cycle it was avoiding came from `http_request_tool` importing the wrapper at module level, unlike the six other call sites that import it inside the function, so that import moved into the function too.