### PR TITLE
fix(deps): keep uipath and uipath-runtime ranges within one minor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "uipath-langchain"
-version = "0.16.0"
+version = "0.16.0.post1"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.13.16, <2.15.0",
+    "uipath>=2.14.0, <2.15.0",
     "uipath-core>=0.5.29, <0.6.0",
     "uipath-platform>=0.2.15, <0.3.0",
-    "uipath-runtime>=0.12.5, <0.14.0",
+    "uipath-runtime>=0.13.0, <0.14.0",
     "uipath-llm-client>=1.17.1, <1.18.0",
     "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.27, <2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4498,7 +4498,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.16.0"
+version = "0.16.0.post1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4578,7 +4578,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rdflib", specifier = ">=7.0.0,<8.0.0" },
-    { name = "uipath", specifier = ">=2.13.16,<2.15.0" },
+    { name = "uipath", specifier = ">=2.14.0,<2.15.0" },
     { name = "uipath-core", specifier = ">=0.5.29,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.17.1,<1.18.0" },
@@ -4589,7 +4589,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-llm-client", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-platform", specifier = ">=0.2.15,<0.3.0" },
-    { name = "uipath-runtime", specifier = ">=0.12.5,<0.14.0" },
+    { name = "uipath-runtime", specifier = ">=0.13.0,<0.14.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
 
@@ -4690,16 +4690,16 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.13.0"
+version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "uipath-core" },
     { name = "vadersentiment" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/c0/d55cf48ee43758c2c1c65f52fd0596fd75f5bd5067a5016e6553b4d2c5fe/uipath_runtime-0.13.0.tar.gz", hash = "sha256:8ae3150df5fb0043210faacf39148789c1fb252c6a8d6bc27174c0d9ce7304f5", size = 243594, upload-time = "2026-08-04T11:19:04.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/4d/86409493366ee75b5548dd992e5d256ddf304f2b398677169f7f9af7cd99/uipath_runtime-0.13.2.tar.gz", hash = "sha256:004c91a20f85c0a0f61cce30b0dae267f1d8e086476adcbe7e723724e22d1475", size = 246648, upload-time = "2026-08-25T09:31:46.189Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/88/9518dcbeedaa8117e5fd3d0424c4a7354bae1f3ede1b2e3f48524e4b7efc/uipath_runtime-0.13.0-py3-none-any.whl", hash = "sha256:2a7c128cf14fdbef899b272ee5995da63baeb882acc904f39ef8f8f52bcb019f", size = 96349, upload-time = "2026-08-04T11:19:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/f9225df568a3f76c2c5c6e47c9c5043d5e2a9c70a4a83b7450010c337bb0/uipath_runtime-0.13.2-py3-none-any.whl", hash = "sha256:33e4fcd9b6edcc01dfa6e87434a3252319c1f1fd0480a2816d591b763b6e4f86", size = 97014, upload-time = "2026-08-25T09:31:44.692Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Releases `uipath-langchain` 0.16.0.post1: 0.16.0's source, with two dependency ranges narrowed to the minors this build was actually released against.

```diff
-version = "0.16.0"
+version = "0.16.0.post1"
-    "uipath>=2.13.16, <2.15.0",
+    "uipath>=2.14.0, <2.15.0",
-    "uipath-runtime>=0.12.5, <0.14.0",
+    "uipath-runtime>=0.13.0, <0.14.0",
```

## Why

0.16.0 was the release that added support for `uipath` 2.14 and `uipath-runtime` 0.13, but it widened both ceilings while leaving the old floors in place. The published ranges therefore span two minors each, and a resolver is free to pair this build with `uipath-runtime` 0.12 or `uipath` 2.13. Neither combination was released or tested against this source.

Narrowing them to a single minor makes the metadata state what the build actually supports. 0.16.2 later landed the same `uipath-runtime>=0.13.0` tightening on the main line; this applies it to 0.16.0 without the source that arrived in between.

## Branch

Cut from `ca64d4f`, the commit that built 0.16.0, per the open-source hotfix procedure. Base branch `release/uipath-langchain-0.16.0` is that same commit. Not for `main`, which is well past 0.16.x.

Source is byte-identical to 0.16.0, which in turn is byte-identical to 0.15.2 under `src/` — `ca64d4f` changed only dependency metadata, and the one commit between 0.15.2 and 0.15.3 was test-only. That is what makes this usable by a consumer that needs `uipath-runtime` 0.13.x without taking any behaviour change.

## Versioning

0.16.1 and later already exist, so per the procedure this is a post-release of the version being fixed rather than a patch increment. PEP 440 orders it `0.16.0 < 0.16.0.post1 < 0.16.1`, so it does not supersede anything for consumers already on a later patch.

## Verification

- `uv lock` pinned at `uipath-runtime==0.13.2`, resolving `uipath` 2.14.1
- `uv sync --locked --all-extras` clean
- full test suite green, exit 0, no failures

## Publishing

CD is `workflow_dispatch`. Dispatch it against the hotfix branch; the merge into the base branch does not trigger it.