### PR TITLE
chore(deps): migrate to deepagents 0.7.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.17.9"
+version = "0.18.0"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -10,11 +10,11 @@ dependencies = [
     "uipath-platform>=0.2.28, <0.3.0",
     "uipath-runtime>=0.13.0, <0.14.0",
     "uipath-llm-client>=1.20.0, <1.21.0",
-    "langgraph>=1.1.8, <2.0.0",
-    "langchain-core>=1.2.27, <2.0.0",
+    "langgraph>=1.2.11, <2.0.0",
+    "langchain-core>=1.6.1, <2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.3, <4.0.0",
-    "langchain>=1.2.15, <2.0.0",
-    "deepagents>=0.5.9, <0.6.0",
+    "langchain>=1.3.18, <2.0.0",
+    "deepagents>=0.7.11, <0.8.0",
     "pydantic-settings>=2.6.0",
     "python-dotenv>=1.0.1",
     "httpx>=0.27.0",
@@ -58,8 +58,12 @@ bedrock = [
 fireworks = [
     "uipath-langchain-client[fireworks]>=1.20.0, <1.21.0",
 ]
+code-interpreter = [
+    "langchain-quickjs>=0.3.5, <0.4.0",
+]
 all = [
     "uipath-langchain-client[all]>=1.20.0, <1.21.0",
+    "uipath-langchain[code-interpreter]",
 ]
 
 [project.entry-points."uipath.middlewares"]

--- a/samples/deepagent-storage-buckets/pyproject.toml
+++ b/samples/deepagent-storage-buckets/pyproject.toml
@@ -5,7 +5,7 @@ description = "DeepAgent with persistant storage in Orchestrator Buckets"
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 requires-python = ">=3.11"
 dependencies = [
-    "deepagents>=0.3.9",
+    "deepagents>=0.7.11, <0.8.0",
     "langchain-anthropic>=1.3.1",
     "langchain-tavily>=0.2.17",
     "langgraph>=1.0.7",

--- a/samples/deepagent-storage-buckets/src/deepagent_storage_buckets/buckets_backend.py
+++ b/samples/deepagent-storage-buckets/src/deepagent_storage_buckets/buckets_backend.py
@@ -21,13 +21,18 @@ from deepagents.backends.protocol import (
     FileDownloadResponse,
     FileInfo,
     FileUploadResponse,
+    GlobResult,
     GrepMatch,
+    GrepResult,
+    LsResult,
+    ReadResult,
     WriteResult,
 )
 from deepagents.backends.utils import (
     check_empty_content,
-    format_content_with_line_numbers,
+    file_data_to_string,
     perform_string_replacement,
+    slice_read_response,
 )
 from uipath.platform import UiPath
 from uipath.platform.common import PagedResult
@@ -148,8 +153,7 @@ class UiPathBucketBackend(BackendProtocol):
         try:
             return json.loads(content.decode("utf-8"))
         except (json.JSONDecodeError, UnicodeDecodeError):
-            lines = content.decode("utf-8", errors="replace").splitlines()
-            return {"content": lines}
+            return {"content": content.decode("utf-8", errors="replace")}
 
     async def _aget_file_data(self, path: str) -> dict[str, Any] | None:
         """Get file data dict from bucket asynchronously."""
@@ -159,8 +163,7 @@ class UiPathBucketBackend(BackendProtocol):
         try:
             return json.loads(content.decode("utf-8"))
         except (json.JSONDecodeError, UnicodeDecodeError):
-            lines = content.decode("utf-8", errors="replace").splitlines()
-            return {"content": lines}
+            return {"content": content.decode("utf-8", errors="replace")}
 
     def _put_file_data(
         self, path: str, data: dict[str, Any], *, update_modified: bool = True
@@ -256,7 +259,7 @@ class UiPathBucketBackend(BackendProtocol):
 
         return results
 
-    def ls_info(self, path: str) -> list[FileInfo]:
+    def ls(self, path: str) -> LsResult:
         """List files in a directory."""
         prefix = path.lstrip("/")
         if prefix and not prefix.endswith("/"):
@@ -277,17 +280,19 @@ class UiPathBucketBackend(BackendProtocol):
                     seen_dirs.add(dir_path)
                     results.append({"path": dir_path, "is_dir": True})
             else:
-                results.append({
-                    "path": vpath,
-                    "is_dir": False,
-                    "size": file.size or 0,
-                    "modified_at": file.last_modified,
-                })
+                results.append(
+                    {
+                        "path": vpath,
+                        "is_dir": False,
+                        "size": file.size or 0,
+                        "modified_at": file.last_modified,
+                    }
+                )
 
         results.sort(key=lambda x: x.get("path", ""))
-        return results
+        return LsResult(entries=results)
 
-    async def als_info(self, path: str) -> list[FileInfo]:
+    async def als(self, path: str) -> LsResult:
         """List files in a directory asynchronously."""
         prefix = path.lstrip("/")
         if prefix and not prefix.endswith("/"):
@@ -308,89 +313,79 @@ class UiPathBucketBackend(BackendProtocol):
                     seen_dirs.add(dir_path)
                     results.append({"path": dir_path, "is_dir": True})
             else:
-                results.append({
-                    "path": vpath,
-                    "is_dir": False,
-                    "size": file.size or 0,
-                    "modified_at": file.last_modified,
-                })
+                results.append(
+                    {
+                        "path": vpath,
+                        "is_dir": False,
+                        "size": file.size or 0,
+                        "modified_at": file.last_modified,
+                    }
+                )
 
         results.sort(key=lambda x: x.get("path", ""))
-        return results
+        return LsResult(entries=results)
 
-    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
-        """Read file content with line numbers."""
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        """Read file content for the requested line range.
+
+        Returns the raw window plus pagination metadata; the filesystem
+        middleware adds the line-number gutter, so this must not format.
+        """
         data = self._get_file_data(file_path)
         if data is None:
-            return f"Error: File '{file_path}' not found"
+            return ReadResult(error=f"Error: File '{file_path}' not found")
 
-        lines = data.get("content", [])
-        if not lines:
+        if not data.get("content"):
             empty_msg = check_empty_content("")
             if empty_msg:
-                return empty_msg
+                return ReadResult(error=empty_msg)
 
-        if offset >= len(lines):
-            return f"Error: Line offset {offset} exceeds file length ({len(lines)} lines)"
+        return slice_read_response(data, offset, limit)
 
-        selected = lines[offset : offset + limit]
-        return format_content_with_line_numbers(selected, start_line=offset + 1)
+    async def aread(
+        self, file_path: str, offset: int = 0, limit: int = 2000
+    ) -> ReadResult:
+        """Read file content for the requested line range.
 
-    async def aread(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
-        """Read file content with line numbers asynchronously."""
+        Returns the raw window plus pagination metadata; the filesystem
+        middleware adds the line-number gutter, so this must not format.
+        """
         data = await self._aget_file_data(file_path)
         if data is None:
-            return f"Error: File '{file_path}' not found"
+            return ReadResult(error=f"Error: File '{file_path}' not found")
 
-        lines = data.get("content", [])
-        if not lines:
+        if not data.get("content"):
             empty_msg = check_empty_content("")
             if empty_msg:
-                return empty_msg
+                return ReadResult(error=empty_msg)
 
-        if offset >= len(lines):
-            return f"Error: Line offset {offset} exceeds file length ({len(lines)} lines)"
-
-        selected = lines[offset : offset + limit]
-        return format_content_with_line_numbers(selected, start_line=offset + 1)
+        return slice_read_response(data, offset, limit)
 
     def write(self, file_path: str, content: str) -> WriteResult:
-        """Create a new file."""
-        if self._exists(file_path):
-            return WriteResult(
-                error=f"Cannot write to {file_path} because it already exists. "
-                "Read and then make an edit, or write to a new path."
-            )
-
+        """Create a file, replacing it if the path already exists."""
         now = datetime.now(timezone.utc).isoformat()
         data = {
-            "content": content.splitlines(),
+            "content": content,
             "created_at": now,
             "modified_at": now,
         }
         try:
             self._put_file_data(file_path, data, update_modified=False)
-            return WriteResult(path=file_path, files_update=None)
+            return WriteResult(path=file_path)
         except Exception as e:
             return WriteResult(error=f"Error writing file '{file_path}': {e}")
 
     async def awrite(self, file_path: str, content: str) -> WriteResult:
-        """Create a new file asynchronously."""
-        if await self._aexists(file_path):
-            return WriteResult(
-                error=f"Cannot write to {file_path} because it already exists. "
-                "Read and then make an edit, or write to a new path."
-            )
-
+        """Create a file asynchronously, replacing it if the path already exists."""
         now = datetime.now(timezone.utc).isoformat()
         data = {
-            "content": content.splitlines(),
+            "content": content,
             "created_at": now,
             "modified_at": now,
         }
         try:
             await self._aput_file_data(file_path, data, update_modified=False)
-            return WriteResult(path=file_path, files_update=None)
+            return WriteResult(path=file_path)
         except Exception as e:
             return WriteResult(error=f"Error writing file '{file_path}': {e}")
 
@@ -406,20 +401,20 @@ class UiPathBucketBackend(BackendProtocol):
         if data is None:
             return EditResult(error=f"Error: File '{file_path}' not found")
 
-        content = "\n".join(data.get("content", []))
-        result = perform_string_replacement(content, old_string, new_string, replace_all)
+        content = file_data_to_string(data)
+        result = perform_string_replacement(
+            content, old_string, new_string, replace_all
+        )
 
         if isinstance(result, str):
             return EditResult(error=result)
 
         new_content, occurrences = result
-        data["content"] = new_content.splitlines()
+        data["content"] = new_content
 
         try:
             self._put_file_data(file_path, data)
-            return EditResult(
-                path=file_path, files_update=None, occurrences=int(occurrences)
-            )
+            return EditResult(path=file_path, occurrences=int(occurrences))
         except Exception as e:
             return EditResult(error=f"Error editing file '{file_path}': {e}")
 
@@ -435,31 +430,36 @@ class UiPathBucketBackend(BackendProtocol):
         if data is None:
             return EditResult(error=f"Error: File '{file_path}' not found")
 
-        content = "\n".join(data.get("content", []))
-        result = perform_string_replacement(content, old_string, new_string, replace_all)
+        content = file_data_to_string(data)
+        result = perform_string_replacement(
+            content, old_string, new_string, replace_all
+        )
 
         if isinstance(result, str):
             return EditResult(error=result)
 
         new_content, occurrences = result
-        data["content"] = new_content.splitlines()
+        data["content"] = new_content
 
         try:
             await self._aput_file_data(file_path, data)
-            return EditResult(
-                path=file_path, files_update=None, occurrences=int(occurrences)
-            )
+            return EditResult(path=file_path, occurrences=int(occurrences))
         except Exception as e:
             return EditResult(error=f"Error editing file '{file_path}': {e}")
 
-    def grep_raw(
-        self, pattern: str, path: str | None = None, glob: str | None = None
-    ) -> list[GrepMatch] | str:
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
+    ) -> GrepResult:
         """Search for pattern in files."""
         try:
             regex = re.compile(pattern)
         except re.error as e:
-            return f"Invalid regex pattern: {e}"
+            return GrepResult(error=f"Invalid regex pattern: {e}")
 
         search_prefix = (path or "/").lstrip("/")
         files = self._list_files(search_prefix)
@@ -476,20 +476,27 @@ class UiPathBucketBackend(BackendProtocol):
             if data is None:
                 continue
 
-            for line_num, line in enumerate(data.get("content", []), 1):
+            for line_num, line in enumerate(file_data_to_string(data).splitlines(), 1):
                 if regex.search(line):
                     matches.append({"path": vpath, "line": line_num, "text": line})
+                    if max_count is not None and len(matches) >= max_count:
+                        return GrepResult(matches=matches, truncated=True)
 
-        return matches
+        return GrepResult(matches=matches)
 
-    async def agrep_raw(
-        self, pattern: str, path: str | None = None, glob: str | None = None
-    ) -> list[GrepMatch] | str:
+    async def agrep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
+    ) -> GrepResult:
         """Search for pattern in files asynchronously."""
         try:
             regex = re.compile(pattern)
         except re.error as e:
-            return f"Invalid regex pattern: {e}"
+            return GrepResult(error=f"Invalid regex pattern: {e}")
 
         search_prefix = (path or "/").lstrip("/")
         files = await self._alist_files(search_prefix)
@@ -506,14 +513,17 @@ class UiPathBucketBackend(BackendProtocol):
             if data is None:
                 continue
 
-            for line_num, line in enumerate(data.get("content", []), 1):
+            for line_num, line in enumerate(file_data_to_string(data).splitlines(), 1):
                 if regex.search(line):
                     matches.append({"path": vpath, "line": line_num, "text": line})
+                    if max_count is not None and len(matches) >= max_count:
+                        return GrepResult(matches=matches, truncated=True)
 
-        return matches
+        return GrepResult(matches=matches)
 
-    def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+    def glob(self, pattern: str, path: str | None = None) -> GlobResult:
         """Find files matching a glob pattern."""
+        path = path or "/"
         search_prefix = path.lstrip("/")
         files = self._list_files(search_prefix)
         results: list[FileInfo] = []
@@ -523,18 +533,21 @@ class UiPathBucketBackend(BackendProtocol):
             rel_path = vpath[len(path) :].lstrip("/") if path != "/" else vpath[1:]
 
             if fnmatch.fnmatch(rel_path, pattern) or fnmatch.fnmatch(vpath, pattern):
-                results.append({
-                    "path": vpath,
-                    "is_dir": False,
-                    "size": file.size or 0,
-                    "modified_at": file.last_modified,
-                })
+                results.append(
+                    {
+                        "path": vpath,
+                        "is_dir": False,
+                        "size": file.size or 0,
+                        "modified_at": file.last_modified,
+                    }
+                )
 
         results.sort(key=lambda x: x.get("path", ""))
-        return results
+        return GlobResult(matches=results)
 
-    async def aglob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+    async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
         """Find files matching a glob pattern asynchronously."""
+        path = path or "/"
         search_prefix = path.lstrip("/")
         files = await self._alist_files(search_prefix)
         results: list[FileInfo] = []
@@ -544,15 +557,17 @@ class UiPathBucketBackend(BackendProtocol):
             rel_path = vpath[len(path) :].lstrip("/") if path != "/" else vpath[1:]
 
             if fnmatch.fnmatch(rel_path, pattern) or fnmatch.fnmatch(vpath, pattern):
-                results.append({
-                    "path": vpath,
-                    "is_dir": False,
-                    "size": file.size or 0,
-                    "modified_at": file.last_modified,
-                })
+                results.append(
+                    {
+                        "path": vpath,
+                        "is_dir": False,
+                        "size": file.size or 0,
+                        "modified_at": file.last_modified,
+                    }
+                )
 
         results.sort(key=lambda x: x.get("path", ""))
-        return results
+        return GlobResult(matches=results)
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload multiple files."""
@@ -570,7 +585,9 @@ class UiPathBucketBackend(BackendProtocol):
             except LookupError:
                 responses.append(FileUploadResponse(path=path, error="file_not_found"))
             except PermissionError:
-                responses.append(FileUploadResponse(path=path, error="permission_denied"))
+                responses.append(
+                    FileUploadResponse(path=path, error="permission_denied")
+                )
             except Exception:
                 responses.append(FileUploadResponse(path=path, error="invalid_path"))
 
@@ -594,7 +611,9 @@ class UiPathBucketBackend(BackendProtocol):
             except LookupError:
                 responses.append(FileUploadResponse(path=path, error="file_not_found"))
             except PermissionError:
-                responses.append(FileUploadResponse(path=path, error="permission_denied"))
+                responses.append(
+                    FileUploadResponse(path=path, error="permission_denied")
+                )
             except Exception:
                 responses.append(FileUploadResponse(path=path, error="invalid_path"))
 
@@ -609,7 +628,9 @@ class UiPathBucketBackend(BackendProtocol):
                 content = self._download_content(path)
                 if content is None:
                     responses.append(
-                        FileDownloadResponse(path=path, content=None, error="file_not_found")
+                        FileDownloadResponse(
+                            path=path, content=None, error="file_not_found"
+                        )
                     )
                 else:
                     responses.append(
@@ -617,7 +638,9 @@ class UiPathBucketBackend(BackendProtocol):
                     )
             except PermissionError:
                 responses.append(
-                    FileDownloadResponse(path=path, content=None, error="permission_denied")
+                    FileDownloadResponse(
+                        path=path, content=None, error="permission_denied"
+                    )
                 )
             except Exception:
                 responses.append(
@@ -635,7 +658,9 @@ class UiPathBucketBackend(BackendProtocol):
                 content = await self._adownload_content(path)
                 if content is None:
                     responses.append(
-                        FileDownloadResponse(path=path, content=None, error="file_not_found")
+                        FileDownloadResponse(
+                            path=path, content=None, error="file_not_found"
+                        )
                     )
                 else:
                     responses.append(
@@ -643,7 +668,9 @@ class UiPathBucketBackend(BackendProtocol):
                     )
             except PermissionError:
                 responses.append(
-                    FileDownloadResponse(path=path, content=None, error="permission_denied")
+                    FileDownloadResponse(
+                        path=path, content=None, error="permission_denied"
+                    )
                 )
             except Exception:
                 responses.append(

--- a/samples/simple-deepagent/pyproject.toml
+++ b/samples/simple-deepagent/pyproject.toml
@@ -5,7 +5,7 @@ description = "Simple DeepAgent for research tasks using Tavily search"
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 requires-python = ">=3.11"
 dependencies = [
-    "deepagents>=0.3.9",
+    "deepagents>=0.7.11, <0.8.0",
     "langchain-anthropic>=1.3.1",
     "langchain-tavily>=0.2.17",
     "langgraph>=1.0.7",

--- a/src/uipath_langchain/_cli/cli_new.py
+++ b/src/uipath_langchain/_cli/cli_new.py
@@ -11,7 +11,7 @@ console = ConsoleLogger()
 # Deliberately a constant: the guard test in tests/cli/test_new.py fails on
 # every minor bump so the scaffold (pin, template, hints) gets reviewed
 # alongside the release rather than drifting silently.
-UIPATH_LANGCHAIN_SCAFFOLD_MINOR = "0.17"
+UIPATH_LANGCHAIN_SCAFFOLD_MINOR = "0.18"
 
 
 def generate_script(target_directory):

--- a/src/uipath_langchain/_utils/durable_interrupt/__init__.py
+++ b/src/uipath_langchain/_utils/durable_interrupt/__init__.py
@@ -1,13 +1,17 @@
 """Durable interrupt package for side-effect-safe interrupt/resume in LangGraph."""
 
 from .decorator import (
+    SUSPENDS_RUN,
     _durable_state,
     durable_interrupt,
+    suspends_run,
 )
 from .skip_interrupt import SkipInterruptValue
 
 __all__ = [
+    "SUSPENDS_RUN",
     "durable_interrupt",
     "SkipInterruptValue",
     "_durable_state",
+    "suspends_run",
 ]

--- a/src/uipath_langchain/_utils/durable_interrupt/decorator.py
+++ b/src/uipath_langchain/_utils/durable_interrupt/decorator.py
@@ -94,6 +94,28 @@ def _inject_resume(scratchpad: Any, value: Any) -> Any:
     return value
 
 
+SUSPENDS_RUN = "suspends_run"
+"""Tool-metadata key: this tool may raise ``GraphInterrupt`` instead of returning.
+
+A caller that invokes tools outside the graph's tool node must not offer these.
+The node is replayed from its checkpoint on resume, so every call made before the
+interrupt runs again, and such bridges do not reach approval hooks.
+
+Set unconditionally on a tool that suspends only sometimes: the answer for a
+caller outside the tool node is the same either way.
+"""
+
+
+def suspends_run(tool: Any) -> bool:
+    """Whether ``tool`` suspends the run instead of returning a value.
+
+    Per-tool rather than per-factory: ``context_tool`` builds both suspending and
+    non-suspending variants depending on retrieval mode. An unstamped tool reports
+    ``False``.
+    """
+    return bool((getattr(tool, "metadata", None) or {}).get(SUSPENDS_RUN))
+
+
 def durable_interrupt(fn: F) -> F:
     """Decorator that executes a side-effecting function exactly once and interrupts.
 

--- a/src/uipath_langchain/agent/advanced/__init__.py
+++ b/src/uipath_langchain/agent/advanced/__init__.py
@@ -2,12 +2,18 @@
 
 from deepagents import CompiledSubAgent, SubAgent
 from deepagents.backends import BackendProtocol, FilesystemBackend
-from deepagents.backends.protocol import BackendFactory
 
 from .agent import (
     create_advanced_agent,
     create_advanced_agent_graph,
     create_conversational_advanced_agent_graph,
+)
+from .code_interpreter import (
+    PTC_FILESYSTEM_TOOLS,
+    PersistenceMode,
+    build_code_interpreter_middleware,
+    ptc_tool_names,
+    subagent_dispatch_is_replay_safe,
 )
 from .types import AdvancedAgentGraphState, ConversationalAdvancedAgentGraphState
 from .utils import (
@@ -21,15 +27,19 @@ __all__ = [
     "MEMORY_DIR_NAME",
     "MEMORY_INDEX_FILENAME",
     "MEMORY_INDEX_VIRTUAL_PATH",
+    "PTC_FILESYSTEM_TOOLS",
+    "PersistenceMode",
     "AdvancedAgentGraphState",
-    "BackendFactory",
     "BackendProtocol",
     "CompiledSubAgent",
     "ConversationalAdvancedAgentGraphState",
     "FilesystemBackend",
     "SubAgent",
+    "build_code_interpreter_middleware",
     "create_advanced_agent",
     "create_advanced_agent_graph",
     "create_conversational_advanced_agent_graph",
     "create_state_with_input",
+    "ptc_tool_names",
+    "subagent_dispatch_is_replay_safe",
 ]

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -6,9 +6,8 @@ from typing import Any, Literal, NotRequired, cast
 
 from deepagents import CompiledSubAgent, SubAgent
 from deepagents import create_deep_agent as _create_deep_agent
-from deepagents.backends import BackendProtocol
-from deepagents.backends.filesystem import FilesystemBackend
-from deepagents.backends.protocol import BackendFactory
+from deepagents.backends import BackendProtocol, FilesystemBackend
+from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 from langchain.agents.middleware import (
     AgentMiddleware,
     AgentState,
@@ -27,6 +26,7 @@ from uipath.core.chat import UiPathConversationMessageData
 from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain._utils import get_unique_model_field_name
+from uipath_langchain.agent.attachments.constants import OUTPUT_FILE_TOOL_NAME
 from uipath_langchain.agent.attachments.job_attachments import get_job_attachment_paths
 from uipath_langchain.agent.attachments.output_files import (
     DEFAULT_MAX_OUTPUT_FILE_RETRIES,
@@ -205,12 +205,69 @@ def _max_iterations_middleware(
     return [_MaxIterationsMiddleware(max_iterations, initial_message_count_key)]
 
 
+# A subagent returns only a text report, so a reference it produces never reaches
+# the main agent -- the only agent that fills the typed output.
+MAIN_AGENT_ONLY_TOOLS: frozenset[str] = frozenset({OUTPUT_FILE_TOOL_NAME})
+
+
+def _partition_main_agent_tools(
+    tools: Sequence[BaseTool],
+) -> tuple[list[BaseTool], list[BaseTool]]:
+    """Split ``tools`` into (shared with subagents, main agent only)."""
+    shared: list[BaseTool] = []
+    main_only: list[BaseTool] = []
+    for tool in tools:
+        (main_only if tool.name in MAIN_AGENT_ONLY_TOOLS else shared).append(tool)
+    return shared, main_only
+
+
+def _subagents_without_main_agent_tools(
+    subagents: Sequence[SubAgent | CompiledSubAgent],
+    shared_tools: Sequence[BaseTool],
+    skills: Sequence[str] | None,
+) -> list[SubAgent | CompiledSubAgent]:
+    """Give every subagent the shared tool list instead of the parent's.
+
+    deepagents hands a subagent the parent's ``tools`` unless its spec declares its
+    own (``graph.py``: ``spec.get("tools") if "tools" in spec else tools``), so
+    pinning ``tools`` on each spec is what actually withholds a main-agent-only tool.
+
+    The auto-added ``general-purpose`` subagent is replaced with an explicit spec,
+    since it would otherwise inherit the parent list too. Supplying a spec under
+    that name suppresses the built-in one. That branch is also the only reader of
+    ``profile.general_purpose_subagent``, so its ``enabled`` / ``description`` /
+    ``system_prompt`` overrides do not apply here. ``skills`` has to be repeated into the
+    spec: the built-in branch reads the top-level ``skills`` argument, while a
+    caller-supplied spec reads ``spec["skills"]``, so omitting it silently drops
+    skills from that subagent.
+    """
+    resolved: list[SubAgent | CompiledSubAgent] = []
+    for spec in subagents:
+        # A CompiledSubAgent brings its own graph and tools; nothing to filter.
+        if "runnable" in spec or "tools" in spec:
+            resolved.append(spec)
+            continue
+        resolved.append({**spec, "tools": list(shared_tools)})
+
+    if not any(
+        spec.get("name") == GENERAL_PURPOSE_SUBAGENT["name"] for spec in resolved
+    ):
+        gp: dict[str, Any] = {
+            **GENERAL_PURPOSE_SUBAGENT,
+            "tools": list(shared_tools),
+        }
+        if skills:
+            gp["skills"] = list(skills)
+        resolved.append(gp)  # type: ignore[arg-type]
+    return resolved
+
+
 def create_advanced_agent(
     model: BaseChatModel,
     system_prompt: str | SystemMessage | None = "",
     tools: Sequence[BaseTool] = (),
     subagents: Sequence[SubAgent | CompiledSubAgent] = (),
-    backend: BackendProtocol | BackendFactory | None = None,
+    backend: BackendProtocol | None = None,
     response_format: ResponseFormat[Any] | None = None,
     memory: Sequence[str] = (),
     middleware: Sequence[AgentMiddleware[Any, Any]] = (),
@@ -224,12 +281,15 @@ def create_advanced_agent(
 
     ``skills`` is a list of skill source paths for deepagents' ``SkillsMiddleware``;
     ``None`` or empty disables it (mirroring ``_create_deep_agent``'s contract).
+
+    Tools named in :data:`MAIN_AGENT_ONLY_TOOLS` are withheld from every subagent.
     """
+    shared_tools, _ = _partition_main_agent_tools(tools)
     return _create_deep_agent(
         model=model,
         system_prompt=system_prompt,
         tools=list(tools),
-        subagents=list(subagents),
+        subagents=_subagents_without_main_agent_tools(subagents, shared_tools, skills),
         backend=backend,
         response_format=response_format,
         memory=list(memory) or None,
@@ -242,7 +302,7 @@ def create_advanced_agent_graph(
     model: BaseChatModel,
     tools: Sequence[BaseTool],
     system_prompt: str | Callable[[dict[str, Any]], str],
-    backend: BackendProtocol | BackendFactory | None,
+    backend: BackendProtocol | None,
     response_format: ResponseFormat[Any] | None,
     input_schema: type[BaseModel] | None,
     output_schema: type[BaseModel],
@@ -250,6 +310,7 @@ def create_advanced_agent_graph(
     skills: Sequence[str] | None = None,
     output_files_enabled: bool = False,
     max_iterations: int | None = None,
+    middleware: Sequence[AgentMiddleware[Any, Any]] = (),
 ) -> StateGraph[Any, Any, Any, Any]:
     """Wrap the advanced agent in a parent graph that maps typed I/O to/from messages.
 
@@ -287,6 +348,7 @@ def create_advanced_agent_graph(
         middleware=[
             *runtime_prompt.middleware,
             *_max_iterations_middleware(max_iterations),
+            *middleware,
         ],
         skills=skills,
     )
@@ -387,11 +449,12 @@ def create_conversational_advanced_agent_graph(
     model: BaseChatModel,
     tools: Sequence[BaseTool],
     system_prompt: str | Callable[[dict[str, Any]], str],
-    backend: BackendProtocol | BackendFactory | None,
+    backend: BackendProtocol | None,
     skills: Sequence[str] | None = None,
     input_schema: type[BaseModel] | None = None,
     output_schema: type[BaseModel] | None = None,
     max_iterations: int | None = None,
+    middleware: Sequence[AgentMiddleware[Any, Any]] = (),
 ) -> StateGraph[Any, Any, Any, Any]:
     """Wrap the advanced agent in a parent graph that speaks the conversational contract.
 
@@ -430,6 +493,7 @@ def create_conversational_advanced_agent_graph(
         middleware=[
             *runtime_prompt.middleware,
             *_max_iterations_middleware(max_iterations, initial_message_count_key),
+            *middleware,
         ],
         skills=skills,
     )

--- a/src/uipath_langchain/agent/advanced/code_interpreter.py
+++ b/src/uipath_langchain/agent/advanced/code_interpreter.py
@@ -1,0 +1,267 @@
+"""The QuickJS code interpreter for advanced agents, and what it may call.
+
+``CodeInterpreterMiddleware`` adds one ``eval`` tool: a persistent JavaScript REPL
+in a WASM guest (QuickJS-ng under wasmtime). It serves three purposes in a single
+tool call -- computation, programmatic tool calling (PTC), and subagent
+orchestration through the top-level ``task()`` global.
+
+The guest has no ambient capability: no network, no filesystem, no ``fetch``, no
+``require``, no timers. Everything it can reach arrives through the ``ptc``
+allowlist, which makes that allowlist the entire security surface of the feature.
+It is derived here rather than configured, because the rule that governs it is a
+property of our tools (see :data:`SUSPENDS_RUN`) and not of any one consumer.
+
+Requires the ``code-interpreter`` extra::
+
+    uv add "uipath-langchain[code-interpreter]"
+"""
+
+import logging
+from collections.abc import Iterable, Sequence
+from typing import Any, Literal, get_args
+
+from deepagents import CompiledSubAgent, FsToolName, SubAgent
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.tools import BaseTool
+
+from uipath_langchain._utils.durable_interrupt import suspends_run
+
+logger = logging.getLogger(__name__)
+
+_MISSING_EXTRA = (
+    "The code interpreter needs the 'code-interpreter' extra. Install it with "
+    '`uv add "uipath-langchain[code-interpreter]"` (or `pip install '
+    '"uipath-langchain[code-interpreter]"`).'
+)
+
+# ``FilesystemMiddleware`` adds these after we are handed the tool list, so their
+# names have to be supplied rather than read off ``tools``. Upstream matches a
+# ``ptc`` name against the live tool list and ignores one that is absent, so
+# listing the whole literal exposes exactly the tools the backend supports:
+# ``execute`` only for a ``SandboxBackendProtocol`` backend, which ours is not.
+PTC_FILESYSTEM_TOOLS: tuple[str, ...] = get_args(FsToolName)
+
+_RESERVED_TOOL_NAMES = frozenset({"task"})
+
+# Subagent spec keys that make deepagents interrupt without a stamped tool.
+_SUBAGENT_INTERRUPT_KEYS = ("interrupt_on", "permissions", "middleware")
+
+PersistenceMode = Literal["thread", "turn", "call"]
+"""How long the REPL keeps state. Mirrors ``langchain_quickjs.PersistenceMode``
+rather than importing ``langchain_quickjs.middleware.PersistenceMode``, so this
+module imports without the optional extra.
+
+``"thread"`` writes a snapshot of the interpreter's memory into the checkpoint on
+every run, measured at ~1.25 MB even when the agent never calls ``eval``. The
+other two write nothing.
+"""
+
+# Per-eval wall clock. The REPL is for orchestration and arithmetic, not long
+# computation, and a bridged tool call does not consume it.
+DEFAULT_EVAL_TIMEOUT_SECONDS = 5.0
+
+
+def ptc_tool_names(tools: Sequence[BaseTool]) -> list[str]:
+    """Names of the agent tools that may be called from inside the REPL.
+
+    Three exclusions, each for a different reason:
+
+    - **Tools that suspend the run.** One raising ``GraphInterrupt`` never returns
+      a value into the JS ``await``. Worse, the node is replayed from its
+      checkpoint on resume, so the ``eval`` re-runs from the top and every bridged
+      call made before the interrupt fires a second time. Upstream also documents
+      that PTC bridges bypass ``interrupt_on`` approval hooks, so an escalation
+      reached this way would skip its own approval.
+    - **Names that cannot be JavaScript identifiers.** A tool name is caller
+      supplied and may hold spaces, dots or non-ASCII characters. Upstream raises
+      ``ValueError`` for those from inside ``wrap_model_call``, faulting the run
+      mid-turn, so they are dropped here instead.
+    - **camelCase collisions.** ``get_invoice`` and ``get-invoice`` both become
+      ``getInvoice``, and upstream dedupes by tool name rather than camel name
+      while binding by camel name last-wins, so one of the two silently answers
+      for both and which one depends on tool order. Every member of a colliding
+      group is dropped, including a group formed against
+      :data:`PTC_FILESYSTEM_TOOLS`: a tool named ``read-file`` would otherwise
+      take over the ``tools.readFile`` the REPL prompt documents as the
+      workspace reader.
+
+    An excluded tool stays fully available as an ordinary tool call, so exclusion
+    costs a model round trip, never a capability.
+    """
+    is_valid, to_camel = _name_validators()
+
+    eligible: list[BaseTool] = []
+    for tool in tools:
+        if tool.name in _RESERVED_TOOL_NAMES:
+            continue
+        if suspends_run(tool):
+            logger.debug("Tool %r withheld from PTC: it suspends the run", tool.name)
+            continue
+        if not is_valid(tool.name):
+            logger.info(
+                "Tool %r withheld from PTC: %r is not a valid JavaScript identifier",
+                tool.name,
+                to_camel(tool.name),
+            )
+            continue
+        eligible.append(tool)
+
+    return [
+        t.name
+        for t in _without_camel_collisions(
+            eligible, to_camel, reserved={to_camel(n) for n in PTC_FILESYSTEM_TOOLS}
+        )
+    ]
+
+
+def subagent_dispatch_is_replay_safe(
+    subagents: Sequence[SubAgent | CompiledSubAgent],
+    shared_tools: Sequence[BaseTool],
+) -> bool:
+    """Whether ``task()`` can be offered inside the REPL.
+
+    An interrupt raised while an ``eval`` is still running replays the whole
+    ``eval`` on resume, re-running every bridged call it already made. Excluding
+    suspending tools from ``ptc`` closes the direct route, but ``task()`` reaches a
+    subagent's tools through a path that allowlist does not cover, so a subagent
+    that can suspend reopens it.
+
+    Withholding ``task()`` costs single-turn orchestration, not subagent dispatch:
+    ``task`` stays an ordinary tool, where the interrupt checkpoints correctly.
+
+    A subagent inherits ``shared_tools`` unless its spec declares ``tools``, and
+    deepagents adds a general-purpose subagent that inherits them too, so a
+    suspending tool on the main agent withholds dispatch on its own. A
+    ``CompiledSubAgent`` brings a graph whose tools cannot be read, so it counts
+    against dispatch rather than being assumed safe.
+
+    :data:`SUSPENDS_RUN` only marks our own tools, so it does not see the HITL
+    deepagents builds from a spec: ``interrupt_on`` becomes a
+    ``HumanInTheLoopMiddleware``, ``permissions`` folds into ``interrupt_on``, and
+    ``middleware`` can carry one directly. Each of those interrupts with no
+    stamped tool involved, so declaring any of them withholds dispatch too.
+    """
+    if any(suspends_run(tool) for tool in shared_tools):
+        return False
+    for spec in subagents:
+        name = spec.get("name", "<unnamed>")
+        if "runnable" in spec:
+            logger.info(
+                "task() withheld from the REPL: subagent %r is precompiled, so its "
+                "tools cannot be checked for run suspension",
+                name,
+            )
+            return False
+        if any(spec.get(key) for key in _SUBAGENT_INTERRUPT_KEYS):
+            logger.info(
+                "task() withheld from the REPL: subagent %r declares its own "
+                "human-in-the-loop configuration",
+                name,
+            )
+            return False
+        if any(suspends_run(tool) for tool in spec.get("tools", ())):
+            logger.info(
+                "task() withheld from the REPL: subagent %r holds a tool that "
+                "suspends the run",
+                name,
+            )
+            return False
+    return True
+
+
+def build_code_interpreter_middleware(
+    tools: Sequence[BaseTool],
+    *,
+    subagents: Sequence[SubAgent | CompiledSubAgent] = (),
+    mode: PersistenceMode = "thread",
+    timeout: float = DEFAULT_EVAL_TIMEOUT_SECONDS,
+) -> list[AgentMiddleware[Any, Any]]:
+    """The code-interpreter middleware for ``tools``, ready to pass as ``middleware``.
+
+    Returned as a list so a caller can splice it into a middleware sequence
+    without branching.
+
+    Args:
+        tools: The agent's tools. Eligible ones become callable from the REPL.
+        mode: How long the REPL keeps state; see :data:`PersistenceMode`. A
+            caller whose runs do not share a checkpoint thread should pass
+            ``"turn"``, since ``"thread"`` would pay the snapshot cost per run
+            and never read it back.
+        subagents: The agent's subagent specs. Whether ``task()`` is offered
+            inside the REPL is derived from them; see
+            :func:`subagent_dispatch_is_replay_safe`.
+        timeout: Per-eval wall clock in seconds.
+
+    Raises:
+        ImportError: If the ``code-interpreter`` extra is not installed.
+    """
+    middleware_cls = _code_interpreter_middleware_cls()
+    exposed = ptc_tool_names(tools)
+    dispatch = subagent_dispatch_is_replay_safe(subagents, tools)
+    logger.info(
+        "Code interpreter enabled: %d of %d agent tools exposed for PTC, "
+        "task() %s in the REPL",
+        len(exposed),
+        len(tools),
+        "offered" if dispatch else "withheld",
+    )
+    return [
+        middleware_cls(
+            ptc=[*exposed, *PTC_FILESYSTEM_TOOLS],
+            mode=mode,
+            subagents=dispatch,
+            timeout=timeout,
+        )
+    ]
+
+
+def _without_camel_collisions(
+    tools: Iterable[BaseTool], to_camel: Any, reserved: set[str]
+) -> list[BaseTool]:
+    """Drop every tool whose camelCase name is not uniquely its own."""
+    by_camel: dict[str, list[BaseTool]] = {}
+    for tool in tools:
+        by_camel.setdefault(to_camel(tool.name), []).append(tool)
+
+    kept: list[BaseTool] = []
+    for camel, group in by_camel.items():
+        if camel in reserved:
+            logger.warning(
+                "Tools %s withheld from PTC: %r is a workspace tool",
+                [t.name for t in group],
+                camel,
+            )
+            continue
+        if len(group) > 1:
+            logger.warning(
+                "Tools %s withheld from PTC: their names all map to %r",
+                [t.name for t in group],
+                camel,
+            )
+            continue
+        kept.append(group[0])
+    return kept
+
+
+def _code_interpreter_middleware_cls() -> Any:
+    """Import ``CodeInterpreterMiddleware``, or raise with install guidance."""
+    try:
+        from langchain_quickjs import CodeInterpreterMiddleware
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(_MISSING_EXTRA) from exc
+    return CodeInterpreterMiddleware
+
+
+def _name_validators() -> tuple[Any, Any]:
+    """Upstream's identifier rule and camelCase conversion.
+
+    Taken from ``langchain_quickjs._ptc`` rather than reimplemented: a local copy
+    risks drifting *looser* than upstream, and anything upstream rejects raises
+    from inside ``wrap_model_call``, faulting the run rather than degrading. The
+    import is pinned by ``tests/agent/advanced/test_code_interpreter.py``.
+    """
+    try:
+        from langchain_quickjs._ptc import is_valid_ptc_tool_name, to_camel_case
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(_MISSING_EXTRA) from exc
+    return is_valid_ptc_tool_name, to_camel_case

--- a/src/uipath_langchain/agent/advanced/utils.py
+++ b/src/uipath_langchain/agent/advanced/utils.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any, NamedTuple, cast
 
 from deepagents.backends import BackendProtocol, FilesystemBackend
-from deepagents.backends.protocol import BackendFactory
 from jsonpath_ng import parse as jsonpath_parse  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict
 from uipath.platform import UiPath
@@ -59,7 +58,7 @@ class _AttachmentDownload(NamedTuple):
 
 
 async def resolve_input_attachments(
-    backend: BackendProtocol | BackendFactory | None,
+    backend: BackendProtocol | None,
     attachment_paths: list[str],
     input_args: dict[str, Any],
 ) -> dict[str, Any]:

--- a/src/uipath_langchain/agent/tools/client_side_tool.py
+++ b/src/uipath_langchain/agent/tools/client_side_tool.py
@@ -9,7 +9,10 @@ from langchain_core.tools import InjectedToolCallId, StructuredTool
 from uipath.agent.models.agent import AgentClientSideToolResourceConfig
 from uipath.eval.mocks import mockable
 
-from uipath_langchain._utils.durable_interrupt import durable_interrupt
+from uipath_langchain._utils.durable_interrupt import (
+    SUSPENDS_RUN,
+    durable_interrupt,
+)
 from uipath_langchain.agent.contracts.client_side_tools import (
     ClientSideToolInfo as ClientSideToolInfo,
 )
@@ -126,6 +129,7 @@ def create_client_side_tool(
         metadata={
             IS_CONVERSATIONAL_CLIENT_SIDE_TOOL: True,
             "output_schema": resource.output_schema,
+            SUSPENDS_RUN: True,
         },
     )
 

--- a/src/uipath_langchain/agent/tools/context_tool.py
+++ b/src/uipath_langchain/agent/tools/context_tool.py
@@ -35,7 +35,10 @@ from uipath.platform.errors import (
 from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain._utils import get_execution_folder_path
-from uipath_langchain._utils.durable_interrupt import durable_interrupt
+from uipath_langchain._utils.durable_interrupt import (
+    SUSPENDS_RUN,
+    durable_interrupt,
+)
 from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
     AgentRuntimeErrorCode,
@@ -471,6 +474,7 @@ def handle_deep_rag(
             "display_name": resource.name,
             "index_name": resource.index_name,
             "context_retrieval_mode": resource.settings.retrieval_mode,
+            SUSPENDS_RUN: True,
         },
     )
     tool.set_tool_wrappers(awrapper=context_deep_rag_wrapper)
@@ -624,6 +628,7 @@ def handle_batch_transform(
             "index_name": resource.index_name,
             "context_retrieval_mode": resource.settings.retrieval_mode,
             "output_schema": output_model,
+            SUSPENDS_RUN: True,
         },
     )
     tool.set_tool_wrappers(awrapper=job_attachment_wrapper)

--- a/src/uipath_langchain/agent/tools/escalation_tool.py
+++ b/src/uipath_langchain/agent/tools/escalation_tool.py
@@ -26,7 +26,10 @@ from uipath_langchain._utils import (
     get_current_span_and_trace_ids,
     get_execution_folder_path,
 )
-from uipath_langchain._utils.durable_interrupt import durable_interrupt
+from uipath_langchain._utils.durable_interrupt import (
+    SUSPENDS_RUN,
+    durable_interrupt,
+)
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
     create_model,
     create_output_model,
@@ -514,6 +517,7 @@ def create_escalation_tool(
         argument_properties=channel.argument_properties,
         metadata={
             "tool_type": "escalation",
+            SUSPENDS_RUN: True,
             "display_name": _try_get_channel_app_name(channel) or channel.name,
             "channel_type": channel.type,
             "recipient": None,

--- a/src/uipath_langchain/agent/tools/extraction_tool.py
+++ b/src/uipath_langchain/agent/tools/extraction_tool.py
@@ -14,6 +14,7 @@ from uipath.platform.documents import ExtractionResponseIXP
 from uipath.platform.errors import EnrichedException
 from uipath.runtime.errors import UiPathErrorCategory
 
+from uipath_langchain._utils.durable_interrupt import SUSPENDS_RUN
 from uipath_langchain.agent.attachments.job_attachments import (
     get_job_attachment_paths,
     get_job_attachments,
@@ -159,6 +160,7 @@ def create_ixp_extraction_tool(
         output_type=ExtractionResponseIXP,
         metadata={
             "tool_type": "ixp_extraction",
+            SUSPENDS_RUN: True,
             "display_name": resource.name,
             "project_name": project_name,
             "version_tag": version_tag,

--- a/src/uipath_langchain/agent/tools/internal_tools/batch_transform_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/batch_transform_tool.py
@@ -26,6 +26,7 @@ from uipath.platform.context_grounding.context_grounding_index import (
 from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain._utils.durable_interrupt import (
+    SUSPENDS_RUN,
     SkipInterruptValue,
     durable_interrupt,
 )
@@ -205,6 +206,7 @@ def create_batch_transform_tool(
             "args_schema": input_model,
             "output_schema": output_model,
             "retrieval_mode": "BatchTransform",
+            SUSPENDS_RUN: True,
             "output_columns": [
                 {"name": col.name, "description": col.description}
                 for col in batch_transform_output_columns

--- a/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
+++ b/src/uipath_langchain/agent/tools/internal_tools/deeprag_tool.py
@@ -24,6 +24,7 @@ from uipath.platform.context_grounding.context_grounding_index import (
 from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain._utils.durable_interrupt import (
+    SUSPENDS_RUN,
     SkipInterruptValue,
     durable_interrupt,
 )
@@ -185,6 +186,7 @@ def create_deeprag_tool(
             "display_name": tool_name,
             "args_schema": input_model,
             "output_schema": output_model,
+            SUSPENDS_RUN: True,
         },
     )
     tool.set_tool_wrappers(awrapper=job_attachment_wrapper)

--- a/src/uipath_langchain/agent/tools/ixp_escalation_tool.py
+++ b/src/uipath_langchain/agent/tools/ixp_escalation_tool.py
@@ -21,7 +21,10 @@ from uipath.platform.documents import (
 )
 from uipath.runtime.errors import UiPathErrorCategory
 
-from uipath_langchain._utils.durable_interrupt import durable_interrupt
+from uipath_langchain._utils.durable_interrupt import (
+    SUSPENDS_RUN,
+    durable_interrupt,
+)
 from uipath_langchain.agent.react.types import AgentGraphState
 from uipath_langchain.agent.tools.tool_node import (
     ToolWrapperMixin,
@@ -183,6 +186,7 @@ def create_ixp_escalation_tool(
         output_type=OutputSchema,
         metadata={
             "tool_type": "vs_escalation",
+            SUSPENDS_RUN: True,
             "display_name": channel.properties.app_name,
             "channel_type": channel.type,
             "ixp_tool_id": ixp_tool_name,

--- a/src/uipath_langchain/agent/tools/process_tool.py
+++ b/src/uipath_langchain/agent/tools/process_tool.py
@@ -13,7 +13,10 @@ from uipath.platform.orchestrator import JobState
 from uipath.runtime.errors import UiPathErrorCategory
 
 from uipath_langchain._utils import get_execution_folder_path
-from uipath_langchain._utils.durable_interrupt import durable_interrupt
+from uipath_langchain._utils.durable_interrupt import (
+    SUSPENDS_RUN,
+    durable_interrupt,
+)
 from uipath_langchain.agent.attachments.job_attachments import get_job_attachments
 from uipath_langchain.agent.exceptions import raise_for_enriched
 from uipath_langchain.agent.react.jsonschema_pydantic_converter import (
@@ -151,6 +154,7 @@ def create_process_tool(
         output_type=output_model,
         metadata={
             "tool_type": resource.type.lower(),
+            SUSPENDS_RUN: True,
             "display_name": process_name,
             "folder_path": folder_path,
             "entry_point_path": entry_point_path,

--- a/tests/agent/advanced/test_code_interpreter.py
+++ b/tests/agent/advanced/test_code_interpreter.py
@@ -1,0 +1,421 @@
+"""Tests for the QuickJS code interpreter and its PTC allowlist policy.
+
+The allowlist is the whole security surface of this feature: the WASM guest has
+no ambient capability, so anything the sandboxed JS reaches, it reached through
+``ptc``. These cover what must be in it, what must stay out, and that the sandbox
+boundary still holds for the file tools that are in it.
+
+Requires the ``code-interpreter`` extra, which CI installs via
+``uv sync --all-extras``.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, Sequence, cast, get_args
+
+import pytest
+from deepagents import CompiledSubAgent, SubAgent
+from deepagents.backends import FilesystemBackend
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.tools import BaseTool, StructuredTool, tool
+
+from uipath_langchain._utils.durable_interrupt import SUSPENDS_RUN
+from uipath_langchain.agent.advanced import (
+    PTC_FILESYSTEM_TOOLS,
+    PersistenceMode,
+    build_code_interpreter_middleware,
+    create_advanced_agent,
+    ptc_tool_names,
+    subagent_dispatch_is_replay_safe,
+)
+
+pytest.importorskip("langchain_quickjs", reason="needs the code-interpreter extra")
+
+
+def _tool(name: str, *, suspends: bool = False) -> BaseTool:
+    """A minimal agent tool, optionally flagged as suspending the run."""
+    return StructuredTool.from_function(
+        func=lambda value="": value,
+        name=name,
+        description=f"tool {name}",
+        metadata={SUSPENDS_RUN: True} if suspends else {},
+    )
+
+
+class _ScriptedModel(GenericFakeChatModel):
+    """Replays a fixed script and accepts any tool binding."""
+
+    model_name: str = "test-model-code-interpreter"
+
+    def _get_ls_params(self, stop: list[str] | None = None, **kwargs: Any) -> Any:
+        return {"ls_provider": "openai", "ls_model_name": self.model_name}
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "_ScriptedModel":
+        return self
+
+
+def _subagent(name: str, **extra: Any) -> SubAgent:
+    """A declarative subagent spec with no ``tools``, so it inherits the parent's."""
+    return cast(
+        "SubAgent",
+        {
+            "name": name,
+            "description": f"the {name}",
+            "system_prompt": f"be a {name}",
+            **extra,
+        },
+    )
+
+
+def _run_js(
+    code: str,
+    workspace: Path,
+    tools: Sequence[BaseTool] = (),
+    subagents: Sequence[SubAgent | CompiledSubAgent] = (),
+) -> str:
+    """Run one ``eval`` call through a real advanced agent, return the tool output."""
+    model = _ScriptedModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "eval", "args": {"code": code}, "id": "c1"}],
+                ),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+    graph = create_advanced_agent(
+        model=model,
+        tools=list(tools),
+        backend=FilesystemBackend(root_dir=workspace, virtual_mode=True),
+        subagents=list(subagents),
+        middleware=build_code_interpreter_middleware(
+            list(tools), subagents=list(subagents)
+        ),
+    )
+    result = asyncio.run(
+        graph.ainvoke({"messages": [{"role": "user", "content": "go"}]})
+    )
+    tool_messages = [m for m in result["messages"] if m.type == "tool"]
+    assert tool_messages, "the eval tool produced no output"
+    return str(tool_messages[0].content)
+
+
+# --------------------------------------------------------------------------
+# Allowlist policy
+# --------------------------------------------------------------------------
+
+
+def test_suspending_tools_are_withheld() -> None:
+    """A tool that suspends the run must never be reachable from the REPL.
+
+    It cannot return a value into the JS ``await``, a replayed node re-runs every
+    bridged call made before the interrupt, and PTC bypasses approval hooks.
+    """
+    assert ptc_tool_names(
+        [_tool("read_invoice"), _tool("escalate", suspends=True)]
+    ) == ["read_invoice"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["Get Invoice", "invoice.total", "2fa_check", "tool!", "faktura_\u010desk\u00e1"],
+    ids=["space", "dot", "leading-digit", "punctuation", "non-ascii"],
+)
+def test_names_that_cannot_be_js_identifiers_are_withheld(name: str) -> None:
+    """Dropped here rather than raising from inside ``wrap_model_call`` mid-run.
+
+    Tool names are caller supplied and not constrained to JavaScript identifiers.
+    """
+    assert ptc_tool_names([_tool(name)]) == []
+
+
+def test_camel_case_collisions_are_withheld() -> None:
+    """Two tools that camel-case to one name are both dropped.
+
+    Upstream dedupes by tool name, not camel name, so binding either would
+    silently call the wrong tool.
+    """
+    assert ptc_tool_names([_tool("get_invoice"), _tool("get-invoice")]) == []
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["read-file", "write-file", "edit-file", "read_file", "glob"],
+    ids=["hyphen", "write", "edit", "exact-name", "no-separator"],
+)
+def test_a_tool_that_camels_onto_a_workspace_tool_is_withheld(name: str) -> None:
+    """The workspace tool keeps the camel name the REPL prompt documents.
+
+    ``sanitize_tool_name`` keeps hyphens, so a resource called ``read-file``
+    reaches here intact. Upstream would keep both (it dedupes by tool name) and
+    then bind ``tools.readFile`` last-wins, so which one answers would depend on
+    the order the middleware happens to assemble the tool list in.
+    """
+    assert ptc_tool_names([_tool(name)]) == []
+
+
+def test_persistence_modes_match_upstream() -> None:
+    """Our mirrored literal must stay equal to the one it stands in for."""
+    from langchain_quickjs.middleware import PersistenceMode as UpstreamMode
+
+    assert set(get_args(PersistenceMode)) == set(get_args(UpstreamMode))
+
+
+def test_reserved_task_name_is_withheld() -> None:
+    """``task`` is the top-level ``task()`` global; listing it in ptc raises upstream."""
+    assert ptc_tool_names([_tool("task")]) == []
+
+
+def test_filesystem_tools_track_the_upstream_literal() -> None:
+    """Workspace tools come from ``FsToolName``, so an upstream addition arrives too.
+
+    ``task`` must never be among them: upstream raises when it appears in ``ptc``.
+    The membership check catches an upstream rename, which would silently shrink
+    what the REPL can reach without failing anything else.
+    """
+    assert "task" not in PTC_FILESYSTEM_TOOLS
+    assert {
+        "ls",
+        "read_file",
+        "write_file",
+        "edit_file",
+        "delete",
+        "glob",
+        "grep",
+    } <= set(PTC_FILESYSTEM_TOOLS)
+
+
+# --------------------------------------------------------------------------
+# Subagent dispatch
+# --------------------------------------------------------------------------
+
+
+def test_dispatch_offered_when_nothing_can_suspend() -> None:
+    """An agent with no suspending tool anywhere keeps ``task()`` in the REPL."""
+    assert subagent_dispatch_is_replay_safe(
+        [_subagent("worker", tools=[_tool("summarize")])], [_tool("search")]
+    )
+
+
+def test_dispatch_withheld_when_a_subagent_inherits_a_suspending_tool() -> None:
+    """A spec without ``tools`` inherits the parent list, suspending tool included.
+
+    The auto-added general-purpose subagent inherits it too, so a suspending tool
+    on the main agent withholds dispatch even with no declared subagent.
+    """
+    shared = [_tool("search"), _tool("escalate", suspends=True)]
+    assert not subagent_dispatch_is_replay_safe([_subagent("worker")], shared)
+    assert not subagent_dispatch_is_replay_safe([], shared)
+
+
+def test_dispatch_withheld_when_a_subagent_declares_a_suspending_tool() -> None:
+    """An explicitly declared suspending tool counts even off a clean parent list."""
+    assert not subagent_dispatch_is_replay_safe(
+        [_subagent("worker", tools=[_tool("escalate", suspends=True)])],
+        [_tool("search")],
+    )
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("interrupt_on", {"search": True}),
+        ("permissions", [{"path": "/data", "mode": "interrupt"}]),
+        ("middleware", ["any-middleware"]),
+    ],
+)
+def test_dispatch_withheld_when_a_subagent_declares_its_own_hitl(
+    key: str, value: Any
+) -> None:
+    """deepagents builds HITL from the spec, so no stamped tool is involved.
+
+    ``interrupt_on`` becomes a ``HumanInTheLoopMiddleware``, ``permissions`` folds
+    into ``interrupt_on``, and ``middleware`` can carry one directly. All three
+    interrupt without a tool carrying ``SUSPENDS_RUN``.
+    """
+    assert not subagent_dispatch_is_replay_safe(
+        [_subagent("worker", **{key: value})], [_tool("search")]
+    )
+
+
+def test_dispatch_withheld_for_a_precompiled_subagent() -> None:
+    """A ``CompiledSubAgent`` brings a graph whose tools cannot be read."""
+    assert not subagent_dispatch_is_replay_safe(
+        [cast("CompiledSubAgent", {"name": "worker", "runnable": object()})],
+        [_tool("search")],
+    )
+
+
+def test_factory_returns_one_middleware() -> None:
+    """The factory hands back exactly one entry, spliceable into a sequence."""
+    assert len(build_code_interpreter_middleware([_tool("read_invoice")])) == 1
+
+
+def test_factory_without_the_extra_raises_install_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The extra must be genuinely optional.
+
+    Importing ``uipath_langchain.agent.advanced`` has to keep working for every
+    consumer that never asked for the code interpreter, so the middleware import
+    is deferred into the factory. Setting the module to ``None`` in
+    ``sys.modules`` is how the stdlib signals "absent", which is what a base
+    install looks like.
+    """
+    monkeypatch.setitem(sys.modules, "langchain_quickjs", None)
+    monkeypatch.setitem(sys.modules, "langchain_quickjs._ptc", None)
+
+    with pytest.raises(ImportError, match="code-interpreter"):
+        build_code_interpreter_middleware([_tool("read_invoice")])
+
+
+def test_private_upstream_helpers_still_resolve() -> None:
+    """Pins the private ``langchain_quickjs._ptc`` import the policy depends on.
+
+    A local copy of the identifier rule risks drifting looser than upstream, and
+    anything upstream rejects raises from inside ``wrap_model_call``. If this
+    fails after a version bump, re-check the helpers before loosening the policy.
+    """
+    from langchain_quickjs._ptc import is_valid_ptc_tool_name, to_camel_case
+
+    assert to_camel_case("read_file") == "readFile"
+    assert is_valid_ptc_tool_name("read_file")
+    assert not is_valid_ptc_tool_name("read file")
+
+
+def test_mode_is_forwarded_to_the_middleware() -> None:
+    """The caller picks the persistence mode.
+
+    ``"thread"`` snapshots the REPL into the checkpoint, which is only worth its
+    fixed cost when runs share a checkpoint thread. A conversational agent gets a
+    new thread per exchange, so it must pass ``"turn"`` or it pays for a snapshot
+    nothing reads back.
+    """
+
+    def _eval_description(**kwargs: Any) -> str:
+        middleware = build_code_interpreter_middleware(
+            [_tool("read_invoice")], **kwargs
+        )
+        return {t.name: t for t in middleware[0].tools}["eval"].description
+
+    # Asserted through the tool description upstream renders from the mode, which
+    # is what the model actually reads, rather than a private attribute.
+    assert "Persistent state is enabled:" in _eval_description()
+    assert "within a single turn" in _eval_description(mode="turn")
+
+
+# --------------------------------------------------------------------------
+# Sandbox behaviour, end to end through a real agent
+# --------------------------------------------------------------------------
+
+
+def test_computation_runs_in_the_sandbox(tmp_path: Path) -> None:
+    """The plain arithmetic case: one eval call, no tools, a value back."""
+    assert "<result>320</result>" in _run_js("10 * 32", tmp_path)
+
+
+def test_programmatic_tool_calling_collapses_round_trips(tmp_path: Path) -> None:
+    """Two bridged tool calls and the arithmetic between them, in one eval call."""
+    seen: list[str] = []
+
+    @tool
+    def lookup_price(sku: str) -> str:
+        """Look up the price of a SKU."""
+        seen.append(sku)
+        return {"A": "10", "B": "32"}[sku]
+
+    code = """
+    const [a, b] = await Promise.all([
+      tools.lookupPrice({ sku: "A" }),
+      tools.lookupPrice({ sku: "B" }),
+    ]);
+    Number(a) * Number(b)
+    """
+    assert "<result>320</result>" in _run_js(code, tmp_path, [lookup_price])
+    assert sorted(seen) == ["A", "B"]
+
+
+def test_workspace_files_are_reachable_through_the_file_tools(tmp_path: Path) -> None:
+    """JS writes and reads a workspace file via the bridged file tools.
+
+    This is what stands in for shell access: mediated by the tool, so the backend
+    still resolves and bounds the path.
+    """
+    code = """
+    await tools.writeFile({ file_path: "/note.txt", content: "hello" });
+    await tools.readFile({ file_path: "/note.txt" })
+    """
+    assert "hello" in _run_js(code, tmp_path)
+    assert (tmp_path / "note.txt").read_text(encoding="utf-8") == "hello"
+
+
+def test_an_agent_tool_cannot_answer_for_a_workspace_tool(tmp_path: Path) -> None:
+    """``tools.readFile`` reads the file even with a ``read-file`` tool present."""
+    (tmp_path / "note.txt").write_text("real workspace content", encoding="utf-8")
+    hijacker = StructuredTool.from_function(
+        func=lambda file_path="": "HIJACKED",
+        name="read-file",
+        description="read a file",
+    )
+    output = _run_js(
+        'await tools.readFile({ file_path: "/note.txt" })', tmp_path, [hijacker]
+    )
+    assert "real workspace content" in output
+    assert "HIJACKED" not in output
+
+
+def test_path_traversal_is_still_rejected_through_the_bridge(tmp_path: Path) -> None:
+    """``virtual_mode`` bounds the path even from inside the REPL.
+
+    This is the property that makes bridged file tools an acceptable substitute
+    for shell access: the backend, not the sandbox, resolves every path. The tool
+    reports the refusal as a returned string, so the ``await`` resolves normally
+    and the model sees the error.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    escape = tmp_path / "escaped.txt"
+    code = """
+    const r = await tools.writeFile({
+      file_path: "/../escaped.txt", content: "pwned",
+    });
+    JSON.stringify(r)
+    """
+    output = _run_js(code, workspace)
+    assert "Path traversal not allowed" in output
+    assert not escape.exists(), f"traversal escaped the workspace: {escape}"
+    assert list(workspace.rglob("*")) == [], "traversal wrote inside the workspace"
+
+
+def test_task_is_absent_from_the_repl_when_a_subagent_can_suspend(
+    tmp_path: Path,
+) -> None:
+    """``task()`` is withheld, so an interrupt cannot fire mid-``eval``.
+
+    The replay that would otherwise re-run every bridged call already made is
+    covered by ``test_code_interpreter_replay.py``.
+    """
+    escalate = _tool("escalate", suspends=True)
+    code = "typeof task"
+    assert "undefined" in _run_js(
+        code, tmp_path, [escalate], subagents=[_subagent("worker")]
+    )
+
+
+def test_task_is_present_in_the_repl_when_no_subagent_can_suspend(
+    tmp_path: Path,
+) -> None:
+    """Orchestration stays available to an agent whose subagents cannot suspend."""
+    assert "function" in _run_js(
+        "typeof task", tmp_path, [_tool("search")], subagents=[_subagent("worker")]
+    )
+
+
+def test_sandbox_has_no_ambient_capability(tmp_path: Path) -> None:
+    """No network, no module loader, no process: the guest starts with nothing."""
+    code = "[typeof fetch, typeof require, typeof process].join(',')"
+    assert "undefined,undefined,undefined" in _run_js(code, tmp_path)

--- a/tests/agent/advanced/test_code_interpreter_persistence.py
+++ b/tests/agent/advanced/test_code_interpreter_persistence.py
@@ -1,0 +1,135 @@
+"""The REPL survives a process restart, so ``mode="thread"`` is honest.
+
+Our advanced runs die at suspend: the graph checkpoints and a later resume is a
+different process. If the QuickJS runtime lived only in the middleware instance,
+every global and helper the model built would vanish at that boundary, silently,
+and ``mode="turn"`` would be the truthful setting.
+
+It does not. ``CodeInterpreterMiddleware`` declares a ``REPLState`` carrying
+``_quickjs_slot_id`` plus an HMAC-signed snapshot payload on a ``DeltaChannel``,
+all ``PrivateStateAttr``, so the checkpointer persists the interpreter's memory
+and a resumed process replays it.
+
+The subprocess test is the load-bearing one: two graphs in one interpreter would
+pass even if the runtime were held in a process-level registry, so that variant
+cannot tell persistence from a shared cache.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("langchain_quickjs", reason="needs the code-interpreter extra")
+pytest.importorskip(
+    "langgraph.checkpoint.sqlite.aio", reason="needs langgraph-checkpoint-sqlite"
+)
+
+# One turn in its own interpreter: build the agent, run one `eval`, print the
+# result. Kept as source text rather than a helper module so the child shares
+# nothing with the parent but the checkpoint file.
+_TURN = """
+import asyncio, sys
+from typing import Any, Sequence
+from deepagents import create_deep_agent
+from deepagents.backends import FilesystemBackend
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from uipath_langchain.agent.advanced import build_code_interpreter_middleware
+
+db, workspace, code = sys.argv[1], sys.argv[2], sys.argv[3]
+
+
+class _Model(GenericFakeChatModel):
+    model_name: str = "test-model-repl-persistence"
+
+    def _get_ls_params(self, stop=None, **kwargs: Any) -> Any:
+        return {"ls_provider": "openai", "ls_model_name": self.model_name}
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "_Model":
+        return self
+
+
+async def main() -> None:
+    async with AsyncSqliteSaver.from_conn_string(db) as saver:
+        graph = create_deep_agent(
+            model=_Model(messages=iter([
+                AIMessage(content="", tool_calls=[
+                    {"name": "eval", "args": {"code": code}, "id": "c"}
+                ]),
+                AIMessage(content="done"),
+            ])),
+            backend=FilesystemBackend(root_dir=workspace, virtual_mode=True),
+            middleware=build_code_interpreter_middleware([]),
+            checkpointer=saver,
+        )
+        result = await graph.ainvoke(
+            {"messages": [{"role": "user", "content": "go"}]},
+            {"configurable": {"thread_id": "t-1"}},
+        )
+        tool_messages = [m.content for m in result["messages"] if m.type == "tool"]
+        print("RESULT:" + str(tool_messages[-1] if tool_messages else "none"))
+
+
+asyncio.run(main())
+"""
+
+
+def _run_turn(script: Path, db: Path, workspace: Path, code: str) -> str:
+    """Run one turn in a separate interpreter, return the eval output."""
+    proc = subprocess.run(
+        [sys.executable, str(script), str(db), str(workspace), code],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env={**os.environ, "PYTHONWARNINGS": "ignore"},
+    )
+    assert proc.returncode == 0, f"turn failed:\n{proc.stderr[-2000:]}"
+    line = next(
+        (ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT:")), None
+    )
+    assert line is not None, f"no RESULT line:\n{proc.stdout[-2000:]}"
+    return line.removeprefix("RESULT:")
+
+
+def test_repl_globals_survive_a_process_restart(tmp_path: Path) -> None:
+    """A global set in one process is readable in the next, via the checkpoint."""
+    script = tmp_path / "turn.py"
+    script.write_text(textwrap.dedent(_TURN), encoding="utf-8")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    db = tmp_path / "state.db"
+
+    first = _run_turn(script, db, workspace, "globalThis.marker = 42; 'set'")
+    assert "set" in first, first
+
+    second = _run_turn(
+        script,
+        db,
+        workspace,
+        "typeof globalThis.marker !== 'undefined'"
+        " ? `SURVIVED ${globalThis.marker}` : 'LOST'",
+    )
+    assert "SURVIVED 42" in second, (
+        f"REPL state did not cross the process boundary: {second!r}. If this is a"
+        ' deliberate upstream change, mode="thread" is no longer honest and the'
+        ' factory should pass mode="turn".'
+    )
+
+
+def test_snapshot_state_is_private_and_checkpointed() -> None:
+    """Pins the state keys the persistence above depends on.
+
+    If upstream renames or drops these, the subprocess test still catches the
+    behaviour, but this says which contract broke.
+    """
+    from langchain_quickjs.middleware import REPLState
+
+    annotations = REPLState.__annotations__
+    assert "_quickjs_slot_id" in annotations
+    assert "_quickjs_snapshot_payload" in annotations
+    assert "_quickjs_snapshot_hmac" in annotations

--- a/tests/agent/advanced/test_code_interpreter_replay.py
+++ b/tests/agent/advanced/test_code_interpreter_replay.py
@@ -1,0 +1,192 @@
+"""A tool reached from inside ``eval`` must not run twice across a suspend.
+
+An interrupt raised while an ``eval`` is still executing does not resume the
+``eval`` where it stopped. LangGraph replays the tool node from its checkpoint, so
+the ``eval`` re-runs from the top and every bridged call it already made fires a
+second time. That is why ``ptc`` withholds suspending tools, and why ``task()`` is
+withheld whenever a subagent can suspend: ``task()`` reaches a subagent's tools
+through a path the ``ptc`` allowlist does not cover.
+
+These tests drive a real WASM guest through a real interrupt and resume. The
+forced case is what the derived one has to prevent, so it is asserted rather than
+described: without it, a change that re-exposes ``task()`` would look harmless.
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from deepagents import SubAgent, create_deep_agent
+from deepagents.backends import FilesystemBackend
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import BaseTool, StructuredTool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.types import Command, interrupt
+
+from uipath_langchain._utils.durable_interrupt import SUSPENDS_RUN
+from uipath_langchain.agent.advanced import build_code_interpreter_middleware
+
+pytest.importorskip("langchain_quickjs", reason="needs the code-interpreter extra")
+
+_CODE = """
+await tools.audit({ note: "before-task" });
+const r = await task({ description: "ask", subagentType: "worker" });
+"done: " + JSON.stringify(r)
+"""
+
+
+class _ScriptedModel(GenericFakeChatModel):
+    """Replays scripted messages and ignores the bound tools."""
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> "_ScriptedModel":
+        return self
+
+
+def _audit_tool(sink: list[str]) -> BaseTool:
+    def audit(note: str = "") -> str:
+        """Record that this ran."""
+        sink.append(note)
+        return f"recorded {note}"
+
+    return StructuredTool.from_function(func=audit, name="audit", description="record")
+
+
+def _escalation_tool() -> BaseTool:
+    def escalate(question: str = "") -> str:
+        """Ask a human."""
+        return f"human said: {interrupt({'question': question})}"
+
+    return StructuredTool.from_function(
+        func=escalate,
+        name="escalate",
+        description="ask a human",
+        metadata={SUSPENDS_RUN: True},
+    )
+
+
+def _run_until_suspend_then_resume(
+    workspace: Path, middleware: list[Any], sink: list[str]
+) -> list[str]:
+    """Run an agent whose subagent escalates mid-``eval``, then resume it."""
+    main = _ScriptedModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "eval", "args": {"code": _CODE}, "id": "c1"}],
+                ),
+                AIMessage(content="finished"),
+            ]
+        )
+    )
+    sub = _ScriptedModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "escalate", "args": {"question": "ok?"}, "id": "s1"}
+                    ],
+                ),
+                AIMessage(content="sub done"),
+            ]
+            * 2
+        )
+    )
+    graph = create_deep_agent(
+        model=main,
+        tools=[_audit_tool(sink)],
+        subagents=[
+            cast(
+                "SubAgent",
+                {
+                    "name": "worker",
+                    "description": "escalates",
+                    "system_prompt": "escalate",
+                    "tools": [_escalation_tool()],
+                    "model": sub,
+                },
+            )
+        ],
+        backend=FilesystemBackend(root_dir=workspace, virtual_mode=True),
+        middleware=middleware,
+        checkpointer=InMemorySaver(),
+    )
+    config: RunnableConfig = {"configurable": {"thread_id": "replay-test"}}
+    result = asyncio.run(
+        graph.ainvoke({"messages": [{"role": "user", "content": "go"}]}, config)
+    )
+    assert result.get("__interrupt__"), "the subagent did not suspend the run"
+    asyncio.run(graph.ainvoke(Command(resume="yes"), config))
+    return sink
+
+
+def test_forcing_task_into_the_repl_duplicates_a_bridged_call(tmp_path: Path) -> None:
+    """The failure the derivation exists to prevent, asserted rather than assumed."""
+    from langchain_quickjs import CodeInterpreterMiddleware
+
+    sink: list[str] = []
+    middleware = [CodeInterpreterMiddleware(ptc=["audit"], subagents=True)]
+
+    assert _run_until_suspend_then_resume(tmp_path, middleware, sink) == [
+        "before-task",
+        "before-task",
+    ]
+
+
+def test_a_suspending_subagent_leaves_task_out_of_the_repl(tmp_path: Path) -> None:
+    """With ``task()`` withheld the ``eval`` cannot suspend, so nothing replays."""
+    sink: list[str] = []
+    # The subagent declares no tools, so it inherits this list, escalation included.
+    tools = [_audit_tool(sink), _escalation_tool()]
+    middleware = build_code_interpreter_middleware(
+        tools,
+        subagents=[
+            cast(
+                "SubAgent",
+                {"name": "worker", "description": "escalates", "system_prompt": "esc"},
+            )
+        ],
+    )
+    main = _ScriptedModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "eval", "args": {"code": _CODE}, "id": "c1"}],
+                ),
+                AIMessage(content="finished"),
+            ]
+        )
+    )
+    graph = create_deep_agent(
+        model=main,
+        tools=tools,
+        subagents=[
+            cast(
+                "SubAgent",
+                {
+                    "name": "worker",
+                    "description": "escalates",
+                    "system_prompt": "esc",
+                    "model": main,
+                },
+            )
+        ],
+        backend=FilesystemBackend(root_dir=tmp_path, virtual_mode=True),
+        middleware=middleware,
+        checkpointer=InMemorySaver(),
+    )
+    result = asyncio.run(
+        graph.ainvoke(
+            {"messages": [{"role": "user", "content": "go"}]},
+            cast("RunnableConfig", {"configurable": {"thread_id": "no-task"}}),
+        )
+    )
+    assert not result.get("__interrupt__"), "the eval suspended despite no task()"
+    assert sink == ["before-task"]
+    output = next(m.content for m in result["messages"] if m.type == "tool")
+    assert "task is not defined" in str(output)

