### PR TITLE
fix: retrieve MCP servers and A2A agents from the resource folder [PRODEV-1374]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.16.10"
+version = "0.16.11"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/_utils/__init__.py
+++ b/src/uipath_langchain/_utils/__init__.py
@@ -1,4 +1,4 @@
-from ._environment import get_execution_folder_path
+from ._environment import get_execution_folder_path, resolve_resource_folder_path
 from ._otel import (
     get_current_span_and_trace_ids,
     set_current_span_error,
@@ -12,6 +12,7 @@ __all__ = [
     "get_current_span_and_trace_ids",
     "get_execution_folder_path",
     "get_unique_model_field_name",
+    "resolve_resource_folder_path",
     "set_current_span_error",
     "set_span_attribute",
 ]

--- a/src/uipath_langchain/_utils/_environment.py
+++ b/src/uipath_langchain/_utils/_environment.py
@@ -1,9 +1,31 @@
 import os
 
+# Packager sentinel written into agent.json for solution-local resources,
+# meaning "same folder as the deployed solution" (see SOLUTION_FOLDER_SENTINEL
+# in the agents repo packager). It must never be sent as a real folder path.
+SOLUTION_FOLDER_SENTINEL = "solution_folder"
+
 
 def get_execution_folder_path() -> str | None:
     """Reads the agent's executing folder path from the runtime environment."""
     return os.environ.get("UIPATH_FOLDER_PATH")
+
+
+def resolve_resource_folder_path(resource_folder_path: str | None) -> str | None:
+    """Folder path where a bound resource lives, or None when unknown.
+
+    Maps the packager's ``solution_folder`` sentinel (and empty values) to
+    None so callers fall back to the execution folder.
+
+    Args:
+        resource_folder_path: The ``folderPath`` recorded on the resource config.
+
+    Returns:
+        The resource's folder path, or None when it is empty or the sentinel.
+    """
+    if not resource_folder_path or resource_folder_path == SOLUTION_FOLDER_SENTINEL:
+        return None
+    return resource_folder_path
 
 
 def get_default_timeout() -> float:

--- a/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
+++ b/src/uipath_langchain/agent/tools/a2a/a2a_tool.py
@@ -37,7 +37,10 @@ from uipath._utils._ssl_context import get_httpx_client_kwargs
 from uipath.agent.models.agent import AgentA2aResourceConfig
 from uipath.core.tracing.span_utils import UiPathSpanUtils
 
-from uipath_langchain._utils import get_execution_folder_path
+from uipath_langchain._utils import (
+    get_execution_folder_path,
+    resolve_resource_folder_path,
+)
 from uipath_langchain.agent.react.types import AgentGraphState
 from uipath_langchain.agent.tools.base_uipath_structured_tool import (
     BaseUiPathStructuredTool,
@@ -84,10 +87,12 @@ class A2aClient:
         agent_card: AgentCard,
         resource_name: str,
         protocol_version: str | None = "1.0",
+        resource_folder_path: str | None = None,
     ) -> None:
         self._agent_card = agent_card
         self._resource_name = resource_name
         self._protocol_version = protocol_version
+        self._resource_folder_path = resource_folder_path
         self._lock = asyncio.Lock()
         self._client: Client | None = None
         self._http_client: httpx.AsyncClient | None = None
@@ -107,7 +112,14 @@ class A2aClient:
                         )
 
                     sdk = UiPath()
