### PR TITLE
feat(mcp): expose the agent resource name in MCP tool metadata [PC-4906]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.17.3"
+version = "0.17.4"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
+++ b/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
@@ -290,6 +290,9 @@ async def create_mcp_tools(
                 "display_name": mcp_tool.name,
                 "folder_path": config.folder_path,
                 "slug": config.slug,
+                # Agent-level resource name (what the designer shows); trace UIs use it
+                # to title MCP tool spans as "{tool} ({resource})" (PC-4906).
+                "resource_name": config.name,
             },
             argument_properties=mcp_tool.argument_properties,
         )

--- a/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
+++ b/src/uipath_langchain/agent/tools/mcp/mcp_tool.py
@@ -290,8 +290,6 @@ async def create_mcp_tools(
                 "display_name": mcp_tool.name,
                 "folder_path": config.folder_path,
                 "slug": config.slug,
-                # Agent-level resource name (what the designer shows); trace UIs use it
-                # to title MCP tool spans as "{tool} ({resource})" (PC-4906).
                 "resource_name": config.name,
             },
             argument_properties=mcp_tool.argument_properties,

--- a/tests/agent/tools/test_mcp/test_mcp_tool.py
+++ b/tests/agent/tools/test_mcp/test_mcp_tool.py
@@ -114,6 +114,17 @@ class TestMcpToolMetadata:
         assert tool.metadata is not None
         assert tool.metadata["slug"] == "my-mcp-server"
 
+    @pytest.mark.asyncio
+    async def test_mcp_tool_metadata_has_resource_name(
+        self, mcp_resource, mock_mcp_client
+    ):
+        """Metadata carries the agent-level resource name used in span titles."""
+        tools = await create_mcp_tools(mcp_resource, mock_mcp_client)
+
+        tool = tools[0]
+        assert tool.metadata is not None
+        assert tool.metadata["resource_name"] == "test_mcp_server"
+
 
 class TestMcpToolCreation:
     """Test MCP tool creation from metadata."""
@@ -325,6 +336,7 @@ class TestCreateMcpToolsFromAgent:
             assert "display_name" in tool.metadata
             assert "folder_path" in tool.metadata
             assert "slug" in tool.metadata
+            assert "resource_name" in tool.metadata
 
 
 class TestMcpToolResultSerialization:

--- a/uv.lock
+++ b/uv.lock
@@ -4574,7 +4574,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.17.3"
+version = "0.17.4"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## What changed?
`create_mcp_tools` adds `resource_name` (the agent-level MCP resource name, `config.name`) to each MCP tool's LangChain metadata, next to the existing `slug`, `display_name` and `folder_path`.

The uipath-agents trace instrumentation uses it to title MCP tool spans as `Tool call - {tool} ({resource name})`, e.g. `Tool call - GetCaseRules (Case Management Control)`, instead of the namespaced identity `mcp-{slug}-tool-{name}` (Case Agent bug bash, PC-4906). The resource name is what the designer shows and is unique per agent, so two servers exposing the same tool name stay distinguishable. Until uipath-agents pins a version with this change it falls back to the slug.

Consumers: UiPath/uipath-agents-python PR https://github.com/UiPath/uipath-agents-python/pull/729 (companion .NET change: https://github.com/UiPath/Agents/pull/6199).

## How has this been tested?
- `tests/agent/tools/test_mcp/test_mcp_tool.py`: new `test_mcp_tool_metadata_has_resource_name`, and `test_tools_have_correct_metadata` asserts the key is present.
- `pytest tests/agent/tools/test_mcp/`, `ruff check`, `ruff format --check` on the changed files.

## Are there any breaking changes?
- [x] None