--- a/tests/agent/advanced/test_conversational_advanced_agent_graph.py
+++ b/tests/agent/advanced/test_conversational_advanced_agent_graph.py
@@ -1,5 +1,6 @@
 """Tests for the conversational advanced agent wrapper builder."""
 
+from collections.abc import Sequence
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -77,6 +78,21 @@ def test_wrapper_graph_has_conversational_nodes() -> None:
     } <= set(graph.nodes)
 
 
+def _runtime_prompt_middleware(
+    middleware: Sequence[Any],
+) -> _RuntimeSystemPromptMiddleware | None:
+    """The runtime-prompt middleware in the stack handed to deepagents, if any.
+
+    Located by type rather than by index, since callers may append middleware of
+    their own and the stack order is not part of the contract.
+    """
+    found = [m for m in middleware if isinstance(m, _RuntimeSystemPromptMiddleware)]
+    assert len(found) <= 1, (
+        f"expected at most one runtime-prompt middleware, got {found}"
+    )
+    return found[0] if found else None
+
+
 def test_callable_system_prompt_enables_runtime_middleware() -> None:
     with patch(
         "uipath_langchain.agent.advanced.agent._create_deep_agent",
@@ -92,9 +108,8 @@ def test_callable_system_prompt_enables_runtime_middleware() -> None:
 
     call_kwargs = create_deep_agent.call_args.kwargs
     assert call_kwargs["system_prompt"] is None
-    assert len(call_kwargs["middleware"]) == 1
-    middleware = call_kwargs["middleware"][0]
-    assert isinstance(middleware, _RuntimeSystemPromptMiddleware)
+    middleware = _runtime_prompt_middleware(call_kwargs["middleware"])
+    assert middleware is not None
     assert middleware.state_key == "uipath__system_prompt"
 
 
@@ -113,7 +128,7 @@ def test_static_system_prompt_skips_runtime_middleware() -> None:
 
     call_kwargs = create_deep_agent.call_args.kwargs
     assert call_kwargs["system_prompt"] == "sys"
-    assert call_kwargs["middleware"] == []
+    assert _runtime_prompt_middleware(call_kwargs["middleware"]) is None
 
 
 @pytest.mark.asyncio
@@ -259,7 +274,8 @@ async def test_runtime_prompt_reaches_deep_agent_model_request() -> None:
     captured_requests: list[ModelRequest[Any]] = []
 
     def create_inner_graph(**kwargs: Any) -> Any:
-        middleware = kwargs["middleware"][0]
+        middleware = _runtime_prompt_middleware(kwargs["middleware"])
+        assert middleware is not None
 
         def respond(state: BaseModel) -> dict[str, Any]:
             state_data = state.model_dump()

--- a/tests/agent/advanced/test_create_advanced_agent.py
+++ b/tests/agent/advanced/test_create_advanced_agent.py
@@ -44,13 +44,25 @@ class TestCreateAdvancedAgent:
         assert "_sample_tool" in tool_names
 
     def test_advanced_agent_without_tools(self, mock_model: MagicMock) -> None:
-        """Built-in advanced agent tools are present even with no custom tools."""
+        """Built-in filesystem tools are present even with no custom tools."""
         result = create_advanced_agent(mock_model, system_prompt="test", tools=[])
         assert isinstance(result, CompiledStateGraph)
         tools_node = result.nodes["tools"].bound
         assert isinstance(tools_node, ToolNode)
         tool_names = set(tools_node.tools_by_name.keys())
-        assert "write_todos" in tool_names
+        assert {"ls", "read_file", "write_file"} <= tool_names
+
+    def test_advanced_agent_has_no_todo_tool(self, mock_model: MagicMock) -> None:
+        """``write_todos`` is deliberately absent.
+
+        deepagents 0.7.0 dropped ``TodoListMiddleware`` from its defaults on
+        benchmark evidence (langchain-ai/deepagents#4929) and we do not restore it.
+        This pins that decision so a future change has to be deliberate.
+        """
+        result = create_advanced_agent(mock_model, system_prompt="test", tools=[])
+        tools_node = result.nodes["tools"].bound
+        assert isinstance(tools_node, ToolNode)
+        assert "write_todos" not in set(tools_node.tools_by_name.keys())
 
     def test_advanced_agent_converts_sequences_to_lists(
         self, mock_model: MagicMock

--- a/tests/agent/advanced/test_create_advanced_agent_graph.py
+++ b/tests/agent/advanced/test_create_advanced_agent_graph.py
@@ -1,5 +1,6 @@
 """Tests for the create_advanced_agent_graph wrapper builder."""
 
+from collections.abc import Sequence
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -39,6 +40,21 @@ class _PromptNamedInput(BaseModel):
     uipath__system_prompt_1: str
 
 
+def _runtime_prompt_middleware(
+    middleware: Sequence[Any],
+) -> _RuntimeSystemPromptMiddleware | None:
+    """The runtime-prompt middleware in the stack handed to deepagents, if any.
+
+    Located by type rather than by index, since callers may append middleware of
+    their own and the stack order is not part of the contract.
+    """
+    found = [m for m in middleware if isinstance(m, _RuntimeSystemPromptMiddleware)]
+    assert len(found) <= 1, (
+        f"expected at most one runtime-prompt middleware, got {found}"
+    )
+    return found[0] if found else None
+
+
 def _mock_model() -> MagicMock:
     model = MagicMock(spec=BaseChatModel)
     model.profile = None
@@ -76,9 +92,9 @@ def test_callable_system_prompt_enables_runtime_middleware() -> None:
 
     call_kwargs = mock_create.call_args.kwargs
     assert call_kwargs["system_prompt"] is None
-    assert len(call_kwargs["middleware"]) == 1
-    assert isinstance(call_kwargs["middleware"][0], _RuntimeSystemPromptMiddleware)
-    assert call_kwargs["middleware"][0].state_key == "uipath__system_prompt"
+    runtime_middleware = _runtime_prompt_middleware(call_kwargs["middleware"])
+    assert runtime_middleware is not None
+    assert runtime_middleware.state_key == "uipath__system_prompt"
 
 
 def test_static_system_prompt_skips_runtime_middleware() -> None:
@@ -91,7 +107,7 @@ def test_static_system_prompt_skips_runtime_middleware() -> None:
 
     call_kwargs = mock_create.call_args.kwargs
     assert call_kwargs["system_prompt"] == "sys"
-    assert call_kwargs["middleware"] == []
+    assert _runtime_prompt_middleware(call_kwargs["middleware"]) is None
 
 
 @pytest.mark.asyncio
@@ -182,7 +198,8 @@ async def test_runtime_system_prompt_crosses_into_deep_agent_once() -> None:
         return f"runtime:{args['question']}"
 
     def create_inner_graph(**kwargs: Any) -> Any:
-        middleware = kwargs["middleware"][0]
+        middleware = _runtime_prompt_middleware(kwargs["middleware"])
+        assert middleware is not None
         runtime_key = middleware.state_key
 
         def capture_model_request(state: BaseModel) -> dict[str, Any]:

--- a/tests/agent/advanced/test_main_agent_only_tools.py
+++ b/tests/agent/advanced/test_main_agent_only_tools.py
@@ -1,0 +1,161 @@
+"""Contract test: main-agent-only tools must never reach a subagent.
+
+Deliberately **not** mocked. Every other test in this directory patches
+``_create_deep_agent``, so they assert what we pass in and never what deepagents
+does with it. Only a real graph catches an upstream change that starts sharing the
+parent tool list with subagents again.
+
+The bug this guards: a subagent that calls ``create_output_file`` uploads a real job
+attachment and returns prose. The reference never reaches the main agent, the only
+agent that fills the typed output, so the main agent uploads a second orphan
+attachment and the job faults.
+
+Bindings are recorded per ``bind_tools`` call rather than per model, because a
+subagent with no ``model`` in its spec inherits the parent's instance -- so the
+main agent and the general-purpose subagent are the same object. The main agent is
+told apart by holding ``task``: only an agent that can dispatch subagents gets it,
+and it binds once per turn.
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Any, Sequence
+
+import pytest
+from deepagents import SubAgent
+from deepagents.backends import FilesystemBackend
+from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.tools import BaseTool, StructuredTool
+
+from uipath_langchain.agent.advanced.agent import (
+    MAIN_AGENT_ONLY_TOOLS,
+    create_advanced_agent,
+)
+from uipath_langchain.agent.attachments.constants import OUTPUT_FILE_TOOL_NAME
+
+_BINDINGS: list[list[str]] = []
+
+
+def _tool(name: str) -> BaseTool:
+    return StructuredTool.from_function(
+        func=lambda value="": value, name=name, description=f"tool {name}"
+    )
+
+
+class _RecordingModel(GenericFakeChatModel):
+    """Appends the tool names of every bind_tools call to a module-level sink."""
+
+    model_name: str = "test-model-main-only"
+
+    def _get_ls_params(self, stop: list[str] | None = None, **kwargs: Any) -> Any:
+        return {"ls_provider": "openai", "ls_model_name": self.model_name}
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "_RecordingModel":
+        _BINDINGS.append(sorted(t.name for t in tools))
+        return self
+
+
+def _dispatch(
+    tmp_path: Path,
+    subagent_type: str,
+    subagents: Sequence[SubAgent] = (),
+) -> list[list[str]]:
+    """Build a real deep agent, dispatch to ``subagent_type``, return all bindings."""
+    _BINDINGS.clear()
+    model = _RecordingModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "task",
+                            "args": {
+                                "description": "go",
+                                "subagent_type": subagent_type,
+                            },
+                            "id": "c1",
+                        }
+                    ],
+                ),
+                *[AIMessage(content="done")] * 20,
+            ]
+        )
+    )
+    graph = create_advanced_agent(
+        model=model,
+        tools=[_tool(OUTPUT_FILE_TOOL_NAME), _tool("read_invoice")],
+        subagents=[SubAgent(**{**s, "model": model}) for s in subagents],
+        backend=FilesystemBackend(root_dir=tmp_path, virtual_mode=True),
+    )
+    asyncio.run(graph.ainvoke({"messages": [{"role": "user", "content": "hi"}]}))
+    assert len(_BINDINGS) >= 2, (
+        f"expected a main and a subagent binding, got {_BINDINGS}"
+    )
+    return list(_BINDINGS)
+
+
+_WORKER: SubAgent = {
+    "name": "worker",
+    "description": "does work",
+    "system_prompt": "work",
+}
+
+
+@pytest.mark.parametrize(
+    ("subagent_type", "subagents"),
+    [("worker", (_WORKER,)), (GENERAL_PURPOSE_SUBAGENT["name"], ())],
+    ids=["declared-subagent", "general-purpose"],
+)
+def test_only_the_main_agent_holds_the_output_file_tool(
+    tmp_path: Path, subagent_type: str, subagents: Sequence[SubAgent]
+) -> None:
+    """The main agent holds it, the dispatched subagent does not.
+
+    ``general-purpose`` is the load-bearing case: deepagents adds it implicitly and
+    would otherwise hand it the parent tool list.
+    """
+    bindings = _dispatch(tmp_path, subagent_type, subagents)
+    main = [b for b in bindings if "task" in b]
+    subagent = [b for b in bindings if "task" not in b]
+
+    assert main, f"no main-agent binding found: {bindings}"
+    assert subagent, f"no subagent binding found: {bindings}"
+    assert all(OUTPUT_FILE_TOOL_NAME in b for b in main), main
+    assert not any(OUTPUT_FILE_TOOL_NAME in b for b in subagent), subagent
+
+
+@pytest.mark.parametrize(
+    ("subagent_type", "subagents"),
+    [("worker", (_WORKER,)), (GENERAL_PURPOSE_SUBAGENT["name"], ())],
+    ids=["declared-subagent", "general-purpose"],
+)
+def test_shared_tools_still_reach_every_agent(
+    tmp_path: Path, subagent_type: str, subagents: Sequence[SubAgent]
+) -> None:
+    """Withholding one tool must not withhold the rest."""
+    bindings = _dispatch(tmp_path, subagent_type, subagents)
+    assert all("read_invoice" in b for b in bindings), bindings
+
+
+def test_a_subagent_declaring_its_own_tools_is_left_alone(tmp_path: Path) -> None:
+    """An explicit ``tools`` on a spec is the caller's decision, not ours to rewrite.
+
+    Its list replaces the parent's rather than merging with it, so the subagent sees
+    ``only_mine`` and not the parent's ``read_invoice``. The filesystem tools are
+    still present because ``FilesystemMiddleware`` adds those to every agent.
+    """
+    bindings = _dispatch(
+        tmp_path, "worker", ({**_WORKER, "tools": [_tool("only_mine")]},)
+    )
+    subagent = [b for b in bindings if "task" not in b]
+    assert subagent, f"no subagent binding found: {bindings}"
+    assert all("only_mine" in b for b in subagent), subagent
+    assert not any("read_invoice" in b for b in subagent), subagent
+
+
+def test_the_withheld_set_is_not_empty() -> None:
+    """Guard against the set being emptied and the tests above passing vacuously."""
+    assert OUTPUT_FILE_TOOL_NAME in MAIN_AGENT_ONLY_TOOLS

--- a/tests/agent/tools/test_suspends_run_metadata.py
+++ b/tests/agent/tools/test_suspends_run_metadata.py
@@ -1,0 +1,108 @@
+"""Every tool factory that suspends the run must advertise it in tool metadata.
+
+A suspending tool raises ``GraphInterrupt`` instead of returning: the run
+checkpoints and the node is replayed from that checkpoint on resume. Callers that
+invoke tools outside the graph's tool node -- the QuickJS code interpreter's
+programmatic tool calling in particular -- must therefore not offer them, because
+a replayed node re-runs every call made before the interrupt, and because such
+bridges bypass approval hooks.
+
+Deciding eligibility from ``SUSPENDS_RUN`` keeps that policy next to the code that
+suspends, rather than in a central list that silently goes stale. This test is
+what makes the flag trustworthy: it reads the factory sources, so a new
+suspending factory that forgets to stamp it fails here instead of quietly
+becoming reachable from inside the sandbox.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from uipath_langchain._utils.durable_interrupt import SUSPENDS_RUN
+
+_TOOLS_DIR = Path(__file__).parents[3] / "src" / "uipath_langchain" / "agent" / "tools"
+
+_Function = ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _decorator_names(fn: _Function) -> set[str]:
+    names = set()
+    for decorator in fn.decorator_list:
+        node = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+    return names
+
+
+def _suspends(fn: _Function) -> bool:
+    """Whether ``fn`` or anything nested in it interrupts the run.
+
+    Both shapes count: the ``durable_interrupt`` decorator, and a bare
+    ``interrupt()`` call, which ``create_ixp_extraction_tool`` uses.
+    """
+    for node in ast.walk(fn):
+        if isinstance(node, _Function) and "durable_interrupt" in _decorator_names(
+            node
+        ):
+            return True
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "interrupt"
+        ):
+            return True
+    return False
+
+
+def _stamps(fn: _Function) -> bool:
+    """Whether ``fn`` sets ``SUSPENDS_RUN`` as a dict key to a true constant.
+
+    Parsed rather than grepped so a mention in a comment or docstring does not
+    count as a stamp.
+    """
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values, strict=False):
+            if (
+                isinstance(key, ast.Name)
+                and key.id == "SUSPENDS_RUN"
+                and isinstance(value, ast.Constant)
+                and value.value is True
+            ):
+                return True
+    return False
+
+
+def _suspending_factories() -> list[tuple[str, _Function]]:
+    """Every top-level factory under the tools package that suspends the run.
+
+    Scoped per factory, not per module: ``context_tool`` holds two suspending
+    builders next to a non-suspending one, so a module-wide answer would let a
+    third suspending builder pass on a sibling's stamp.
+    """
+    found = []
+    for path in sorted(_TOOLS_DIR.rglob("*.py")):
+        module = ast.parse(path.read_text(encoding="utf-8"))
+        for fn in module.body:
+            if isinstance(fn, _Function) and _suspends(fn):
+                found.append((f"{path.name}::{fn.name}", fn))
+    assert found, f"no suspending tool factories found under {_TOOLS_DIR}"
+    return found
+
+
+@pytest.mark.parametrize(
+    ("factory", "node"),
+    _suspending_factories(),
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_suspending_factory_stamps_the_flag(factory: str, node: _Function) -> None:
+    """A factory that suspends the run stamps ``SUSPENDS_RUN: True`` in metadata."""
+    assert _stamps(node), (
+        f"{factory} suspends the run but does not set {SUSPENDS_RUN!r} in its "
+        f"tool metadata. Add `SUSPENDS_RUN: True` to the tool's metadata dict, "
+        f"or the tool becomes callable from the code interpreter's tools namespace."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -172,9 +172,9 @@ name = "aiologic"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-    { name = "wrapt" },
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
 wheels = [
@@ -596,11 +596,61 @@ wheels = [
 
 [[package]]
 name = "bracex"
-version = "2.6"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
+]
+
+[[package]]
+name = "bsdiff4"
+version = "1.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/b9/4559ede9a4c8c4451688303544da84654643fdc7f28790aca85be80b4b7c/bsdiff4-1.2.6.tar.gz", hash = "sha256:2ab57d01a78b39e29e5accc9cfead4130982ded9dccbc4261bd0e9c51d6b751d", size = 13259, upload-time = "2025-02-19T17:42:33.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/08/6472d5c2527688b16ad2c2dd09e324281f5e78eea5e4dba5f65a7949f39c/bsdiff4-1.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b151c28098b3c522b1735cdfe5e84e8f164f0ef4a592adb227d7a10727034673", size = 16212, upload-time = "2025-02-19T17:39:53.399Z" },
+    { url = "https://files.pythonhosted.org/packages/33/41/4d1fa5980c01faa0d5c578e41ce73b4df98cd74e33f92323880df0da035e/bsdiff4-1.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:29def064f6bcd13d0d7a82e5caa4848158b7f49c3a8fe44fbef3031456fb7dd2", size = 16031, upload-time = "2025-02-19T17:39:54.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/41/188f858a71eb529145b6706f8ac618fd9f719807f46e0cebe2ea482bfe78/bsdiff4-1.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6f4cf8e00116e14e9e6c3fb5747478022a27215a9a65ed223fed82d2cfbc4d3", size = 33763, upload-time = "2025-02-19T17:39:55.438Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ea/84cc364a0c0f6eb3e503bf1625aa62eb411aa7474d1c91ec201812295fcb/bsdiff4-1.2.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:897a260d30acc4df9803f500682eb7951fdc104a3e155787e1e581258f38df50", size = 35705, upload-time = "2025-02-19T17:39:56.601Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/c235fd3e95aa3a4ac53de83605723a149a33eb11aff64e49488132b857f8/bsdiff4-1.2.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d994ee6113c3f030bb9f373e917f00db13c026c295fe9f314f23171935d88371", size = 33807, upload-time = "2025-02-19T17:39:57.601Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/010d14d3ab321c1c35fc4145b020c1e76ed8a29a214ce6bcc093ddedee13/bsdiff4-1.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba5028a2aaa8e4cacb224031af9140e05d9c407ba15b59471380badcc4845777", size = 33250, upload-time = "2025-02-19T17:39:58.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/91/ae41950f7b823e8061520f3b28d47534b47f314b4148690c4a002d764bd7/bsdiff4-1.2.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1edd3069dc14cecaa804faaae776a5d14f85217c41b3180b794e5fbf684d35dd", size = 35919, upload-time = "2025-02-19T17:40:00.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b4/f29c451e7718d4366a72f9a87a7f3cc76cb56cb5e9305eae087eab83f7a0/bsdiff4-1.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0fb562e451d5b3a7523c67ce04fe541d3a004914e5760a47116883972f5ff8bc", size = 33740, upload-time = "2025-02-19T17:40:01.893Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/73/004b3c4511df3df0d5e591ecd7aaf92c851b22be200283428d3577f4400b/bsdiff4-1.2.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:b7309380d8edbd3d46c4ed3930f7062b793bac8f004b32139db7af7c4612e241", size = 37325, upload-time = "2025-02-19T17:40:02.911Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ea/5fa1d331c4a2e73e4e90a851768749a9960cefcb443da3abaae69e891f06/bsdiff4-1.2.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f2f7504f08181227717fee04f25169d5901322c29d3fd054e4cb61bd60b3ffb4", size = 35791, upload-time = "2025-02-19T17:40:03.866Z" },
+    { url = "https://files.pythonhosted.org/packages/10/04/7616e8abec54562c86742c7bacaaba53c0c4733565ea00e8c5ffe2c5c9ce/bsdiff4-1.2.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:6ad599216e7ee3db5737951d06c43b8e65d5b0db5c42300e85f18d399ec0bc5e", size = 35413, upload-time = "2025-02-19T17:40:05.692Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d6/3fff18a97e127cc783e02de3c934bca63fabc0d4a379e091973b006cbae6/bsdiff4-1.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cd133a9475c9dfba6243dd07f118ee58a0b7f136c00d316e2d92d3f82169bd9e", size = 32939, upload-time = "2025-02-19T17:40:06.639Z" },
+    { url = "https://files.pythonhosted.org/packages/36/32/2943637e17eca717cdd091625d4198cf7a49dd7d235944a86f1a8a6134fe/bsdiff4-1.2.6-cp311-cp311-win32.whl", hash = "sha256:403e8cc003451a8c4672c345a50aee3cf89d20983701e38fbbb67e07cb808c57", size = 18257, upload-time = "2025-02-19T17:40:07.59Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f8/83f087ab62bebde26956f084ab272e19d11db5df6700f4f48d29647235fd/bsdiff4-1.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:164a059e1e07932f91d90471a4ef4dac749f2dee780f08501522805398b32ed8", size = 19530, upload-time = "2025-02-19T17:40:08.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/58/044dd110fb0a0160f5cacecbfb9904043c8179f8c14093e22b6d8c6b9391/bsdiff4-1.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:69c5052e94ad991c397b5a46f8eab42f2e256c42aa5677896b7a3ea9e3d06adc", size = 16267, upload-time = "2025-02-19T17:40:10.376Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/70b74154344486bac9bf438ec309ae502f07df8cd7ca713d58f658769ff4/bsdiff4-1.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:223ae0fc9f386dcf919a09a2029c391a0f0afaf4a5892b9a6e1b622bf42e1ae5", size = 16090, upload-time = "2025-02-19T17:40:11.334Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/90/36531261d8a150fcb8193fe2ad46d939b8a91549976424852f6a2a335689/bsdiff4-1.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48ea2298a281068d82b78454ee58ac7306ed38c9af55afddb04cf796df932d63", size = 33675, upload-time = "2025-02-19T17:40:13.218Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/97/8b73b3684c63e88508ad308229f33a8a5be6c4762e4160f96e2a6fc46906/bsdiff4-1.2.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2534e286ef5ae58767b9b17be64742424ca1e52ec748b0d8f8e24eecd12bc28a", size = 35648, upload-time = "2025-02-19T17:40:14.296Z" },
+    { url = "https://files.pythonhosted.org/packages/52/39/0b1dd6494c743fa2c62bd7c35f5dec9f5802d01c1da1ef75a2e20a481ed4/bsdiff4-1.2.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4ff079b0f4cf874af4b6816983557b6b9d45996f88736046653e2d2311fa1876", size = 33772, upload-time = "2025-02-19T17:40:15.341Z" },
+    { url = "https://files.pythonhosted.org/packages/88/23/98fc7482f957602c611203a9e485b9dbf4caf9d918e92453e3729cf5f0b4/bsdiff4-1.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56c2728c96d1d4eb8e089e4797c018a56be3f905f440fb507773f44c567fcd38", size = 33238, upload-time = "2025-02-19T17:40:16.343Z" },
+    { url = "https://files.pythonhosted.org/packages/75/04/c3db957b7a324a3f25f721a82c288e9abe60059a0a2d2f9b3c19fb49cdb2/bsdiff4-1.2.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9deb9b3cdb4d327e43b8c7bd11ed3707587f1183b35fb8a4c06c4f34bce62c6a", size = 35889, upload-time = "2025-02-19T17:40:18.237Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a8/73d2abfd98a33cd74a0fc491e527d734c222ae18b499a10689f3adbc8d5c/bsdiff4-1.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e87c67b06ac96af6171b774dc8c03d2bde70c67c6488078eff44e0af4864acf6", size = 33606, upload-time = "2025-02-19T17:40:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c3/713b3bb3711b62e51f6f67d6d9f63098e4d3a51d8b91e52c962f5c01a2b7/bsdiff4-1.2.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:04bb2948301ad48123d308bf2342c83cae81d7edb52d11bdde00266d89ca071e", size = 37211, upload-time = "2025-02-19T17:40:22.365Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c5/40559695ea0bd3332c37ef8182fc0f96ceed838ae6b03ca9ddcd8cf0f7df/bsdiff4-1.2.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:43649a44fc21f017be902e19ccf7fb8bac6ef2d7f93d871bbc6bc49acec9ffee", size = 35750, upload-time = "2025-02-19T17:40:23.554Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/9b/eb4683896119ec9d26d1eb3f12efc0d8a902451f4025db12c21c5a82992a/bsdiff4-1.2.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:baa76ec557dc48847c3ed1ff5720b5095c439c868f7568da30dcabbabceb2b92", size = 35364, upload-time = "2025-02-19T17:40:24.485Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ad/0968b67aecf00873e0e5c07e97ba2300594505d4dbce62702b9f56a62d66/bsdiff4-1.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:701168e2931da777e6e72ae17f22eb519e9ce25ec5108d149c9da7b3b80e1184", size = 32831, upload-time = "2025-02-19T17:40:25.571Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/adfcf72780f19cea1fe9948cbfb49890599424e94c752bf7d614093c0fc5/bsdiff4-1.2.6-cp312-cp312-win32.whl", hash = "sha256:f9f2e5e716d35af3252f69a15afc2b166970c98596a1114af4c6d2834fe8e871", size = 18308, upload-time = "2025-02-19T17:40:26.571Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5d/31672172bb4566c1f1187fa28a1437125d4b5106bc55f9f7b9a75371094c/bsdiff4-1.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:0b29568d1e33e32ea075c12a696b32e4d6cea344d0270a2292075254efd86014", size = 19553, upload-time = "2025-02-19T17:40:27.592Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/56/887d90b0e52ce7b5533a6f1390ab9a68215a70ba34848441730e215ffc1c/bsdiff4-1.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a98d7975a670fc360d894ef2ec00294e6b7b19790c58457e40c8a5d57a1865b0", size = 16260, upload-time = "2025-02-19T17:40:28.614Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/4c/825a16932605d305501ed144ae5567a3dc90c9164a393c61cc0ed68df3f0/bsdiff4-1.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ee4417341712a4bf736694ce9ad3902b8c6fbd3425aadca44df9b66a51bbefa4", size = 16080, upload-time = "2025-02-19T17:40:29.612Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0cf538a786f47b08e26f3970a6f98c2b7b9d555c01e085425282944a2c7f/bsdiff4-1.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39ddfa2137de44c9743a611d71d263d0cc8c45e5b18ee84ca5ff6b6240be1740", size = 33664, upload-time = "2025-02-19T17:40:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/c0/44ac255f1d16865e39ef941470e30bb5c362dd216b62837bb13880d1dd36/bsdiff4-1.2.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6474d8f34f89d25fa1803c639cc8ed49121752a56a15b4cd21e9267154cdaf70", size = 35648, upload-time = "2025-02-19T17:40:32.793Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6b/d5871af38cbb8527652b65463c3dd736b6250828d8d6daf48be712a2ebfe/bsdiff4-1.2.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8e9c876929c03ef5d448e2626e8b2961040c3a9f0dd3d483643dbccd0e7ff7a", size = 33792, upload-time = "2025-02-19T17:40:35.498Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1e/7027849a6dc02b580e352b1528899053bd919029b185fbaa14c6f268180b/bsdiff4-1.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46313f0eb8f63efb54a3c4219cd7b5b8a7795012b535f9d0838fe3f2b3349849", size = 33238, upload-time = "2025-02-19T17:40:37.165Z" },
+    { url = "https://files.pythonhosted.org/packages/97/df/c4a3e2bb1c1f9f09c2c5f8a9025c67f5ec7fcc8949338e54cb2d4fba9009/bsdiff4-1.2.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6b5757b1a83829f00ef34953c6865ea82e9c71126e465bc32d029c55da9e45b", size = 35866, upload-time = "2025-02-19T17:40:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/83/03/76a5aaaa0ccc282b239b3f148f6dd6033d37f79c1d1a89846b712224d132/bsdiff4-1.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:734552992ecc86749a8ef55d03f999f9a47576cc609d7d4d9a7aec274b43ee4d", size = 33688, upload-time = "2025-02-19T17:40:39.762Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/b3/b240d4840a16d923c60e8e9eacf0777cf9378e30610037f6c85324daea85/bsdiff4-1.2.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:853c3221daac6f8d347f12eb0b73ca9dbb7db483e7b5f40b1e2fbb05730645a7", size = 37273, upload-time = "2025-02-19T17:40:41.626Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/84/2223a09c4950a3e419ce94eb0af6d90c1ee562b9962ef2d72515f4ad6271/bsdiff4-1.2.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:94526dc11e56f330c2f4b1e2e9389b958a7891f6c86b5aac83bd9c7a90eb088a", size = 35844, upload-time = "2025-02-19T17:40:42.646Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7b/c02f703b449feb20b245eb803e7d446508b80d5b4065d1eb9cc75d02ae3b/bsdiff4-1.2.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f5474e1d9253564ed0823e2685a403d9dfdbba3c7b70a80f5066d61427848253", size = 35418, upload-time = "2025-02-19T17:40:44.562Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/52/623ee28011b6935f0dfe67397ec27c2a900b9f0bda1b1ec2a5b174c53fb7/bsdiff4-1.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5529731ac88151345a8bb76dad4fdb218af10a8a505161d1aa3d669e49cb7b77", size = 32892, upload-time = "2025-02-19T17:40:45.552Z" },
+    { url = "https://files.pythonhosted.org/packages/44/6c/e740e347bb46ea08ceacf39df56c2ffd2bd20b95d458409ea303fbf2b946/bsdiff4-1.2.6-cp313-cp313-win32.whl", hash = "sha256:c8089827c41b37f7c9192492742289929097c5ab2a6b3a120919fee27fbc01b8", size = 18304, upload-time = "2025-02-19T17:40:47.37Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/9be6f6124afab9837db1ffc5801ca1aa86f2077d4224ff729e88fabada71/bsdiff4-1.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:37ff935ba714e0726584dad2bc4c063218b588b110115e8554ebc438ee7bccf3", size = 19543, upload-time = "2025-02-19T17:40:48.369Z" },
 ]
 
 [[package]]
@@ -991,8 +1041,8 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic" },
-    { name = "typing-extensions" },
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
 wheels = [
@@ -1020,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.5.9"
+version = "0.7.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -1028,11 +1078,12 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/74/776e606f0508a4d7d4c9d061c797dcde43eed2452fea546ae29047aeaaa6/deepagents-0.5.9.tar.gz", hash = "sha256:74fe0f998641b20bda8adac662a018051c623a3c8e5ed4b6ff9ad53fc493a783", size = 165651, upload-time = "2026-05-10T22:31:17.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/a7/18d5479456c5c4d47d6074a8af615f8b844d91ec4e7bd548f2b047953903/deepagents-0.7.13.tar.gz", hash = "sha256:99fc1855b1387c1c6e6035ba3600edbd933f59c39a4863ef3a7d5a0272ea67ab", size = 297293, upload-time = "2026-09-02T17:36:38.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/f6/9698f98da72dfa8dc8e1d0f0542f2407a40a50cfdccf522fdb5cb43e39e2/deepagents-0.5.9-py3-none-any.whl", hash = "sha256:ce24a41763b2793bd21217411e9fb9f187a9128da6789f5a81654da1de9e4c7c", size = 188118, upload-time = "2026-05-10T22:31:15.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/64/6881d1c040433a3c48a1556afa5e70bcd5a761b0f67f9162a311ca8ed91c/deepagents-0.7.13-py3-none-any.whl", hash = "sha256:d717ee8ee092a91c475a6124ed578d5e4154d54120769a1081bfe1aece87c248", size = 324274, upload-time = "2026-09-02T17:36:37.165Z" },
 ]
 
 [[package]]
