### PR TITLE
ci: run checks and publish on release branches

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
     paths:
       - pyproject.toml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
     paths-ignore:
       - pyproject.toml
   pull_request:
     branches:
       - main
+      - 'release/**'
 
 jobs:
   commit-lint:


### PR DESCRIPTION
Scopes both workflows to `release/**` in addition to `main`.

```diff
 # ci.yml
   push:
     branches:
       - main
+      - 'release/**'
     paths-ignore:
       - pyproject.toml
   pull_request:
     branches:
       - main
+      - 'release/**'

 # cd.yml
   push:
     branches:
       - main
+      - 'release/**'
     paths:
       - pyproject.toml
```

## Why

Hotfix releases are cut on `release/*` branches, but both workflows are scoped to `main` only.

**Checks never run.** `ci.yml` fires only for PRs targeting `main`, and it is the only workflow that calls `lint.yml`, `test.yml` and `commitlint.yml`. The `MainProtect` ruleset covers `refs/heads/release/*` and requires `lint / Lint`, `commit-lint / Commit Lint`, `SonarCloud Code Analysis` and the six `test / Test (3.x, uipath-{ubuntu,windows}-latest)` contexts. For a PR into a release branch nothing produces them, so every one sits at `Expected — Waiting for status to be reported` and the PR is unmergeable without an admin bypass. That happened on #1058, which had to be force-merged despite a clean local run.

**Publishing never happens.** `cd.yml` fires only on push to `main`, so merging a hotfix into its release branch publishes nothing and every release needs a manual `workflow_dispatch`. A dispatch also runs the workflow file *from the dispatched ref*, so a branch cut from an older commit runs an older CI definition than `main`'s.

## Is auto-publishing from a release branch safe

The `pypi` environment has no deployment branch policy or protection rules, so a release ref is already permitted to publish, and `release/*` is covered by `MainProtect`, which requires a pull request — nothing lands there unreviewed. The trigger is already filtered to `paths: pyproject.toml`, so only a version or dependency change starts a run.

Worth noting that this repo's publish step does not pass `skip-existing`, so a push touching `pyproject.toml` without a version bump would fail at upload rather than no-op. Happy to add `skip-existing: true` here if you would rather it be silent.

## Known limitation

This does not retroactively fix a hotfix branch cut from a commit that predates the `uipath-ubuntu-latest` runner rename. Such a branch produces contexts named `test / Test (3.11, ubuntu-latest)`, which do not match what the ruleset requires, so those PRs still need a bypass or a workflow sync. This change is what stops it recurring for branches cut from here on.