### PR TITLE
fix(advanced): honor the configured max iterations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.17.8"
+version = "0.17.9"
 description = "Python SDK that enables developers to build and deploy LangGraph agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_langchain/agent/advanced/agent.py
+++ b/src/uipath_langchain/agent/advanced/agent.py
@@ -17,7 +17,7 @@ from langchain.agents.middleware import (
 )
 from langchain.agents.structured_output import ResponseFormat
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool
 from langgraph.graph import END, START
 from langgraph.graph.state import CompiledStateGraph, StateGraph
@@ -36,6 +36,7 @@ from uipath_langchain.agent.attachments.output_files import (
 from uipath_langchain.agent.exceptions import (
     AgentRuntimeError,
     AgentRuntimeErrorCode,
+    max_iterations_error,
 )
 from uipath_langchain.agent.react.conversational_output_node import (
     create_conversational_output_extractor,
@@ -101,6 +102,61 @@ class _RuntimeSystemPromptMiddleware(AgentMiddleware[AgentState[Any], Any]):
         return await handler(self._prepare_request(request))
 
 
+class _MaxIterationsMiddleware(AgentMiddleware[AgentState[Any], Any]):
+    """Stop the loop once it has spent its iteration budget for this turn.
+
+    Counts the AI messages the agent produced since the turn started, the way the
+    standard agent's llm node does, and raises the same termination error. Counting
+    messages rather than model calls keeps the budget spent across a suspend and
+    resume, where any per-run counter starts over.
+    """
+
+    def __init__(
+        self, max_iterations: int, initial_message_count_key: str | None = None
+    ) -> None:
+        self.max_iterations = max_iterations
+        self.initial_message_count_key = initial_message_count_key
+        if initial_message_count_key is not None:
+            self.state_schema = type(
+                "MaxIterationsState",
+                (AgentState,),
+                {
+                    "__annotations__": {
+                        initial_message_count_key: NotRequired[int | None]
+                    }
+                },
+            )
+
+    def _check_budget(self, request: ModelRequest[Any]) -> None:
+        initial_count = (
+            cast("int | None", request.state.get(self.initial_message_count_key)) or 0
+            if self.initial_message_count_key is not None
+            else 0
+        )
+        messages = cast("list[Any]", request.state.get("messages") or [])
+        produced = sum(
+            1 for message in messages[initial_count:] if isinstance(message, AIMessage)
+        )
+        if produced >= self.max_iterations:
+            raise max_iterations_error(self.max_iterations)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        self._check_budget(request)
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
+    ) -> ModelResponse[Any]:
+        self._check_budget(request)
+        return await handler(request)
+
+
 @dataclass(frozen=True)
 class _RuntimeSystemPrompt:
     """A system prompt that is either fixed or resolved from each invocation's input."""
@@ -139,6 +195,14 @@ def _resolve_runtime_system_prompt(
         "uipath__system_prompt", base_state, input_schema
     )
     return _RuntimeSystemPrompt(None, system_prompt, state_key)
+
+
+def _max_iterations_middleware(
+    max_iterations: int | None, initial_message_count_key: str | None = None
+) -> list[AgentMiddleware[Any, Any]]:
+    if max_iterations is None:
+        return []
+    return [_MaxIterationsMiddleware(max_iterations, initial_message_count_key)]
 
 
 def create_advanced_agent(
@@ -185,6 +249,7 @@ def create_advanced_agent_graph(
     build_user_message: Callable[[dict[str, Any]], str],
     skills: Sequence[str] | None = None,
     output_files_enabled: bool = False,
+    max_iterations: int | None = None,
 ) -> StateGraph[Any, Any, Any, Any]:
     """Wrap the advanced agent in a parent graph that maps typed I/O to/from messages.
 
@@ -198,6 +263,9 @@ def create_advanced_agent_graph(
     is gated by a verification node: an unfilled required file field, or a
     reference to an attachment that is not linked to this job, sends the agent
     back for another turn instead of emitting an output it cannot honor.
+
+    ``max_iterations`` caps the model calls the agent loop may make; ``None``
+    leaves it uncapped.
     """
     memory_sources = (
         [MEMORY_INDEX_VIRTUAL_PATH] if isinstance(backend, FilesystemBackend) else []
@@ -216,7 +284,10 @@ def create_advanced_agent_graph(
         backend=backend,
         response_format=response_format,
         memory=memory_sources,
-        middleware=runtime_prompt.middleware,
+        middleware=[
+            *runtime_prompt.middleware,
+            *_max_iterations_middleware(max_iterations),
+        ],
         skills=skills,
     )
 
@@ -320,6 +391,7 @@ def create_conversational_advanced_agent_graph(
     skills: Sequence[str] | None = None,
     input_schema: type[BaseModel] | None = None,
     output_schema: type[BaseModel] | None = None,
+    max_iterations: int | None = None,
 ) -> StateGraph[Any, Any, Any, Any]:
     """Wrap the advanced agent in a parent graph that speaks the conversational contract.
 
@@ -333,6 +405,9 @@ def create_conversational_advanced_agent_graph(
     filled the same way the standard conversational agent fills them: a focused
     extraction call over the exchange's messages, after the loop has finished.
     The loop itself produces messages, so nothing in it can produce those fields.
+
+    ``max_iterations`` caps the model calls the agent loop may make per exchange;
+    ``None`` leaves it uncapped.
     """
     memory_sources = (
         [MEMORY_INDEX_VIRTUAL_PATH] if isinstance(backend, FilesystemBackend) else []
@@ -352,7 +427,10 @@ def create_conversational_advanced_agent_graph(
         system_prompt=runtime_prompt.static_prompt,
         backend=backend,
         memory=memory_sources,
-        middleware=runtime_prompt.middleware,
+        middleware=[
+            *runtime_prompt.middleware,
+            *_max_iterations_middleware(max_iterations, initial_message_count_key),
+        ],
         skills=skills,
     )
 

--- a/src/uipath_langchain/agent/exceptions/__init__.py
+++ b/src/uipath_langchain/agent/exceptions/__init__.py
@@ -3,6 +3,7 @@ from .exceptions import (
     AgentRuntimeErrorCode,
     AgentStartupError,
     AgentStartupErrorCode,
+    max_iterations_error,
 )
 from .helpers import raise_for_enriched
 
@@ -12,4 +13,5 @@ __all__ = [
     "AgentStartupErrorCode",
     "AgentRuntimeErrorCode",
     "raise_for_enriched",
+    "max_iterations_error",
 ]

--- a/src/uipath_langchain/agent/exceptions/exceptions.py
+++ b/src/uipath_langchain/agent/exceptions/exceptions.py
@@ -191,3 +191,13 @@ class AgentStartupError(UiPathBaseRuntimeError):
             prefix="AGENT_STARTUP",
             include_traceback=include_traceback,
         )
+
+
+def max_iterations_error(max_iterations: int) -> AgentRuntimeError:
+    """The termination error raised when an agent loop exhausts its iteration budget."""
+    return AgentRuntimeError(
+        code=AgentRuntimeErrorCode.TERMINATION_MAX_ITERATIONS,
+        title=f"Maximum iterations of '{max_iterations}' reached.",
+        detail="Verify the agent's trajectory or consider increasing the max iterations in the agent's settings.",
+        category=UiPathErrorCategory.USER,
+    )

--- a/src/uipath_langchain/agent/react/llm_node.py
+++ b/src/uipath_langchain/agent/react/llm_node.py
@@ -18,7 +18,11 @@ from uipath.runtime.errors import UiPathErrorCategory
 from uipath_langchain.chat.handlers import get_payload_handler
 from uipath_langchain.chat.thinking import thinking_rejects_forced_tool_choice
 
-from ..exceptions import AgentRuntimeError, AgentRuntimeErrorCode
+from ..exceptions import (
+    AgentRuntimeError,
+    AgentRuntimeErrorCode,
+    max_iterations_error,
+)
 from ..exceptions.llm import (
     raise_for_llm_client_error,
     raise_for_provider_http_error,
@@ -95,12 +99,7 @@ def create_llm_node(
             1 for msg in current_turn_messages if isinstance(msg, AIMessage)
         )
         if agent_ai_messages >= llm_messages_limit:
-            raise AgentRuntimeError(
-                code=AgentRuntimeErrorCode.TERMINATION_MAX_ITERATIONS,
-                title=f"Maximum iterations of '{llm_messages_limit}' reached.",
-                detail="Verify the agent's trajectory or consider increasing the max iterations in the agent's settings.",
-                category=UiPathErrorCategory.USER,
-            )
+            raise max_iterations_error(llm_messages_limit)
 
         static_schema_tools = static_args_handler.initialize(
             bindable_tools, state, input_schema or type(state)

--- a/tests/agent/advanced/test_max_iterations.py
+++ b/tests/agent/advanced/test_max_iterations.py
@@ -1,0 +1,125 @@
+"""The advanced agent loop honors the configured iteration budget."""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool
+from pydantic import BaseModel
+from uipath.runtime.errors import UiPathErrorCategory
+
+from uipath_langchain.agent.advanced.agent import (
+    _MaxIterationsMiddleware,
+    create_advanced_agent_graph,
+    create_conversational_advanced_agent_graph,
+)
+from uipath_langchain.agent.exceptions import AgentRuntimeError
+
+
+class _Input(BaseModel):
+    task: str = ""
+
+
+class _Output(BaseModel):
+    result: str = ""
+
+
+@tool
+def ping(value: str) -> str:
+    """Echo the value back."""
+    return value
+
+
+class _ToolCallingFakeModel(GenericFakeChatModel):
+    """A fake model that accepts tool bindings, so the real loop can run."""
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> BaseChatModel:
+        return self
+
+
+def _never_stops(calls: list[int]) -> _ToolCallingFakeModel:
+    """A model that always asks for another tool call, so only the budget stops it."""
+
+    def messages() -> Iterator[AIMessage]:
+        while True:
+            calls.append(len(calls) + 1)
+            yield AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "ping",
+                        "args": {"value": str(len(calls))},
+                        "id": f"call-{len(calls)}",
+                    }
+                ],
+            )
+
+    return _ToolCallingFakeModel(messages=messages())
+
+
+def _autonomous_graph(model: BaseChatModel, max_iterations: int | None) -> Any:
+    return create_advanced_agent_graph(
+        model=model,
+        tools=[ping],
+        system_prompt="sys",
+        backend=None,
+        response_format=None,
+        input_schema=_Input,
+        output_schema=_Output,
+        build_user_message=lambda args: args.get("task", ""),
+        max_iterations=max_iterations,
+    ).compile()
+
+
+@pytest.mark.asyncio
+async def test_autonomous_loop_stops_at_max_iterations() -> None:
+    calls: list[int] = []
+    graph = _autonomous_graph(_never_stops(calls), max_iterations=3)
+
+    with pytest.raises(AgentRuntimeError) as error:
+        await graph.ainvoke({"task": "loop"}, {"recursion_limit": 100})
+
+    assert error.value.error_info.code == "AGENT_RUNTIME.TERMINATION_MAX_ITERATIONS"
+    assert error.value.error_info.title == "Maximum iterations of '3' reached."
+    assert error.value.error_info.category == UiPathErrorCategory.USER
+    assert len(calls) == 3
+
+
+def test_no_middleware_without_a_limit() -> None:
+    with patch(
+        "uipath_langchain.agent.advanced.agent._create_deep_agent",
+        return_value=MagicMock(),
+    ) as mock_create:
+        _autonomous_graph(MagicMock(spec=BaseChatModel), max_iterations=None)
+
+    middleware = mock_create.call_args.kwargs["middleware"]
+    assert not any(isinstance(m, _MaxIterationsMiddleware) for m in middleware)
+
+
+@pytest.mark.asyncio
+async def test_conversational_budget_is_per_exchange() -> None:
+    """Messages carried in from earlier exchanges do not spend this exchange's budget."""
+    calls: list[int] = []
+    graph = create_conversational_advanced_agent_graph(
+        model=_never_stops(calls),
+        tools=[ping],
+        system_prompt="sys",
+        backend=None,
+        max_iterations=2,
+    ).compile()
+
+    history: list[Any] = [
+        HumanMessage(content="hi", id="u1"),
+        AIMessage(content="hello", id="a1"),
+        AIMessage(content="still here", id="a2"),
+        HumanMessage(content="keep going", id="u2"),
+    ]
+
+    with pytest.raises(AgentRuntimeError):
+        await graph.ainvoke({"messages": history}, {"recursion_limit": 100})
+
+    assert len(calls) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -4738,7 +4738,7 @@ wheels = [
 
 [[package]]
 name = "uipath-langchain"
-version = "0.17.8"
+version = "0.17.9"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Problem

Advanced agents ignored `maxIterations` from `agent.json`. Standard agents turn it into `AgentGraphConfig.llm_messages_limit`, and the react llm node stops the turn with `TERMINATION_MAX_ITERATIONS` once the budget is spent. The advanced builders passed nothing equivalent to the deepagents loop, so an advanced agent kept calling the model until LangGraph's recursion limit tripped, with an error that says nothing about iterations.

## Change

`create_advanced_agent_graph` and `create_conversational_advanced_agent_graph` take `max_iterations: int | None` (None leaves the loop uncapped, so existing callers are unaffected) and install a middleware on the main loop.

The middleware counts the AI messages produced in the current turn, the same signal the react llm node uses, rather than langchain's `ModelCallLimitMiddleware` counters: a per-run counter starts over after a suspend and resume, which would hand a resumed job a fresh budget, and a per-thread counter never resets for a conversational agent. For conversational agents the count starts at the exchange's initial message count, so the history carried in from earlier exchanges does not spend this exchange's budget.

The error itself moved into a shared `max_iterations_error()` factory used by both the react llm node and the advanced middleware, so the two paths cannot drift on code, title, detail, or category.

## Tests

`tests/agent/advanced/test_max_iterations.py`, running the real deepagents loop against a fake tool-calling model:

- autonomous: with `max_iterations=3` the model is called exactly 3 times, then `AGENT_RUNTIME.TERMINATION_MAX_ITERATIONS` "Maximum iterations of '3' reached." (USER category)
- conversational: with a history holding 2 earlier AI messages and `max_iterations=2`, the model still gets its 2 calls for this exchange
- no limit configured leaves the middleware out of the stack

`uv run pytest tests/agent/advanced tests/agent/react tests/agent/test_exceptions.py` passes (603 tests), plus ruff and mypy.

Version bumped to 0.17.9. `uipath-agents` consumes it in UiPath/uipath-agents-python#736, where the value from `agent.json` reaches these builders.
