### PR TITLE
fix: don't let the multipart body envelope param shadow real body fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.17.0"
+version = "0.17.1"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/integration_tool.py
+++ b/src/uipath_langchain/agent/tools/integration_tool.py
@@ -243,6 +243,15 @@ def convert_to_activity_metadata(
     if http_method == "GETBYID":
         http_method = "GET"
 
+    # determine content type and json body section
+    content_type = "application/json"
+    json_body_section = None
+    if resource.properties.body_structure is not None:
+        shorthand_type = resource.properties.body_structure.get("contentType", "json")
+        if shorthand_type == "multipart":
+            content_type = "multipart/form-data"
+        json_body_section = resource.properties.body_structure.get("jsonBodySection")
+
     param_location_info = ActivityParameterLocationInfo()
     # because of nested fields and array notation, use a set to avoid duplicates
     body_fields_set = set()
@@ -251,6 +260,11 @@ def convert_to_activity_metadata(
     for param in resource.properties.parameters:
         param_name = param.name
         field_location = param.field_location
+
+        # Skip the multipart envelope marker itself - not real data, and its
+        # name can collide with an entity field of the same name (e.g. "body").
+        if field_location in ("multipart", "file") and param_name == json_body_section:
+            continue
 
         if field_location == "query":
             param_location_info.query_params.append(param_name)
@@ -270,15 +284,6 @@ def convert_to_activity_metadata(
             body_fields_set.add(top_level_field)
 
     param_location_info.body_fields = list(body_fields_set)
-
-    # determine content type and json body section
-    content_type = "application/json"
-    json_body_section = None
-    if resource.properties.body_structure is not None:
-        shorthand_type = resource.properties.body_structure.get("contentType", "json")
-        if shorthand_type == "multipart":
-            content_type = "multipart/form-data"
-        json_body_section = resource.properties.body_structure.get("jsonBodySection")
 
     return ActivityMetadata(
         object_path=resource.properties.tool_path,

--- a/tests/agent/tools/test_integration_tool.py
+++ b/tests/agent/tools/test_integration_tool.py
@@ -249,6 +249,38 @@ class TestConvertToIntegrationServiceMetadata:
         assert result.content_type == "application/json"
         assert result.json_body_section is None
 
+    def test_multipart_envelope_marker_does_not_shadow_nested_body_field(
+        self, resource_factory
+    ):
+        """A parameter naming the multipart JSON envelope (fieldLocation multipart,
+        name == jsonBodySection) must not shadow a real entity field that shares
+        that same top-level name via dotted children (fieldLocation body)."""
+        params = [
+            AgentIntegrationToolParameter(
+                name="body", type="string", field_location="multipart"
+            ),
+            AgentIntegrationToolParameter(
+                name="body.content", type="string", field_location="body"
+            ),
+            AgentIntegrationToolParameter(
+                name="body.adaptiveCardContent", type="string", field_location="body"
+            ),
+            AgentIntegrationToolParameter(
+                name="file", type="file", field_location="file"
+            ),
+        ]
+        resource = resource_factory(parameters=params)
+        resource.properties.body_structure = {
+            "contentType": "multipart",
+            "jsonBodySection": "body",
+        }
+
+        result = convert_to_activity_metadata(resource)
+
+        assert "body" in result.parameter_location_info.body_fields
+        assert "body" not in result.parameter_location_info.multipart_params
+        assert result.parameter_location_info.multipart_params == ["file"]
+
     def test_parameter_location_mapping_simple_fields(self, resource_factory):
         """Test parameter mapping for simple field names across different locations."""
         params = [

--- a/uv.lock
+++ b/uv.lock
@@ -4574,7 +4574,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- For IS activities using a multipart body (`bodyStructure.contentType: "multipart"`), the raw connector parameter list includes an envelope-marker parameter whose name equals `jsonBodySection` (e.g. `body`, `fieldLocation: "multipart"`). This is IS's own convention for "wrap the JSON entity in one multipart part named X" — not real data.
- When an activity's entity schema also nests real fields under that same top-level name (e.g. Teams' `chatMessage.body` → `body.content`, `body.adaptiveCardContent`, `fieldLocation: "body"`), both got classified under the identical key in `convert_to_activity_metadata`. Since `multipart_params` was checked before `body_fields`, the real value was misrouted there and silently dropped by the existing "don't duplicate the envelope part" guard in `uipath-platform`'s `_build_activity_request_spec`.
- Reproduced live against the Microsoft Teams "Send Individual Chat Message" IS tool: the LLM-supplied message body was silently missing from the outgoing request.
- Fix: skip the envelope-marker parameter by identity (name matches `jsonBodySection` and its own `fieldLocation` is `multipart`/`file`) so it never competes with the real body-field grouping derived from its children.

## Test plan
- [x] Added `test_multipart_envelope_marker_does_not_shadow_nested_body_field` — confirmed it fails without the fix and passes with it
- [x] `uv run pytest tests/agent/tools/test_integration_tool.py` — 69 passed
- [x] `uv run pytest` (full suite, all extras) — 2799 passed, 3 skipped (unrelated, `uip` CLI not on PATH)
- [x] `ruff check` / `ruff format --check` / `mypy` clean on changed files
- [x] Verified live end-to-end against a real UiPath tenant's Teams connector: the message body now reaches the actual HTTP request and a real Teams message is sent successfully