### PR TITLE
fix(deps): move the uipath-runtime range to 0.13 on the 0.15 line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "uipath-langchain"
-version = "0.15.2"
+version = "0.15.2.post1"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-    "uipath>=2.13.16, <2.14.0",
+    "uipath>=2.13.23, <2.14.0",
     "uipath-core>=0.5.29, <0.6.0",
     "uipath-platform>=0.2.15, <0.3.0",
-    "uipath-runtime>=0.12.5, <0.13.0",
+    "uipath-runtime>=0.13.0, <0.14.0",
     "uipath-llm-client>=1.17.1, <1.18.0",
     "langgraph>=1.1.8, <2.0.0",
     "langchain-core>=1.2.27, <2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4453,7 +4453,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.16"
+version = "2.13.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -4477,28 +4477,28 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/99/17036d803ea11745af4c2cc1d6c8c6ec1b2d3d454eec842f220930a48f4e/uipath-2.13.16.tar.gz", hash = "sha256:d8977972ab29c7eac22fcfa044186701ba2961d746fd38b06f43c665d8f8cf5f", size = 4527477, upload-time = "2026-07-24T08:09:45.569Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/cc5f023c4f0a5bbf5febed8baea2a224bc7fdad92ee12b4f66c7e256c300/uipath-2.13.23.tar.gz", hash = "sha256:a85ce111a359739555efb74e8404678f5f8468ba4a21c5d71f73adbae55f3d75", size = 4539655, upload-time = "2026-09-01T11:05:53.855Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/08/aec381f035d00d2c0e1bde410a1d79c9c61d697004d1a849d2be373e3486/uipath-2.13.16-py3-none-any.whl", hash = "sha256:99909c8dcbbb0c2b08710f2d55c55b6b54a4473be6df3c4daab8442e12a4b860", size = 431522, upload-time = "2026-07-24T08:09:43.486Z" },
+    { url = "https://files.pythonhosted.org/packages/32/46/ec2fa73145a9900ace88a397c3d8967970882c9f324d6405f095c7a049ab/uipath-2.13.23-py3-none-any.whl", hash = "sha256:a1519afaef491898396e75d3754b0b5da7143c0edcbc95671981b21a2559e362", size = 434723, upload-time = "2026-09-01T11:05:51.048Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.30"
+version = "0.5.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/cc/a5acd1d4bbf3c8252a2c8ee3a57b584a790b8bfd86661cf2c236084875ac/uipath_core-0.5.30.tar.gz", hash = "sha256:746494d97a07fc557baff6dca341d53f28ffdd09109b666c19892092816c3335", size = 130833, upload-time = "2026-07-07T14:38:57.377Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/0b/deb01dc671b075d88841f017a7c394e1b6f6869a9b3c027333cce587d59f/uipath_core-0.5.32.tar.gz", hash = "sha256:f709cc0b6a24d779b1b2200943512bedfc0842bac983ad0a9c668f35a991f4e7", size = 131009, upload-time = "2026-08-19T13:10:13.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/da/a90a150141449a540be6b607dd01b6aa08823b3332531c54813ad627cfb6/uipath_core-0.5.30-py3-none-any.whl", hash = "sha256:b8c4f48a06a1c49504351bbfa42282e225af1a30467e93d4e2e2ea0e3a2f06f9", size = 55038, upload-time = "2026-07-07T14:38:55.979Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/8c8641ea4b1596158ce47d6917d320a093bef9d7d93f781aeb03ee1ecf50/uipath_core-0.5.32-py3-none-any.whl", hash = "sha256:0a08644b6805db42be11257446947e419d14bb75e9c3ad82c4eee2509a5181da", size = 55123, upload-time = "2026-08-19T13:10:12.238Z" },
 ]
 
 [[package]]
 name = "uipath-langchain"
-version = "0.15.2"
+version = "0.15.2.post1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -4578,7 +4578,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rdflib", specifier = ">=7.0.0,<8.0.0" },
-    { name = "uipath", specifier = ">=2.13.16,<2.14.0" },
+    { name = "uipath", specifier = ">=2.13.23,<2.14.0" },
     { name = "uipath-core", specifier = ">=0.5.29,<0.6.0" },
     { name = "uipath-langchain-client", extras = ["all"], marker = "extra == 'all'", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-langchain-client", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.17.1,<1.18.0" },