@@ -1295,20 +1346,20 @@ grpc = [
 
 [[package]]
 name = "google-auth"
-version = "2.55.0"
+version = "2.57.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb", size = 349379, upload-time = "2026-06-15T22:33:16.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/3a/d3982b28d267880b5641f9a32c55d8062a9d2bad2d28d0274285391c89c2/google_auth-2.57.1.tar.gz", hash = "sha256:eb47b230fc6707eed4aee1c9cef55ec05bc1785eecba74ff8b572d531e921b1e", size = 372426, upload-time = "2026-09-04T00:50:27.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a", size = 252400, upload-time = "2026-06-15T22:33:14.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/27/0f7247b8002a1404fdb5412aeb15fb0fe70288eb8f88a5873d1c0d8262cf/google_auth-2.57.1-py3-none-any.whl", hash = "sha256:ab439dee60a6856412bc058f13a68eb6a59c5b81526bb89cfdcf89ce9c0a48c9", size = 259974, upload-time = "2026-09-04T00:50:21.693Z" },
 ]
 
 [package.optional-dependencies]
 pyopenssl = [
-    { name = "pyopenssl" },
+    { name = "cryptography" },
 ]
 requests = [
     { name = "requests" },
@@ -1451,7 +1502,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "2.9.0"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1465,9 +1516,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/75/81c01294db3a3005dc8a807ed889a10ecd66ef89462c118adcffa5f7981c/google_genai-2.9.0.tar.gz", hash = "sha256:a8a10e9113f460cc668c1d9deeb62ba393ad1ba704bf3166d5a0f32a434f9415", size = 595700, upload-time = "2026-06-19T08:23:42.718Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/f1/f2f31b2a6bd826bc2cb73068df880954a026474c03a4315637d20cc13965/google_genai-2.22.0.tar.gz", hash = "sha256:9fa3b5d9ddb635005d8ab2d6206fb2b3d7204b66965bbce7de13ecd1a866ebcd", size = 684719, upload-time = "2026-09-02T18:06:02.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/17/bb2cdd0a6c6fec32f14e85735917d1052f82430b1de58c2b606740740419/google_genai-2.9.0-py3-none-any.whl", hash = "sha256:2a79e2b08e8439f5f25c2b42f98e3f3e8ea4be9c9265f5d7321580dbaf2764f4", size = 950790, upload-time = "2026-06-19T08:23:40.995Z" },
+    { url = "https://files.pythonhosted.org/packages/de/96/0120d214958cb54f2b9c48da9f564a0e6eae269e9dd702415fb1d0551cc7/google_genai-2.22.0-py3-none-any.whl", hash = "sha256:c514001c45470cc0a942440ae1b8215445d12bfb6c373aac94637127e1f74ec6", size = 1088792, upload-time = "2026-09-02T18:06:00.629Z" },
 ]
 
 [[package]]