-                    folder_path = get_execution_folder_path()
+                    # The agent is retrieved from the folder recorded on the
+                    # resource — an external reference living in its own folder,
+                    # not necessarily the job's. The solution_folder sentinel
+                    # falls back to the execution folder.
+                    folder_path = (
+                        resolve_resource_folder_path(self._resource_folder_path)
+                        or get_execution_folder_path()
+                    )
                     agent = await sdk.remote_a2a.retrieve_async(
                         name=self._resource_name,
                         folder_path=folder_path,
@@ -484,6 +496,7 @@ def create_a2a_tools_and_clients(
             agent_card,
             resource.name,
             protocol_version=_select_protocol_version(resource.cached_agent_card),
+            resource_folder_path=resource.folder_path,
         )
         tool = _create_a2a_tool(resource, a2a_client, agent_card)
         tools.append(tool)

--- a/src/uipath_langchain/agent/tools/mcp/claude.md
+++ b/src/uipath_langchain/agent/tools/mcp/claude.md
@@ -443,9 +443,14 @@ The MCP server URL and authorization headers are loaded lazily on first tool cal
 async def _initialize_client(self) -> None:
     from uipath.platform import UiPath
 
+    folder_path = (
+        resolve_resource_folder_path(self._config.folder_path)
+        or get_execution_folder_path()
+    )
     sdk = UiPath()
     mcp_server = await sdk.mcp.retrieve_async(
-        slug=self._config.slug, folder_path=self._config.folder_path
+        name=self._config.name,
+        folder_path=folder_path,
     )
     self._url = mcp_server.mcp_url
     self._headers = {"Authorization": f"Bearer {sdk._config.secret}"}
@@ -460,6 +465,18 @@ The `uipath debug` command loads resource bindings (which can override MCP serve
 **after** the LangGraph agent graph is built. This means bindings are only available at
 execution time, not at graph construction time. By deferring the SDK call to the first
 tool invocation, we ensure the bindings are properly loaded and applied.
+
+**Folder resolution:** the server is retrieved from the folder recorded on the
+resource config (`config.folder_path`) — an MCP registration is an external
+reference that lives in its own folder, not necessarily the one the job executes
+in (debug runs execute in the personal workspace, so AgentHub's folder-scoped
+`GET api/servers/{name}` would 404 for any tenant-folder server otherwise).
+`resolve_resource_folder_path` (in `_utils/_environment.py`) maps the packager's
+`solution_folder` sentinel and empty values to `None`, which falls back to the
+execution folder (`UIPATH_FOLDER_PATH`), and from there the SDK falls back to
+the ambient folder key. Binding overwrites, when present, still win — the
+`@resource_override` decorators on `retrieve_async` replace both name and
+folder. The same resolution is used by `a2a_tool.py` for Remote A2A agents.
 
 ### 2. HTTP Client Configuration
 

--- a/src/uipath_langchain/agent/tools/mcp/mcp_client.py
+++ b/src/uipath_langchain/agent/tools/mcp/mcp_client.py
@@ -19,7 +19,10 @@ from mcp.types import CallToolResult, ListToolsResult
 from uipath._utils._ssl_context import get_httpx_client_kwargs
 from uipath.runtime.base import UiPathDisposableProtocol
 
-from uipath_langchain._utils import get_execution_folder_path
+from uipath_langchain._utils import (
+    get_execution_folder_path,
+    resolve_resource_folder_path,
+)
 
 from .streamable_http import SessionInfo, streamable_http_client
 
@@ -150,8 +153,18 @@ class McpClient(UiPathDisposableProtocol):
         - ClientSession
 
         Then calls _initialize_session() to complete the MCP handshake.
+
+        The server is retrieved from the folder recorded on the resource config —
+        an MCP registration is an external reference that lives in its own folder,
+        not necessarily the one the job executes in (debug runs execute in the
+        personal workspace). Solution-local resources carry the ``solution_folder``
+        sentinel instead of a folder, so they fall back to the execution folder;
+        binding overwrites, when present, replace both name and folder in the SDK.
         """
-        folder_path = get_execution_folder_path()
+        folder_path = (
+            resolve_resource_folder_path(self._config.folder_path)
+            or get_execution_folder_path()
+        )
         logger.debug(
             f"Initializing MCP client for '{self._config.name}' "
             f"in folder '{folder_path}'"

--- a/tests/agent/tools/test_a2a_tool.py
+++ b/tests/agent/tools/test_a2a_tool.py
@@ -52,6 +52,7 @@ def _make_resource(
     *,
     cached_agent_card: dict[str, Any] | None = None,
     is_enabled: bool = True,
+    folder_path: str = "Shared",
 ) -> AgentA2aResourceConfig:
     """Build an A2A resource config for tests."""
     return AgentA2aResourceConfig(
@@ -60,7 +61,7 @@ def _make_resource(
         description="A remote A2A agent",
         is_enabled=is_enabled,
         slug="remote-agent-slug",
-        folder_path="Shared",
+        folder_path=folder_path,
         cached_agent_card=cached_agent_card,
     )
 
@@ -178,6 +179,46 @@ async def test_client_resolves_proxy_url_via_retrieve(
     assert sdk.remote_a2a.calls == [("Remote Agent", "Shared")]
 
     await client.dispose()
+
+
+async def test_client_retrieves_agent_from_resource_folder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The remote agent is retrieved from the folder recorded on the resource,
+    not the folder the job executes in."""
+    sdk = _FakeSdk(a2a_url=PROXY_URL)
+    _patch_runtime(monkeypatch, sdk)
+    monkeypatch.setattr(a2a_tool, "get_execution_folder_path", lambda: "ExecFolder")
+
+    resource = _make_resource(cached_agent_card=_cached_card(), folder_path="Shared")
+    _, clients = create_a2a_tools_and_clients([resource])
+
+    await clients[0].get()
+
+    assert sdk.remote_a2a.calls == [("remote-agent", "Shared")]
+
+    await clients[0].dispose()
+
+
+async def test_client_falls_back_to_execution_folder_for_sentinel_resource(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The packager's ``solution_folder`` sentinel means "same folder as the
+    deployed solution" and must never be sent as a real folder path."""
+    sdk = _FakeSdk(a2a_url=PROXY_URL)
+    _patch_runtime(monkeypatch, sdk)
+    monkeypatch.setattr(a2a_tool, "get_execution_folder_path", lambda: "ExecFolder")
+
+    resource = _make_resource(
+        cached_agent_card=_cached_card(), folder_path="solution_folder"
+    )
+    _, clients = create_a2a_tools_and_clients([resource])
+
+    await clients[0].get()
+
+    assert sdk.remote_a2a.calls == [("remote-agent", "ExecFolder")]
+
+    await clients[0].dispose()
 
 
 async def test_client_raises_when_agent_has_no_proxy_url(

--- a/tests/agent/tools/test_mcp/claude.md
+++ b/tests/agent/tools/test_mcp/claude.md
@@ -41,7 +41,10 @@ tests/agent/tools/test_mcp/
 │       ├── test_session_can_be_reused_after_dispose
 │       ├── test_list_tools_caches_result_across_calls   ← list_tools fetched once per lifetime
 │       ├── test_list_tools_force_refresh_bypasses_cache
-│       └── test_dispose_clears_tools_cache
+│       ├── test_dispose_clears_tools_cache
+│       ├── test_retrieve_uses_resource_folder_not_execution_folder  ← folder resolution
+│       ├── test_retrieve_falls_back_to_execution_folder_for_sentinel
+│       └── test_retrieve_passes_none_when_sentinel_and_no_execution_folder
 │
 └── test_mcp_tool.py           # Tool factory tests (17 tests)
     ├── TestMcpToolMetadata (class)
@@ -83,6 +86,22 @@ tests/agent/tools/test_mcp/
         ├── test_nonbreaking_change_executes_without_retry
         └── test_schema_change_message_lists_param_types
 ```
+
+### Folder resolution tests (`test_retrieve_*`)
+
+Cover which folder `McpClient._initialize_client` passes to
+`sdk.mcp.retrieve_async`. The server must be retrieved from the folder recorded
+on the resource config (`/Shared/TestFolder` in the fixture), **not** the job's
+execution folder (`UIPATH_FOLDER_PATH`) — a debug run executes in the personal
+workspace while the server lives in its registration folder, and AgentHub's
+lookup is folder-scoped. The packager's `solution_folder` sentinel (and empty
+values) must fall back to the execution folder, and with neither available
+`folder_path=None` is passed so the SDK uses the ambient folder key. These use
+the shared `_call_tool_and_capture_retrieve` helper, which runs one tool call
+with mocked transport and returns the `retrieve_async` mock for call-args
+assertions. Mirrored for A2A in `tests/agent/tools/test_a2a_tool.py`
+(`test_client_retrieves_agent_from_resource_folder`,
+`test_client_falls_back_to_execution_folder_for_sentinel_resource`).
 
 ### TestCachedRefreshSchemaBeforeCall
 

--- a/tests/agent/tools/test_mcp/test_mcp_client.py
+++ b/tests/agent/tools/test_mcp/test_mcp_client.py
@@ -846,13 +846,10 @@ class TestMcpClient:
         await client.dispose()
         assert client._tools_cache is None
 
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Shared/TestFolder"})
-    @patch("httpx.AsyncClient")
-    async def test_retrieve_async_uses_name_and_execution_folder_path(
-        self, mock_async_client_class, mcp_resource_config
-    ):
-        """Test that name resolution receives both identities and the execution folder."""
+    async def _call_tool_and_capture_retrieve(
+        self, config: AgentMcpResourceConfig
+    ) -> AsyncMock:
+        """Run one tool call with mocked transport; return the retrieve_async mock."""
         mock_sdk = MagicMock()
         mock_server = MagicMock()
         mock_server.mcp_url = "https://test.uipath.com/mcp"
@@ -860,24 +857,65 @@ class TestMcpClient:
         mock_sdk._config = MagicMock()
         mock_sdk._config.secret = "test-secret-token"
 
-        method_call_sequence: list[str] = []
-        initialize_count = [0]
-        tool_call_count = [0]
-
-        MockStreamResponse = self.create_mock_stream_response(
-            method_call_sequence, initialize_count, tool_call_count
-        )
+        MockStreamResponse = self.create_mock_stream_response([], [0], [0])
         mock_http_client = self.create_mock_http_client(MockStreamResponse)
-        mock_async_client_class.return_value = mock_http_client
 
-        session = McpClient(config=mcp_resource_config)
-
-        with patch("uipath.platform.UiPath", return_value=mock_sdk):
+        session = McpClient(config=config)
+        with (
+            patch("httpx.AsyncClient", return_value=mock_http_client),
+            patch("uipath.platform.UiPath", return_value=mock_sdk),
+        ):
             await session.call_tool("test_tool", {"query": "test"})
+        await session.dispose()
+        return mock_sdk.mcp.retrieve_async
 
-        mock_sdk.mcp.retrieve_async.assert_called_once_with(
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Exec/JobFolder"})
+    async def test_retrieve_uses_resource_folder_not_execution_folder(
+        self, mcp_resource_config
+    ):
+        """The server is retrieved from the folder recorded on the resource, not
+        the folder the job executes in (a debug run executes in the personal
+        workspace while the server lives in its registration folder)."""
+        retrieve_async = await self._call_tool_and_capture_retrieve(mcp_resource_config)
+
+        retrieve_async.assert_called_once_with(
             name="test_server",
             folder_path="/Shared/TestFolder",
         )
 
-        await session.dispose()
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"UIPATH_FOLDER_PATH": "/Exec/JobFolder"})
+    async def test_retrieve_falls_back_to_execution_folder_for_sentinel(
+        self, mcp_resource_config
+    ):
+        """The packager's ``solution_folder`` sentinel means "same folder as the
+        deployed solution" and must never be sent as a real folder path."""
+        config = mcp_resource_config.model_copy(
+            update={"folder_path": "solution_folder"}
+        )
+
+        retrieve_async = await self._call_tool_and_capture_retrieve(config)
+
+        retrieve_async.assert_called_once_with(
+            name="test_server",
+            folder_path="/Exec/JobFolder",
+        )
+
+    @pytest.mark.asyncio
+    async def test_retrieve_passes_none_when_sentinel_and_no_execution_folder(
+        self, mcp_resource_config, monkeypatch
+    ):
+        """With the sentinel and no execution folder path, folder_path is None so
+        the SDK falls back to the ambient folder key."""
+        monkeypatch.delenv("UIPATH_FOLDER_PATH", raising=False)
+        config = mcp_resource_config.model_copy(
+            update={"folder_path": "solution_folder"}
+        )
+
+        retrieve_async = await self._call_tool_and_capture_retrieve(config)
+
+        retrieve_async.assert_called_once_with(
+            name="test_server",
+            folder_path=None,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -4546,7 +4546,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.16.10"
+version = "0.16.11"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Problem

`McpClient._initialize_client` retrieves the MCP server with the folder the **job executes in** (`get_execution_folder_path()` → `UIPATH_FOLDER_PATH`, falling back to the ambient `UIPATH_FOLDER_KEY` inside the SDK), ignoring the `folderPath` recorded on the resource config. `A2aClient.get()` does the same for remote A2A agents.

AgentHub's server lookup (`GET api/servers/{identifier}`, and the A2A equivalent) is folder-scoped, so a server living in a different folder than the job 404s:

- Agent Builder debug runs execute in the personal workspace, so **every** debug run against a tenant-folder server fails — cached discovery dies on the first tool call with `404 Not Found` on `GET …/agenthub_/api/servers/{name}`, dynamic discovery (Flow inline agents) dies at startup in `list_tools`.
- Published agents whose job runs in a different folder than the server hit the same 404.
- The failing call happens before any type-specific logic, so all MCP server types are affected (Remote, Coded, Command, UiPath), and Remote A2A tools identically.

Binding overwrites cannot compensate today: the Studio binding-overwrites response carries `process`/`index`/`memorySpace` entries but no `mcpServer`/`remoteA2aAgent` ones (the bindings generator emits those bindings without a `folderPath` value), so the `@resource_override` decorators on `retrieve_async` never match — those are the `No resource overwrite matched for mcpServer key='mcpServer.<Name>' on retrieve_async` lines in the failing runs' logs.

Tracked as [PRODEV-1374](https://uipath.atlassian.net/browse/PRODEV-1374) (dogfooding, Remote MCP; independently reported for coded MCP servers on staging).

## Fix

Resolve the retrieve folder from the resource first:

1. `config.folder_path` — where the registration actually lives. An MCP server / remote A2A agent is an **external reference** with its own folder, unlike a process deployed alongside the agent, so the recorded folder is authoritative;
2. mapped through the new `resolve_resource_folder_path()` (`_utils/_environment.py`): the packager's `solution_folder` sentinel and empty values become `None`, so solution-local resources keep falling back to
3. the execution folder (`UIPATH_FOLDER_PATH`) — and from there the SDK's ambient folder key, as before.

The sentinel guard is the lesson from #1038 / #1047: `solution_folder` must never be sent as a real folder path. Binding overwrites, when present, still win — the `@resource_override` decorators replace both name and folder args after this resolution.

`A2aClient` gains an optional `resource_folder_path` parameter (default `None` preserves the previous behavior for direct constructions); `create_a2a_tools_and_clients` passes `resource.folder_path`.

## Testing

- New tests (written first, watched fail with `folder_path='/Exec/JobFolder'` instead of the resource folder):
  - `TestMcpClient::test_retrieve_uses_resource_folder_not_execution_folder`, plus sentinel-fallback and sentinel-with-no-env pins (`…falls_back_to_execution_folder_for_sentinel`, `…passes_none_when_sentinel_and_no_execution_folder`)
  - `test_client_retrieves_agent_from_resource_folder` and `test_client_falls_back_to_execution_folder_for_sentinel_resource` for A2A, going through `create_a2a_tools_and_clients` so the resource→client wiring is covered
- Removed `test_retrieve_async_uses_name_and_execution_folder_path`, which pinned the buggy resolution (and used identical env/resource values, so it could not tell the two sources apart).
- Full suite green except 3 pre-existing `test_uipath_cli_tool.py` schema-example failures that fail identically on clean `main` in this environment (local CLI version, unrelated).
- `ruff check` / `ruff format --check` / httpx client linter clean. Module docs (`mcp/claude.md`, `test_mcp/claude.md`) updated. Version bumped 0.16.10 → 0.16.11.

## Follow-ups (separate, noted on PRODEV-1374)

- Agents repo: `BindingsGenerator` should emit `folderPath` in `mcpServer`/`remoteA2aAgent` bindings so Solutions deployments can remap folders and binding overwrites start covering MCP/A2A.
- Per #1038's notes, `context_tool.py` / `escalation_recipient.py` / `escalation_tool.py` still do env-only resolution; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PRODEV-1374]: https://uipath.atlassian.net/browse/PRODEV-1374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