@@ -4589,7 +4589,7 @@ requires-dist = [
     { name = "uipath-langchain-client", extras = ["vertexai"], marker = "extra == 'vertex'", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-llm-client", specifier = ">=1.17.1,<1.18.0" },
     { name = "uipath-platform", specifier = ">=0.2.15,<0.3.0" },
-    { name = "uipath-runtime", specifier = ">=0.12.5,<0.13.0" },
+    { name = "uipath-runtime", specifier = ">=0.13.0,<0.14.0" },
 ]
 provides-extras = ["anthropic", "vertex", "bedrock", "fireworks", "all"]
 
@@ -4690,16 +4690,16 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.12.5"
+version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "uipath-core" },
     { name = "vadersentiment" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/01/36ce16df36fc45cfafa1e27e137bc1bfc437a7c31704d7523994cccfdc58/uipath_runtime-0.12.5.tar.gz", hash = "sha256:dabe662ab7ffd0281d9dbde8c37f36d638bd266f9887fa893b025eae575e99fd", size = 236475, upload-time = "2026-07-21T04:32:31.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/4d/86409493366ee75b5548dd992e5d256ddf304f2b398677169f7f9af7cd99/uipath_runtime-0.13.2.tar.gz", hash = "sha256:004c91a20f85c0a0f61cce30b0dae267f1d8e086476adcbe7e723724e22d1475", size = 246648, upload-time = "2026-08-25T09:31:46.189Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/4d/1f5d2428baaff401fcc0dbc8ece285e44333c7de2bc801fd003ee7c1cd11/uipath_runtime-0.12.5-py3-none-any.whl", hash = "sha256:3a52d4ae61ac60b0b29454d7a2e33c0e78e65826c59447792b69c6993deef620", size = 92037, upload-time = "2026-07-21T04:32:29.869Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/f9225df568a3f76c2c5c6e47c9c5043d5e2a9c70a4a83b7450010c337bb0/uipath_runtime-0.13.2-py3-none-any.whl", hash = "sha256:33e4fcd9b6edcc01dfa6e87434a3252319c1f1fd0480a2816d591b763b6e4f86", size = 97014, upload-time = "2026-08-25T09:31:44.692Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Releases `uipath-langchain` 0.15.2.post1: 0.15.2's source with two dependency ranges moved.

**Draft until `uipath` 2.13.23 is published** (UiPath/uipath-python#1878). `uv.lock` is intentionally not regenerated here, because `uv lock` cannot resolve against a version that does not exist yet.

```diff
-version = "0.15.2"
+version = "0.15.2.post1"
-    "uipath>=2.13.16, <2.14.0",
+    "uipath>=2.13.23, <2.14.0",
-    "uipath-runtime>=0.12.5, <0.13.0",
+    "uipath-runtime>=0.13.0, <0.14.0",
```

## Why

Every published 0.15.x caps `uipath-runtime` below 0.13.0. A consumer that has to stay on this line therefore cannot reach `uipath-runtime` 0.13.x, since there is one `uipath-runtime` in an environment and 0.13.x does not satisfy `<0.13.0`. Published metadata is immutable, so the range needs a new release on the line.

The `uipath` floor moves with it because 2.13.23 is the only release on the 2.13 line that admits `uipath-runtime` 0.13.x. Leaving the floor at 2.13.16 would declare support for combinations that cannot resolve.

Both ranges **move** rather than widen, so each stays within a single minor.

## Compatibility

The source is unchanged from 0.15.2, and it was never released against `uipath-runtime` 0.13.x, so that pairing is verified by running it rather than by a prior release: the full test suite passes against 0.13.2, exit 0, no failures.

## Branch

Cut from `ef7600c`, the commit that built 0.15.2, per the open-source hotfix procedure. Base branch `release/uipath-langchain-0.15.2` is that same commit. Not for `main`, which is well past 0.16.x.

## Versioning

0.15.3 and later already exist, so this is a post-release of the version being fixed rather than a patch increment. PEP 440 orders it `0.15.2 < 0.15.2.post1 < 0.15.3`, so it does not supersede anything for consumers already on a later patch.

## Verification

- full test suite green against `uipath-runtime` 0.13.2, exit 0, no failures
- `uv sync --locked --all-extras` clean in that configuration

## Sequencing

1. Publish `uipath` 2.13.23 (UiPath/uipath-python#1878)
2. Run `uv lock` here, push the lockfile, undraft, merge
3. Dispatch CD against this hotfix branch. Merging into the base branch triggers nothing.