@@ -1991,16 +2042,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.10"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/e351d85c7828b9b90c5729de66170457c882c754efef0712904cfcd3192d/langchain-1.3.10.tar.gz", hash = "sha256:fd6ac9da86c479e4ff376e772d9e17a9232bd3113e9f2ddcb70cdc4bf7afc119", size = 632522, upload-time = "2026-06-18T19:43:00.86Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/5d/0ef368fdcf5df08a394787196fb7a80f473a9c7b3fc4cd2e3b53a7a5853d/langchain-1.4.0.tar.gz", hash = "sha256:08da122a439f738f4c09a5158cfa3d2c1d8bea2d0bde7fbbf4aeb4d7f7fd9d80", size = 729354, upload-time = "2026-09-03T16:59:32.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/f6/a682e68d004a2e23cae6c5c42e3c0d071bc0e7768167bd12277992f096f9/langchain-1.3.10-py3-none-any.whl", hash = "sha256:5da67f21aa56119744ad51b3e46ffac570c88f4fae0876e3b1c6a1c4bc0e344e", size = 133038, upload-time = "2026-06-18T19:42:58.918Z" },
+    { url = "https://files.pythonhosted.org/packages/92/fa/7da07d9977a5e292ef602c1bb911514ff8206e85dc09a66961874345d57a/langchain-1.4.0-py3-none-any.whl", hash = "sha256:af1dc0161d30944a52ec7844d9bf890d0497b12ec0703069f3503b4003cbbac3", size = 161534, upload-time = "2026-09-03T16:59:31.154Z" },
 ]
 
 [[package]]
