### PR TITLE
ci: exempt first-party packages from the Safe Chain age gate in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - pyproject.toml
 
+env:
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: uipath,uipath-core,uipath-dev,uipath-langchain,uipath-langchain-client,uipath-llm-client,uipath-platform,uipath-robot,uipath-runtime,jsonschema-pydantic-converter
+
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml


### PR DESCRIPTION
`uipath-langchain` 0.16.15 did not reach PyPI. The post-merge CD run resolved its dependencies fine and then failed downloading `uipath-langchain-client` 1.18.3, published an hour earlier, with a Safe Chain 403 on the minimum-package-age gate.

`lint.yml`, `test.yml` and `publish-dev.yml` already set `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS`, and the list in all three already names `uipath-langchain-client`. `cd.yml` never got it, and CD builds in its own inline job rather than through those workflows, which is why the `lint` job passed and `build` died. This adds the same line, unchanged, at workflow level.

The `[tool.uv.exclude-newer-package]` exemption in `pyproject.toml` covers a different gate: it governs which version uv resolves, not whether the download is allowed. Resolution succeeded here, so that exemption was already doing its job.

Skips only the age gate. Malware scanning and every other Safe Chain check still run, which is the least-disabling override the supply-chain-guard runbook asks for before reaching for `SCG_KILL_SWITCH`.

uipath-python hit this exact split in #1858 and #1861: the first PR added the variable to lint and test, the second had to follow up because the CD path built through a workflow that never got it.

Merging this does not republish on its own, since CD triggers on pushes that touch `pyproject.toml`. 0.16.15 needs a manual run of the CD workflow against `main` afterwards.