@@ -2100,7 +2151,7 @@ wheels = [
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.2.5"
+version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
@@ -2108,9 +2159,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/4b/a1acdba3a86f861d379cb654f234d334c04a4c93178c8c7b0182ddeb9966/langchain_google_genai-4.2.5.tar.gz", hash = "sha256:2abab4be22699a9cc29948b2bf012946f51a0bbf10ab3a4a9a129047234829f8", size = 271850, upload-time = "2026-06-10T01:48:57.06Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/4e/41798c80b574d958d189e049f13d64eb9246a66623465290f2cbfd641759/langchain_google_genai-4.4.0.tar.gz", hash = "sha256:7871beec56ac07b719f77c46997845db6ff2267b817bffb0f97877053b0895d7", size = 378415, upload-time = "2026-09-01T20:15:45.816Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/82/3d4d3dc181ea1756f323dad4d5936239c2f404ea0acb5102316224280634/langchain_google_genai-4.2.5-py3-none-any.whl", hash = "sha256:289699ddb8e1076a76144f83e25e0086e4ce629b196fc103251f2a629e0756e5", size = 69404, upload-time = "2026-06-10T01:48:56.09Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/10/83bb535e78c2cf767a6193c2f3b00b2894c1581a36ef85911ebaa3b9a891/langchain_google_genai-4.4.0-py3-none-any.whl", hash = "sha256:8e23a1307bd2158590bbf9d99f1d658fc84a9d9ddb77fb1b372f8875a2bafbbf", size = 81617, upload-time = "2026-09-01T20:15:44.533Z" },
 ]
 
 [[package]]
@@ -2177,8 +2228,25 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-quickjs"
+version = "0.3.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bsdiff4" },
+    { name = "deepagents" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "quickjs-rs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/20/fa0df0783912318c1899704fa3377a5276e9e88279a089d3bf5586658f08/langchain_quickjs-0.3.7.tar.gz", hash = "sha256:7570d85710cff93935509606da0838de4d7c6405021165f8b57555caa24aa662", size = 232367, upload-time = "2026-09-06T03:07:30.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/e7/c37198e5c00cc0814b323d8de10de0f8abb59bed8cef5bcb8f7aeb46d16a/langchain_quickjs-0.3.7-py3-none-any.whl", hash = "sha256:50f384b209f0f0f472c043024e2c74276900352591422df1aeae7a0fbcf8566f", size = 47199, upload-time = "2026-09-06T03:07:29.058Z" },
+]
+
+[[package]]
 name = "langgraph"
-version = "1.2.6"
+version = "1.2.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2188,9 +2256,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/7a/ea09b05bb0cbddfa43bd34fc581357e87fc3f21a751cc0d419688c3106da/langgraph-1.2.6.tar.gz", hash = "sha256:f9b45a34f13930c94d96cdb76277447ad2cc70ec2d18cd2764d7fdadb36cdc1b", size = 714400, upload-time = "2026-06-18T20:58:21.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/0d/c8e7ee98896659e1b6555db0ab115a9ca899844744645d5d894032bab1d7/langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363", size = 725753, upload-time = "2026-08-11T14:00:36.945Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/32/772db1b00a9fe42f50320d1aa20caefb76e621eff1f7218b9918093d631d/langgraph-1.2.6-py3-none-any.whl", hash = "sha256:1cf94d3ca124f84f77ce408fa1b06c3dee680a8aafffe364a8fd5d7d03eb8695", size = 246132, upload-time = "2026-06-18T20:58:20.335Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7f/c5c30e4be99ff821029c7ac872a480676bb179c9f3df85ea3f38d13f86d4/langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b", size = 248854, upload-time = "2026-08-11T14:00:35.494Z" },
 ]
 
 [[package]]
@@ -2251,23 +2319,27 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.8.18"
+version = "0.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx2" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
     { name = "uuid-utils" },
     { name = "websockets" },
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/d9/a6681aa9847bbbc5ec21abe20a5e233b94e5edcfe39624db607ac7e8ccb4/langsmith-0.8.18.tar.gz", hash = "sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd", size = 4526988, upload-time = "2026-06-19T13:12:17.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/b7/74d0992a461eacad8106e5dcfd7677d7640b5ff4e12ea545856467004f4f/langsmith-0.12.2.tar.gz", hash = "sha256:ff369ba4390e0969dbb109e838281404ae637e76ef73b347336bae05b4f87331", size = 4860106, upload-time = "2026-09-05T20:26:19.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/70/0e0cc80a3b064c8d6c8d697c3125ed86e39d5a7393ec6dc8b07cb1cf13c4/langsmith-0.8.18-py3-none-any.whl", hash = "sha256:3940183349993faef48e6c7d08e4822ee9cefd906b362d0e3c2d650314d2f282", size = 508108, upload-time = "2026-06-19T13:12:15.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e1/5c751a0f1a14de49f19a2ebc0f5dfadfaf04a07f245c5f749ec31f263715/langsmith-0.12.2-py3-none-any.whl", hash = "sha256:ca2b6386cf452cf8edebf27c9c476503c18bad895e7ad566578393fa0ba7fea2", size = 760692, upload-time = "2026-09-05T20:26:18.166Z" },
 ]
 
 [[package]]
@@ -3702,19 +3774,6 @@ crypto = [
 ]
 
 [[package]]
-name = "pyopenssl"
-version = "26.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
-]
-
-[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3983,6 +4042,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "quickjs-rs"
+version = "0.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wasmtime" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/dc/177301106aede96a709d5577127aaa090364d4abb8b4c4cfb87b12ae2c30/quickjs_rs-0.2.5.tar.gz", hash = "sha256:3ceb30fba27013108fac92f0a716d6a16980131ce5b13f9912848df1f1f2cf09", size = 830147, upload-time = "2026-07-24T20:29:26.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/1d/e4406d13ce9b9443dbfa59e2a2d5b3e11278ebe322b54de38ae18faf5436/quickjs_rs-0.2.5-py3-none-any.whl", hash = "sha256:e82240af1f1dd1b2e12bcf169a22a8e0e451e356f0688f2fc3bba886d9b2bb20", size = 801138, upload-time = "2026-07-24T20:29:24.194Z" },
 ]
 
 [[package]]
@@ -4738,7 +4809,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.17.9"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4769,6 +4840,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "langchain-quickjs" },
     { name = "uipath-langchain-client", extra = ["all"] },
 ]
 anthropic = [
@@ -4777,6 +4849,9 @@ anthropic = [
 bedrock = [
     { name = "boto3-stubs" },
     { name = "uipath-langchain-client", extra = ["bedrock"] },
+]
+code-interpreter = [
+    { name = "langchain-quickjs" },
 ]
 fireworks = [
     { name = "uipath-langchain-client", extra = ["fireworks"] },
@@ -4811,15 +4886,16 @@ requires-dist = [
     { name = "a2a-sdk", specifier = ">=1.1.2,<2.0.0" },
     { name = "boto3-stubs", marker = "extra == 'bedrock'", specifier = ">=1.41.4" },
     { name = "datamodel-code-generator", specifier = ">=0.76.0" },
-    { name = "deepagents", specifier = ">=0.5.9,<0.6.0" },
+    { name = "deepagents", specifier = ">=0.7.11,<0.8.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx2", specifier = ">=2.5.0,<2.10.0" },
     { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "jsonschema-pydantic-converter", specifier = ">=0.4.1" },
-    { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
-    { name = "langgraph", specifier = ">=1.1.8,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.18,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.6.1,<2.0.0" },
+    { name = "langchain-quickjs", marker = "extra == 'code-interpreter'", specifier = ">=0.3.5,<0.4.0" },
+    { name = "langgraph", specifier = ">=1.2.11,<2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.3,<4.0.0" },
     { name = "mcp", specifier = "==2.0.0" },
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.69,<0.2.0" },
@@ -4829,6 +4905,7 @@ requires-dist = [
     { name = "rdflib", specifier = ">=7.0.0,<8.0.0" },
     { name = "uipath", specifier = ">=2.14.13,<2.15.0" },
     { name = "uipath-core", specifier = ">=0.5.29,<0.6.0" },
+    { name = "uipath-langchain", extras = ["code-interpreter"], marker = "extra == 'all'" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.20.0,<1.21.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.20.0,<1.21.0" },
     { name = "uipath-langchain-client", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.20.0,<1.21.0" },
@@ -4840,7 +4917,7 @@ requires-dist = [
     { name = "uipath-platform", specifier = ">=0.2.28,<0.3.0" },
     { name = "uipath-runtime", specifier = ">=0.13.0,<0.14.0" },
 ]
-provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
+provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "code-interpreter", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5104,15 +5181,34 @@ wheels = [
 ]
 
 [[package]]
+name = "wasmtime"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/1f/03a286dc84d83cc3274d5599543558442ba9332b676e6408ee9e1c171199/wasmtime-48.0.0.tar.gz", hash = "sha256:dba27d59209fac703e7d5753af78c2af2c1cd1ed735f520ec76dc31c60a05815", size = 128804, upload-time = "2026-08-20T19:31:57.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/e6/39da2f4047a281bce7d4651e21785942d630033931eb397cf734e7ccc048/wasmtime-48.0.0-py3-none-android_26_arm64_v8a.whl", hash = "sha256:a55abf132fe238b843a963c68cd1a30d8f686c1bc75d8fbf042d8b7a1d51ee36", size = 8800816, upload-time = "2026-08-20T19:31:28.761Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d0/f4f107166a65ddf8a6d8cf74f0cea33c06a08c74fe686f8e83b194e57e8b/wasmtime-48.0.0-py3-none-android_26_x86_64.whl", hash = "sha256:d8e94276ff6c0c5ce73ee16ccbacb00b3512a4b3a664749380705d81ee06a23c", size = 9731711, upload-time = "2026-08-20T19:31:31.905Z" },
+    { url = "https://files.pythonhosted.org/packages/95/15/20fad0cb2b9cff130c225bf827e16365e02883f504297eccf172c6bb7228/wasmtime-48.0.0-py3-none-any.whl", hash = "sha256:49c9ee43e9cf59ad7453ac65dce0cc4b885837904dd3cfd45faafe930defe14a", size = 8157926, upload-time = "2026-08-20T19:31:34.74Z" },
+    { url = "https://files.pythonhosted.org/packages/89/93/911434c6c4406e6979b6cb67ba889c85633ff8d92eb0cb569fec6e2a43f7/wasmtime-48.0.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:50e1ea81a3bec537d00e076722dfdc48978a56ea24619d8153aa1f75b11796b9", size = 9395773, upload-time = "2026-08-20T19:31:37.312Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a6/91c9c19ed7f8e164f4db6405d872c9397be9f53e4f325d0adcd5e67598f4/wasmtime-48.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ea69889a3c51702e9da5f5f441027ca934f7758f8926a4ed167b0d6877f092e8", size = 8343024, upload-time = "2026-08-20T19:31:39.922Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/92/e144fcf578fc394678c24b042efe45f3b0614acdb87ea95d8b839b208842/wasmtime-48.0.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:58544d539053dff7bd4cf30c40d7a540862d683013c0dfa6ba46a063f5b682f7", size = 9796354, upload-time = "2026-08-20T19:31:42.325Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c3/a957b226979daaeb09ec024562e9aac05e475a954537e6f150eb60bca84d/wasmtime-48.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:26fce3613fefbe29a28e9d659dca3326e800593858e5758cad086eb802b3b766", size = 8734885, upload-time = "2026-08-20T19:31:44.966Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bf/00e44d1971307620d6660760ed04796405a5fb1819c8b43ec03ad85efac6/wasmtime-48.0.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:77f6b75db20be065e205e7af814d4e4f06784c3a00eb346e8c76148ecb4afe5a", size = 8786289, upload-time = "2026-08-20T19:31:47.99Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/55/ce68af7734a5a9424dd66a301b11c810215ec7f70230b35bed10ed312e97/wasmtime-48.0.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:62b241c8d5dfb59ff8af1ccaa5351f0ab7aba8cc872f7d80e0e3c95d54c13562", size = 9889697, upload-time = "2026-08-20T19:31:50.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/12/5266bebece874ebfa3196c973b917091dd4c55e9e9da55401e312c403044/wasmtime-48.0.0-py3-none-win_amd64.whl", hash = "sha256:21fa500e70f3819a8c0539c3f0be6b3b81ec3c630bb90c47dba4d8a2c1d4c698", size = 8157931, upload-time = "2026-08-20T19:31:53.312Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a4/bb6c90d99ad893bd42f33aa7fb386deecb55987f012c0c2f5fcaba83106d/wasmtime-48.0.0-py3-none-win_arm64.whl", hash = "sha256:09cd5e14df80a3a8d447428a548583181c568ea2e617419d23600deff21d4b82", size = 7044651, upload-time = "2026-08-20T19:31:55.63Z" },
+]
+
+[[package]]
 name = "wcmatch"
-version = "10.1"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/43/30e407989e313677dbb9d5f045f966549a7254834571e342eaa4b55cc67b/wcmatch-11.0.1.tar.gz", hash = "sha256:1ea2b4fa678b8ca268253798d5963935df39132d47c3e241c0a0732224005e7d", size = 144662, upload-time = "2026-08-14T15:20:40.477Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl", hash = "sha256:fd149ecddb9f0a88ea780017d6dde17c994e494e7f7303d4e3c9d6251f978f4b", size = 43449, upload-time = "2026-08-14T15:20:39.379Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump deepagents to 0.7.11, raising the langchain floor to 1.3.18 and langgraph to 1.2.11
- offer the QuickJS code interpreter to advanced agents, behind the optional `code-interpreter` extra
- drop the `write_todos` tool, following the benchmark deepagents 0.7.0 based its own removal on
- flag tools that suspend the run, so callers can tell which ones are unsafe to invoke outside the graph's tool node

## Code interpreter

`build_code_interpreter_middleware(tools)` returns middleware giving the agent one `eval` tool: a persistent JavaScript REPL in a WASM guest, with eligible tools callable from inside it as `tools.<camelCaseName>(...)`. Pass it via `middleware=` on either advanced graph builder.

It is opt-in twice over. The dependency is an extra (`uipath-langchain[code-interpreter]`), because wasmtime and the QuickJS guest are ~27 MB on disk and no consumer should carry that unless it asks. The middleware import is deferred into the factory, so importing the package without the extra keeps working and only the factory raises, with install guidance.

The allowlist governing what the sandbox can reach is derived, never hand-written. Three exclusions: tools that suspend the run (a replayed node re-runs every bridged call made before the interrupt, and PTC bypasses approval hooks), names that cannot be JavaScript identifiers (upstream raises mid-turn for those), and camelCase collisions (upstream dedupes by tool name, so binding either would call the wrong tool).

`mode` is a parameter rather than a constant. `"thread"` snapshots the REPL into the checkpoint, so state survives a suspend and resume, at a fixed ~1.25 MB per checkpoint thread written even when the agent never calls `eval`. That only pays off where a later run reads it back, so a caller whose runs each get their own thread should pass `"turn"`, which writes nothing. Upstream renders the tool description from the mode, so the model is told the correct semantics either way.

## `write_todos` removed

deepagents 0.7.0 dropped `TodoListMiddleware` from its defaults after benchmarking across three models: no statistically significant accuracy gain on any of them, and higher token use on two ([langchain-ai/deepagents#4929](https://github.com/langchain-ai/deepagents/pull/4929)). This follows that rather than restoring it, and pins the absence with a test so a future change has to be deliberate.

Kept as its own commit, so it can be reverted without touching the version bump.

## Breaking

`BackendFactory` is gone from `uipath_langchain.agent.advanced`, and the `backend` parameters no longer accept a factory. deepagents 0.7.0 deleted the type, so there is nothing left to alias it to and a factory would be rejected downstream regardless. Pass a `BackendProtocol` instance instead.

Advanced agents no longer expose `write_todos`. A caller that wants it can pass `middleware=[TodoListMiddleware()]`; the middleware injects its own usage prompt, so no caller prompt needs to describe the tool.

Two behaviour changes come from deepagents itself and are worth knowing before upgrading: `write_file` now replaces an existing file rather than erroring, and a recursive `delete` tool appears whenever the backend supports it. `delete` is deliberately not withheld: an agent can already replace a file with `write_file`, and letting it clean up scratch files reduces orphan job attachments.

## Why

deepagents 0.5.9 is two minor versions behind, and 0.7.x is the floor `langchain-quickjs` requires, so the code interpreter was not reachable before this.

the base prompt goes with it: 0.7.0 empties `BASE_AGENT_PROMPT`, which is where its input-token reduction comes from, so this adopts the lean prompt rather than passing the deprecated constant back in.